### PR TITLE
feat: add custom API base URL support for Anthropic-compatible APIs

### DIFF
--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -5,6 +5,7 @@ struct AppSettings {
     private static let isMutedKey = "isMuted"
     private static let previousSoundKey = "previousNotificationSound"
     private static let isUsageEnabledKey = "isUsageEnabled"
+    private static let anthropicApiBaseURLKey = "anthropicApiBaseURL"
 
     static var isUsageEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: isUsageEnabledKey) }
@@ -14,6 +15,11 @@ struct AppSettings {
     static var anthropicApiKey: String? {
         get { KeychainManager.getAnthropicApiKey() }
         set { KeychainManager.setAnthropicApiKey(newValue) }
+    }
+
+    static var anthropicApiBaseURL: String? {
+        get { UserDefaults.standard.string(forKey: anthropicApiBaseURLKey) }
+        set { UserDefaults.standard.set(newValue, forKey: anthropicApiBaseURLKey) }
     }
 
     static var notificationSound: NotificationSound {

--- a/notchi/notchi/Services/EmotionAnalyzer.swift
+++ b/notchi/notchi/Services/EmotionAnalyzer.swift
@@ -20,7 +20,7 @@ private struct EmotionResponse: Decodable {
 final class EmotionAnalyzer {
     static let shared = EmotionAnalyzer()
 
-    private static let apiURL = URL(string: "https://api.anthropic.com/v1/messages")!
+    private static let defaultBaseURL = "https://api.anthropic.com"
     private static let model = "claude-haiku-4-5-20251001"
     private static let validEmotions: Set<String> = ["happy", "sad", "neutral"]
 
@@ -36,6 +36,12 @@ final class EmotionAnalyzer {
         """
 
     private init() {}
+
+    private static func getApiURL() -> URL {
+        let baseURL = AppSettings.anthropicApiBaseURL?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let url = baseURL.isEmpty ? defaultBaseURL : baseURL
+        return URL(string: "\(url)/v1/messages")!
+    }
 
     func analyze(_ prompt: String) async -> (emotion: String, intensity: Double) {
         let start = ContinuousClock.now
@@ -83,7 +89,10 @@ final class EmotionAnalyzer {
     }
 
     private func callHaiku(prompt: String, apiKey: String) async throws -> (emotion: String, intensity: Double) {
-        var request = URLRequest(url: Self.apiURL)
+        let apiURL = Self.getApiURL()
+        logger.info("Using API URL: \(apiURL.absoluteString, privacy: .public)")
+        
+        var request = URLRequest(url: apiURL)
         request.httpMethod = "POST"
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -6,6 +6,7 @@ struct PanelSettingsView: View {
     @State private var hooksInstalled = HookInstaller.isInstalled()
     @State private var hooksError = false
     @State private var apiKeyInput = AppSettings.anthropicApiKey ?? ""
+    @State private var baseURLInput = AppSettings.anthropicApiBaseURL ?? ""
     @ObservedObject private var updateManager = UpdateManager.shared
     private var usageConnected: Bool { ClaudeUsageService.shared.isConnected }
     private var hasApiKey: Bool { !apiKeyInput.isEmpty }
@@ -77,11 +78,11 @@ struct PanelSettingsView: View {
             }
             .buttonStyle(.plain)
 
-            apiKeyRow
+            apiKeySection
         }
     }
 
-    private var apiKeyRow: some View {
+    private var apiKeySection: some View {
         VStack(alignment: .leading, spacing: 6) {
             SettingsRowView(icon: "brain", title: "Emotion Analysis") {
                 statusBadge(
@@ -90,6 +91,7 @@ struct PanelSettingsView: View {
                 )
             }
 
+            // API Key input
             HStack(spacing: 6) {
                 SecureField("", text: $apiKeyInput)
                     .textFieldStyle(.plain)
@@ -102,7 +104,7 @@ struct PanelSettingsView: View {
                     .onSubmit { saveApiKey() }
                     .overlay(alignment: .leading) {
                         if apiKeyInput.isEmpty {
-                            Text("Anthropic API Key")
+                            Text("API Key")
                                 .font(.system(size: 11, design: .monospaced))
                                 .foregroundColor(TerminalColors.dimmedText)
                                 .padding(.leading, 8)
@@ -118,12 +120,47 @@ struct PanelSettingsView: View {
                 .buttonStyle(.plain)
             }
             .padding(.leading, 28)
+
+            // Base URL input
+            HStack(spacing: 6) {
+                TextField("", text: $baseURLInput)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(TerminalColors.primaryText)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(Color.white.opacity(0.06))
+                    .cornerRadius(6)
+                    .onSubmit { saveBaseURL() }
+                    .overlay(alignment: .leading) {
+                        if baseURLInput.isEmpty {
+                            Text("API Base URL (optional, e.g. https://api.yourservice.com)")
+                                .font(.system(size: 9, design: .monospaced))
+                                .foregroundColor(TerminalColors.dimmedText)
+                                .padding(.leading, 8)
+                                .allowsHitTesting(false)
+                        }
+                    }
+
+                Button(action: saveBaseURL) {
+                    Image(systemName: baseURLInput.isEmpty ? "arrow.right.circle" : "checkmark.circle.fill")
+                        .font(.system(size: 14))
+                        .foregroundColor(baseURLInput.isEmpty ? TerminalColors.dimmedText : TerminalColors.green)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.leading, 28)
         }
     }
 
     private func saveApiKey() {
         let trimmed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         AppSettings.anthropicApiKey = trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func saveBaseURL() {
+        let trimmed = baseURLInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        AppSettings.anthropicApiBaseURL = trimmed.isEmpty ? nil : trimmed
     }
 
     private var actionsSection: some View {


### PR DESCRIPTION
## Summary
- Add `anthropicApiBaseURL` setting to allow custom API endpoints
- Update `EmotionAnalyzer` to use custom base URL when configured
- Add base URL input field in the settings UI
- Falls back to official `https://api.anthropic.com` when not set

## Why
This enables users to use Anthropic-compatible API services for emotion analysis, such as:
- OpenRouter
- Azure Anthropic API
- Self-hosted proxies
- Other third-party compatible services

## Changes
1. `AppSettings.swift` - Added `anthropicApiBaseURL` property stored in UserDefaults
2. `EmotionAnalyzer.swift` - Modified to construct API URL from custom base URL when set
3. `PanelSettingsView.swift` - Added a new text field for base URL input below the API key field

## Screenshot
The settings UI now shows two input fields:
- API Key (existing, secure field)
- API Base URL (new, plain text field with placeholder)

Users can leave the base URL empty to use the official Anthropic API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)