### PR TITLE
feat: add on-device emotion analysis using NLEmbedding

### DIFF
--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -5,6 +5,20 @@ struct AppSettings {
     private static let isMutedKey = "isMuted"
     private static let previousSoundKey = "previousNotificationSound"
     private static let isUsageEnabledKey = "isUsageEnabled"
+    private static let emotionAnalysisModeKey = "emotionAnalysisMode"
+
+    static var emotionAnalysisMode: EmotionAnalysisMode {
+        get {
+            guard let rawValue = UserDefaults.standard.string(forKey: emotionAnalysisModeKey),
+                  let mode = EmotionAnalysisMode(rawValue: rawValue) else {
+                return .simple
+            }
+            return mode
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: emotionAnalysisModeKey)
+        }
+    }
 
     static var isUsageEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: isUsageEnabledKey) }

--- a/notchi/notchi/Services/EmotionAnalyzer.swift
+++ b/notchi/notchi/Services/EmotionAnalyzer.swift
@@ -1,7 +1,23 @@
+import Accelerate
 import Foundation
+import NaturalLanguage
 import os.log
 
 private let logger = Logger(subsystem: "com.ruban.notchi", category: "EmotionAnalyzer")
+
+enum EmotionAnalysisMode: String, CaseIterable {
+    case simple = "simple"
+    case api = "api"
+    case disabled = "disabled"
+
+    var displayName: String {
+        switch self {
+        case .simple: return "Simple"
+        case .api: return "Anthropic API"
+        case .disabled: return "Disabled"
+        }
+    }
+}
 
 private struct HaikuResponse: Decodable {
     let content: [ContentBlock]
@@ -22,7 +38,9 @@ final class EmotionAnalyzer {
 
     private static let apiURL = URL(string: "https://api.anthropic.com/v1/messages")!
     private static let model = "claude-haiku-4-5-20251001"
-    private static let validEmotions: Set<String> = ["happy", "sad", "neutral"]
+    private static let validEmotions: Set<String> = Set(
+        NotchiEmotion.allCases.filter { $0 != .sob }.map(\.rawValue)
+    )
 
     private static let systemPrompt = """
         Classify the emotional tone of the user's message into exactly one emotion and an intensity score.
@@ -35,9 +53,146 @@ final class EmotionAnalyzer {
         Reply with ONLY valid JSON: {"emotion": "...", "intensity": ...}
         """
 
+    // MARK: - On-Device Embedding Classification
+
+    private static let ambiguityMargin = 0.05
+
+    private static let happyAnchorStrings = [
+        "great work thank you", "amazing I love it", "looks perfect now",
+        "that works thanks", "this is so fun and exciting", "you did it congrats",
+        "finally it works", "you're doing a great job",
+    ]
+
+    private static let sadAnchorStrings = [
+        "bruh what did you do this is broken", "this is terrible and ugly",
+        "why does it still not work", "I'm so frustrated it keeps failing",
+        "we took steps back this is worse now", "it doesn't fucking work",
+        "still not doing what I want", "back to a broken state again",
+    ]
+
+    private static let neutralAnchorStrings = [
+        "fix this and deploy it", "commit and push the changes",
+        "refactor the database module", "can you explain how this works",
+        "continue please keep going", "build and run it", "try again ultrathink",
+        "merge into main", "my codebase is confusing",
+        "sorry that was wrong let me clarify", "use this other approach instead",
+        "it works but it's not ideal", "what is the value for this",
+    ]
+
+    private struct AnchorSet {
+        let vectors: [[Double]]
+        let norms: [Double]
+    }
+
+    private static var _embedding: NLEmbedding?
+    private static var _happyAnchors: AnchorSet?
+    private static var _sadAnchors: AnchorSet?
+    private static var _neutralAnchors: AnchorSet?
+    private static var _initialized = false
+
+    private static func ensureEmbedding() -> Bool {
+        guard !_initialized else { return _embedding != nil }
+        _initialized = true
+        guard let embedding = NLEmbedding.sentenceEmbedding(for: .english) else {
+            logger.warning("NLEmbedding.sentenceEmbedding unavailable")
+            return false
+        }
+        _embedding = embedding
+        _happyAnchors = makeAnchorSet(happyAnchorStrings, embedding: embedding)
+        _sadAnchors = makeAnchorSet(sadAnchorStrings, embedding: embedding)
+        _neutralAnchors = makeAnchorSet(neutralAnchorStrings, embedding: embedding)
+        let total = (_happyAnchors?.vectors.count ?? 0) + (_sadAnchors?.vectors.count ?? 0) + (_neutralAnchors?.vectors.count ?? 0)
+        logger.info("Loaded sentence embedding with \(total) anchor vectors")
+        return true
+    }
+
+    private static func makeAnchorSet(_ strings: [String], embedding: NLEmbedding) -> AnchorSet {
+        let vectors = strings.compactMap { embedding.vector(for: $0) }
+        let norms = vectors.map { vec -> Double in
+            var norm = 0.0
+            vDSP_dotprD(vec, 1, vec, 1, &norm, vDSP_Length(vec.count))
+            return sqrt(norm)
+        }
+        return AnchorSet(vectors: vectors, norms: norms)
+    }
+
+    private static func minDistance(_ vec: [Double], vecNorm: Double, _ anchors: AnchorSet) -> Double {
+        anchors.vectors.enumerated().reduce(999.0) { best, pair in
+            let (i, anchor) = pair
+            var dot = 0.0
+            vDSP_dotprD(vec, 1, anchor, 1, &dot, vDSP_Length(vec.count))
+            let denom = vecNorm * anchors.norms[i]
+            guard denom > 0 else { return best }
+            return min(best, 1.0 - (dot / denom))
+        }
+    }
+
     private init() {}
 
     func analyze(_ prompt: String) async -> (emotion: String, intensity: Double) {
+        switch AppSettings.emotionAnalysisMode {
+        case .simple:
+            return analyzeLocally(prompt)
+        case .api:
+            return await analyzeWithAPI(prompt)
+        case .disabled:
+            return ("neutral", 0.0)
+        }
+    }
+
+    // MARK: - On-Device (NLEmbedding)
+
+    private static let maxPromptLength = 200
+
+    private func analyzeLocally(_ prompt: String) -> (emotion: String, intensity: Double) {
+        let start = ContinuousClock.now
+
+        guard prompt.count <= Self.maxPromptLength else {
+            return ("neutral", 0.0)
+        }
+
+        guard Self.ensureEmbedding(),
+              let embedding = Self._embedding,
+              let happyAnchors = Self._happyAnchors,
+              let sadAnchors = Self._sadAnchors,
+              let neutralAnchors = Self._neutralAnchors,
+              let promptVec = embedding.vector(for: prompt.lowercased())
+        else {
+            logger.info("Embedding unavailable, defaulting to neutral")
+            return ("neutral", 0.0)
+        }
+
+        var promptNorm = 0.0
+        vDSP_dotprD(promptVec, 1, promptVec, 1, &promptNorm, vDSP_Length(promptVec.count))
+        promptNorm = sqrt(promptNorm)
+
+        let categories: [(String, Double)] = [
+            ("happy", Self.minDistance(promptVec, vecNorm: promptNorm, happyAnchors)),
+            ("sad", Self.minDistance(promptVec, vecNorm: promptNorm, sadAnchors)),
+            ("neutral", Self.minDistance(promptVec, vecNorm: promptNorm, neutralAnchors)),
+        ]
+        let sorted = categories.sorted { $0.1 < $1.1 }
+        let margin = sorted[1].1 - sorted[0].1
+
+        let result: (emotion: String, intensity: Double)
+
+        if margin < Self.ambiguityMargin {
+            result = ("neutral", 0.0)
+        } else if sorted[0].0 == "neutral" {
+            result = ("neutral", 0.0)
+        } else {
+            result = (sorted[0].0, min(max(1.0 - sorted[0].1, 0.0), 1.0))
+        }
+
+        let elapsed = ContinuousClock.now - start
+        logger.info("Local analysis took \(elapsed, privacy: .public): h=\(String(format: "%.3f", categories[0].1), privacy: .public) s=\(String(format: "%.3f", categories[1].1), privacy: .public) n=\(String(format: "%.3f", categories[2].1), privacy: .public) margin=\(String(format: "%.3f", margin), privacy: .public) -> \(result.emotion, privacy: .public) (\(String(format: "%.2f", result.intensity), privacy: .public))")
+
+        return result
+    }
+
+    // MARK: - Claude API
+
+    private func analyzeWithAPI(_ prompt: String) async -> (emotion: String, intensity: Double) {
         let start = ContinuousClock.now
 
         guard let apiKey = AppSettings.anthropicApiKey, !apiKey.isEmpty else {

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -6,6 +6,7 @@ struct PanelSettingsView: View {
     @State private var hooksInstalled = HookInstaller.isInstalled()
     @State private var hooksError = false
     @State private var apiKeyInput = AppSettings.anthropicApiKey ?? ""
+    @State private var selectedMode = AppSettings.emotionAnalysisMode
     @ObservedObject private var updateManager = UpdateManager.shared
     private var usageConnected: Bool { ClaudeUsageService.shared.isConnected }
     private var hasApiKey: Bool { !apiKeyInput.isEmpty }
@@ -77,47 +78,85 @@ struct PanelSettingsView: View {
             }
             .buttonStyle(.plain)
 
-            apiKeyRow
+            emotionAnalysisSection
         }
     }
 
-    private var apiKeyRow: some View {
+    private var emotionStatusText: String {
+        switch selectedMode {
+        case .simple: return "Active"
+        case .api: return hasApiKey ? "Active" : "No Key"
+        case .disabled: return "Disabled"
+        }
+    }
+
+    private var emotionStatusColor: Color {
+        switch selectedMode {
+        case .simple: return TerminalColors.green
+        case .api: return hasApiKey ? TerminalColors.green : TerminalColors.red
+        case .disabled: return TerminalColors.dimmedText
+        }
+    }
+
+    private var emotionAnalysisSection: some View {
         VStack(alignment: .leading, spacing: 6) {
             SettingsRowView(icon: "brain", title: "Emotion Analysis") {
-                statusBadge(
-                    hasApiKey ? "Active" : "No Key",
-                    color: hasApiKey ? TerminalColors.green : TerminalColors.red
-                )
+                statusBadge(emotionStatusText, color: emotionStatusColor)
             }
 
-            HStack(spacing: 6) {
-                SecureField("", text: $apiKeyInput)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(TerminalColors.primaryText)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 5)
-                    .background(Color.white.opacity(0.06))
-                    .cornerRadius(6)
-                    .onSubmit { saveApiKey() }
-                    .overlay(alignment: .leading) {
-                        if apiKeyInput.isEmpty {
-                            Text("Anthropic API Key")
-                                .font(.system(size: 11, design: .monospaced))
-                                .foregroundColor(TerminalColors.dimmedText)
-                                .padding(.leading, 8)
-                                .allowsHitTesting(false)
-                        }
+            HStack(spacing: 4) {
+                ForEach(EmotionAnalysisMode.allCases, id: \.self) { mode in
+                    Button(action: {
+                        selectedMode = mode
+                        AppSettings.emotionAnalysisMode = mode
+                    }) {
+                        Text(mode.displayName)
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(selectedMode == mode
+                                ? TerminalColors.primaryText
+                                : TerminalColors.dimmedText)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(selectedMode == mode
+                                ? Color.white.opacity(0.12)
+                                : Color.clear)
+                            .cornerRadius(4)
                     }
-
-                Button(action: saveApiKey) {
-                    Image(systemName: hasApiKey ? "checkmark.circle.fill" : "arrow.right.circle")
-                        .font(.system(size: 14))
-                        .foregroundColor(hasApiKey ? TerminalColors.green : TerminalColors.dimmedText)
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
             }
             .padding(.leading, 28)
+
+            if selectedMode == .api {
+                HStack(spacing: 6) {
+                    SecureField("", text: $apiKeyInput)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(TerminalColors.primaryText)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(Color.white.opacity(0.06))
+                        .cornerRadius(6)
+                        .onSubmit { saveApiKey() }
+                        .overlay(alignment: .leading) {
+                            if apiKeyInput.isEmpty {
+                                Text("Anthropic API Key")
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .foregroundColor(TerminalColors.dimmedText)
+                                    .padding(.leading, 8)
+                                    .allowsHitTesting(false)
+                            }
+                        }
+
+                    Button(action: saveApiKey) {
+                        Image(systemName: hasApiKey ? "checkmark.circle.fill" : "arrow.right.circle")
+                            .font(.system(size: 14))
+                            .foregroundColor(hasApiKey ? TerminalColors.green : TerminalColors.dimmedText)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.leading, 28)
+            }
         }
     }
 


### PR DESCRIPTION
Add a fast local alternative to the Anthropic API for emotion classification.

Uses Apple's NLEmbedding sentence embeddings to classify prompts by cosine distance to anchor phrases (happy/sad/neutral), with neutral as default for ambiguous cases. ~3ms per prompt, no API key required.

- Add "Simple" mode using NLEmbedding semantic distance classification
- Update settings UI to add toggle to switch between Simple/API/Disabled, with Simple as new default (previously none/disabled.)
 
---

**Benchmark Results**

The anchor phrases work well with Claude's quick benchmark of ~60 prompt examples, but feel free to change/adjust of course. They're precomputed and cached in about ~100ms.

  | Category | Accuracy | Examples |
  |----------|----------|---------|
  | Happy | 17/17 (100%) | "Great work! Go ahead :)", "that works!", "nice" |
  | Sad | 16/17 (~94%) | "HOW ARE WE STILL GETTING THIS WRONG", "no this is terrible" |
  | Neutral | 24/24 (100%) | "commit and push", "Try again, ultrathink", "Please commit new changes and push." |
  | **Overall** | **57/58 (~98%)** | **Avg 3ms/prompt** |