### PR TITLE
feat: support Claude provider config for emotion analysis

### DIFF
--- a/notchi/Tests/EmotionAnalyzerTests.swift
+++ b/notchi/Tests/EmotionAnalyzerTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import XCTest
+@testable import notchi
+
+final class EmotionAnalyzerTests: XCTestCase {
+    func testParseClaudeSettingsDefaultsBaseURLWhenMissing() throws {
+        let data = try makeSettingsJSON(env: [
+            "ANTHROPIC_AUTH_TOKEN": "token-123",
+        ])
+
+        let config = try XCTUnwrap(ClaudeSettingsConfig.parse(from: data))
+
+        XCTAssertEqual(config.apiURL, URL(string: "https://api.anthropic.com/v1/messages"))
+        XCTAssertEqual(config.apiKey, "token-123")
+        XCTAssertEqual(config.model, ClaudeSettingsConfig.defaultModel)
+    }
+
+    func testParseClaudeSettingsAllowsMissingEnvObject() throws {
+        let data = Data("{}".utf8)
+
+        XCTAssertNil(try ClaudeSettingsConfig.parse(from: data))
+    }
+
+    func testParseClaudeSettingsNormalizesCustomBaseURL() throws {
+        let data = try makeSettingsJSON(env: [
+            "ANTHROPIC_BASE_URL": "https://example.com/proxy",
+            "ANTHROPIC_AUTH_TOKEN": "token-123",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "custom-model",
+        ])
+
+        let config = try XCTUnwrap(ClaudeSettingsConfig.parse(from: data))
+
+        XCTAssertEqual(config.apiURL, URL(string: "https://example.com/proxy/v1/messages"))
+        XCTAssertEqual(config.apiKey, "token-123")
+        XCTAssertEqual(config.model, "custom-model")
+    }
+
+    func testBuildMessagesURLHandlesCommonBaseURLShapes() {
+        XCTAssertEqual(
+            ClaudeSettingsConfig.buildMessagesURL(from: "https://api.anthropic.com"),
+            URL(string: "https://api.anthropic.com/v1/messages")
+        )
+        XCTAssertEqual(
+            ClaudeSettingsConfig.buildMessagesURL(from: "https://api.anthropic.com/v1"),
+            URL(string: "https://api.anthropic.com/v1/messages")
+        )
+        XCTAssertEqual(
+            ClaudeSettingsConfig.buildMessagesURL(from: "https://api.anthropic.com/v1/messages"),
+            URL(string: "https://api.anthropic.com/v1/messages")
+        )
+        XCTAssertEqual(
+            ClaudeSettingsConfig.buildMessagesURL(from: "https://example.com/proxy/"),
+            URL(string: "https://example.com/proxy/v1/messages")
+        )
+    }
+
+    private func makeSettingsJSON(env: [String: String]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: [
+            "env": env,
+        ])
+    }
+}

--- a/notchi/notchi/Services/EmotionAnalyzer.swift
+++ b/notchi/notchi/Services/EmotionAnalyzer.swift
@@ -3,6 +3,65 @@ import os.log
 
 private let logger = Logger(subsystem: "com.ruban.notchi", category: "EmotionAnalyzer")
 
+private struct ClaudeSettingsFile: Decodable {
+    let env: [String: String]?
+}
+
+struct ClaudeSettingsConfig {
+    let apiURL: URL
+    let apiKey: String
+    let model: String
+
+    static let defaultBaseURL = "https://api.anthropic.com"
+    static let defaultAPIURL = URL(string: "\(defaultBaseURL)/v1/messages")!
+    static let defaultModel = "claude-haiku-4-5-20251001"
+
+    static func parse(from data: Data) throws -> ClaudeSettingsConfig? {
+        let settings = try JSONDecoder().decode(ClaudeSettingsFile.self, from: data)
+        let env = settings.env ?? [:]
+
+        let baseURL = env["ANTHROPIC_BASE_URL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBaseURL = (baseURL?.isEmpty == false) ? baseURL! : defaultBaseURL
+
+        guard let authToken = env["ANTHROPIC_AUTH_TOKEN"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !authToken.isEmpty,
+              let apiURL = buildMessagesURL(from: resolvedBaseURL) else {
+            logger.debug("Claude settings present but missing valid auth token or base URL")
+            return nil
+        }
+
+        let model = env["ANTHROPIC_DEFAULT_HAIKU_MODEL"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return ClaudeSettingsConfig(
+            apiURL: apiURL,
+            apiKey: authToken,
+            model: (model?.isEmpty == false) ? model! : defaultModel
+        )
+    }
+
+    static func buildMessagesURL(from baseURL: String) -> URL? {
+        guard var components = URLComponents(string: baseURL) else {
+            logger.error("Invalid ANTHROPIC_BASE_URL: \(baseURL, privacy: .public)")
+            return nil
+        }
+
+        let normalizedPath = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        switch true {
+        case normalizedPath.isEmpty:
+            components.path = "/v1/messages"
+        case normalizedPath.hasSuffix("/v1/messages") || normalizedPath == "v1/messages":
+            components.path = "/\(normalizedPath)"
+        case normalizedPath.hasSuffix("/v1") || normalizedPath == "v1":
+            components.path = "/\(normalizedPath)/messages"
+        default:
+            components.path = "/\(normalizedPath)/v1/messages"
+        }
+
+        return components.url
+    }
+}
+
 private struct HaikuResponse: Decodable {
     let content: [ContentBlock]
 
@@ -20,8 +79,6 @@ private struct EmotionResponse: Decodable {
 final class EmotionAnalyzer {
     static let shared = EmotionAnalyzer()
 
-    private static let apiURL = URL(string: "https://api.anthropic.com/v1/messages")!
-    private static let model = "claude-haiku-4-5-20251001"
     private static let validEmotions: Set<String> = ["happy", "sad", "neutral"]
 
     private static let systemPrompt = """
@@ -40,13 +97,18 @@ final class EmotionAnalyzer {
     func analyze(_ prompt: String) async -> (emotion: String, intensity: Double) {
         let start = ContinuousClock.now
 
-        guard let apiKey = AppSettings.anthropicApiKey, !apiKey.isEmpty else {
-            logger.info("No Anthropic API key configured, skipping emotion analysis")
+        guard let config = resolveAPIConfig() else {
+            logger.info("No emotion analysis configuration available, using neutral fallback")
             return ("neutral", 0.0)
         }
 
         do {
-            let result = try await callHaiku(prompt: prompt, apiKey: apiKey)
+            let result = try await callHaiku(
+                prompt: prompt,
+                apiURL: config.apiURL,
+                apiKey: config.apiKey,
+                model: config.model
+            )
             let elapsed = ContinuousClock.now - start
             logger.info("Analysis took \(elapsed, privacy: .public)")
             return result
@@ -82,15 +144,51 @@ final class EmotionAnalyzer {
         return cleaned
     }
 
-    private func callHaiku(prompt: String, apiKey: String) async throws -> (emotion: String, intensity: Double) {
-        var request = URLRequest(url: Self.apiURL)
+    private func resolveAPIConfig() -> (apiURL: URL, apiKey: String, model: String)? {
+        guard let apiKey = AppSettings.anthropicApiKey?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !apiKey.isEmpty else {
+            return loadClaudeSettingsConfig()
+        }
+
+        return (
+            apiURL: ClaudeSettingsConfig.defaultAPIURL,
+            apiKey: apiKey,
+            model: ClaudeSettingsConfig.defaultModel
+        )
+    }
+
+    private func loadClaudeSettingsConfig() -> (apiURL: URL, apiKey: String, model: String)? {
+        let settingsURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/settings.json")
+
+        guard let data = try? Data(contentsOf: settingsURL) else {
+            return nil
+        }
+
+        do {
+            guard let config = try ClaudeSettingsConfig.parse(from: data) else {
+                return nil
+            }
+            return (
+                apiURL: config.apiURL,
+                apiKey: config.apiKey,
+                model: config.model
+            )
+        } catch {
+            logger.error("Failed to parse Claude settings.json: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func callHaiku(prompt: String, apiURL: URL, apiKey: String, model: String) async throws -> (emotion: String, intensity: Double) {
+        var request = URLRequest(url: apiURL)
         request.httpMethod = "POST"
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         request.setValue("application/json", forHTTPHeaderField: "content-type")
 
         let body: [String: Any] = [
-            "model": Self.model,
+            "model": model,
             "max_tokens": 50,
             "system": Self.systemPrompt,
             "messages": [


### PR DESCRIPTION
## Summary
- add Claude settings fallback for emotion analysis when no manual Notchi API key is configured
- read `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_DEFAULT_HAIKU_MODEL` from `~/.claude/settings.json`
- normalize custom provider base URLs so root, `/v1`, `/v1/messages`, and proxied paths like `/anthropic/v1` resolve to the correct messages endpoint

## Behavior
- keep the existing Notchi manual API key path as the first priority
- fall back to Claude Code provider settings only when the manual key is not configured
- return neutral emotion when neither configuration is available or the request fails

## Verification
- built successfully with `xcodebuild -project notchi/notchi.xcodeproj -scheme notchi -sdk macosx CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- manually verified that a Claude prompt triggered emotion analysis through a Claude-compatible provider configuration

Closes #19