### PR TITLE
Show multiple sprites on external monitors

### DIFF
--- a/notchi/notchi/AppDelegate.swift
+++ b/notchi/notchi/AppDelegate.swift
@@ -59,7 +59,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard let screen = ScreenSelector.shared.selectedScreen else { return }
         NotchPanelManager.shared.updateGeometry(for: screen)
 
-        let panel = NotchPanel(frame: windowFrame(for: screen))
+        let panel = NotchPanel(frame: windowFrame(for: screen), hasNotch: screen.hasNotch)
 
         let contentView = NotchContentView()
         let hostingView = NSHostingView(rootView: contentView)

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -228,13 +228,21 @@ struct NotchContentView: View {
 
     @ViewBuilder
     private var headerRow: some View {
-        HStack(spacing: 0) {
-            Color.clear
-                .frame(width: notchSize.width - cornerRadiusInsets.closed.top)
+        if panelManager.hasNotch {
+            HStack(spacing: 0) {
+                Color.clear
+                    .frame(width: notchSize.width - cornerRadiusInsets.closed.top)
 
+                headerSprites
+                    .offset(x: 15, y: -2)
+                    .frame(width: sideWidth)
+                    .opacity(isExpanded ? 0 : 1)
+                    .animation(.none, value: isExpanded)
+            }
+        } else {
             headerSprites
-                .offset(x: 15, y: -2)
-                .frame(width: sideWidth)
+                .offset(y: -2)
+                .frame(width: notchSize.width, height: notchSize.height)
                 .opacity(isExpanded ? 0 : 1)
                 .animation(.none, value: isExpanded)
         }
@@ -242,11 +250,27 @@ struct NotchContentView: View {
 
     @ViewBuilder
     private var headerSprites: some View {
-        let topSession = sessionStore.sortedSessions.first
-        SessionSpriteView(
-            state: topSession?.state ?? .idle,
-            isSelected: true
-        )
+        if panelManager.hasNotch {
+            let topSession = sessionStore.sortedSessions.first
+            SessionSpriteView(
+                state: topSession?.state ?? .idle,
+                isSelected: true
+            )
+        } else {
+            let sessions = Array(sessionStore.sortedSessions.prefix(5))
+            if sessions.isEmpty {
+                SessionSpriteView(state: .idle, isSelected: true)
+            } else {
+                HStack(spacing: 6) {
+                    ForEach(sessions) { session in
+                        SessionSpriteView(
+                            state: session.state,
+                            isSelected: session.id == sessionStore.effectiveSession?.id
+                        )
+                    }
+                }
+            }
+        }
     }
 
     private func openSettings() {

--- a/notchi/notchi/NotchPanel.swift
+++ b/notchi/notchi/NotchPanel.swift
@@ -2,7 +2,7 @@ import AppKit
 
 /// A borderless, transparent panel positioned at the MacBook notch area
 final class NotchPanel: NSPanel {
-    init(frame: CGRect) {
+    init(frame: CGRect, hasNotch: Bool = true) {
         super.init(
             contentRect: frame,
             styleMask: [.borderless, .nonactivatingPanel],
@@ -13,13 +13,22 @@ final class NotchPanel: NSPanel {
         isFloatingPanel = true
         becomesKeyOnlyIfNeeded = true
 
-        level = .mainMenu + 3
-        collectionBehavior = [
-            .fullScreenAuxiliary,
-            .stationary,
-            .canJoinAllSpaces,
-            .ignoresCycle
-        ]
+        if hasNotch {
+            level = .mainMenu + 3
+            collectionBehavior = [
+                .fullScreenAuxiliary,
+                .stationary,
+                .canJoinAllSpaces,
+                .ignoresCycle
+            ]
+        } else {
+            level = .statusBar
+            collectionBehavior = [
+                .fullScreenAuxiliary,
+                .canJoinAllSpaces,
+                .ignoresCycle
+            ]
+        }
 
         isOpaque = false
         backgroundColor = .clear

--- a/notchi/notchi/Services/NotchPanelManager.swift
+++ b/notchi/notchi/Services/NotchPanelManager.swift
@@ -10,6 +10,7 @@ final class NotchPanelManager {
     private(set) var notchSize: CGSize = .zero
     private(set) var notchRect: CGRect = .zero
     private(set) var panelRect: CGRect = .zero
+    private(set) var hasNotch: Bool = false
     private var screenHeight: CGFloat = 0
 
     private var mouseDownMonitor: EventMonitor?
@@ -23,6 +24,7 @@ final class NotchPanelManager {
         let screenFrame = screen.frame
 
         notchSize = newNotchSize
+        hasNotch = screen.hasNotch
 
         let notchCenterX = screenFrame.origin.x + screenFrame.width / 2
         let sideWidth = max(0, newNotchSize.height - 12) + 24


### PR DESCRIPTION
## Summary

- On external monitors (no notch), display up to 5 active session sprites side-by-side in the collapsed header, instead of only showing one
- Use lower window level (`.statusBar`) and remove `.stationary` on non-notch screens to avoid obstructing Mission Control

No behavioral changes on MacBook displays with notch.

Closes #24

## Known limitations

- Mission Control animation direction on external monitors is system-controlled
- If the user switches screens at runtime, the panel's window level is not dynamically updated (pre-existing behavior)