### PR TITLE
feat: add remote session support via TCP

### DIFF
--- a/notchi/Info.plist
+++ b/notchi/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUAutomaticallyUpdate</key>

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -6,6 +6,10 @@ struct AppSettings {
     private static let previousSoundKey = "previousNotificationSound"
     private static let isUsageEnabledKey = "isUsageEnabled"
     private static let claudeUsageRecoverySnapshotKey = "claudeUsageRecoverySnapshot"
+    private static let remoteTCPEnabledKey = "remoteTCPEnabled"
+    private static let remoteTCPPortKey = "remoteTCPPort"
+
+    static let defaultTCPPort: UInt16 = 9876
 
     static var isUsageEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: isUsageEnabledKey) }
@@ -31,6 +35,19 @@ struct AppSettings {
     static var anthropicApiKey: String? {
         get { KeychainManager.getAnthropicApiKey() }
         set { KeychainManager.setAnthropicApiKey(newValue) }
+    }
+
+    static var isRemoteTCPEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: remoteTCPEnabledKey) }
+        set { UserDefaults.standard.set(newValue, forKey: remoteTCPEnabledKey) }
+    }
+
+    static var remoteTCPPort: UInt16 {
+        get {
+            let val = UserDefaults.standard.integer(forKey: remoteTCPPortKey)
+            return (val > 0 && val <= Int(UInt16.max)) ? UInt16(val) : defaultTCPPort
+        }
+        set { UserDefaults.standard.set(Int(newValue), forKey: remoteTCPPortKey) }
     }
 
     static var notificationSound: NotificationSound {

--- a/notchi/notchi/Resources/notchi-hook-remote.sh
+++ b/notchi/notchi/Resources/notchi-hook-remote.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Notchi Remote Hook - forwards Claude Code events to Notchi app via TCP
+# Install this on remote machines where Claude Code runs.
+# Set NOTCHI_HOST and NOTCHI_PORT environment variables, or edit defaults below.
+
+NOTCHI_HOST="${NOTCHI_HOST:-}"
+NOTCHI_PORT="${NOTCHI_PORT:-9876}"
+
+# Exit silently if no host configured
+[ -n "$NOTCHI_HOST" ] || exit 0
+
+# Detect non-interactive (claude -p / --print) sessions
+IS_INTERACTIVE=true
+for CHECK_PID in $PPID $(ps -o ppid= -p $PPID 2>/dev/null | tr -d ' '); do
+    if ps -o args= -p "$CHECK_PID" 2>/dev/null | grep -qE '(^| )(-p|--print)( |$)'; then
+        IS_INTERACTIVE=false
+        break
+    fi
+done
+export NOTCHI_INTERACTIVE=$IS_INTERACTIVE
+
+# Parse input and send to Notchi via TCP
+/usr/bin/python3 -c "
+import json
+import os
+import socket
+import sys
+
+try:
+    input_data = json.load(sys.stdin)
+except:
+    sys.exit(0)
+
+hook_event = input_data.get('hook_event_name', '')
+
+status_map = {
+    'UserPromptSubmit': 'processing',
+    'PreCompact': 'compacting',
+    'SessionStart': 'waiting_for_input',
+    'SessionEnd': 'ended',
+    'PreToolUse': 'running_tool',
+    'PostToolUse': 'processing',
+    'PermissionRequest': 'waiting_for_input',
+    'Stop': 'waiting_for_input',
+    'SubagentStop': 'waiting_for_input'
+}
+
+output = {
+    'session_id': input_data.get('session_id', ''),
+    'cwd': input_data.get('cwd', ''),
+    'event': hook_event,
+    'status': input_data.get('status', status_map.get(hook_event, 'unknown')),
+    'pid': None,
+    'tty': None,
+    'interactive': os.environ.get('NOTCHI_INTERACTIVE', 'true') == 'true',
+    'permission_mode': input_data.get('permission_mode', 'default')
+}
+
+# Pass user prompt directly for UserPromptSubmit
+if hook_event == 'UserPromptSubmit':
+    prompt = input_data.get('prompt', '')
+    if prompt:
+        output['user_prompt'] = prompt
+
+tool = input_data.get('tool_name', '')
+if tool:
+    output['tool'] = tool
+
+tool_id = input_data.get('tool_use_id', '')
+if tool_id:
+    output['tool_use_id'] = tool_id
+
+tool_input = input_data.get('tool_input', {})
+if tool_input:
+    output['tool_input'] = tool_input
+
+host = os.environ.get('NOTCHI_HOST', '$NOTCHI_HOST')
+port = int(os.environ.get('NOTCHI_PORT', '$NOTCHI_PORT'))
+
+try:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(2)
+    sock.connect((host, port))
+    sock.sendall(json.dumps(output).encode())
+    sock.close()
+except:
+    pass
+"

--- a/notchi/notchi/Services/SocketServer.swift
+++ b/notchi/notchi/Services/SocketServer.swift
@@ -10,22 +10,34 @@ final class SocketServer {
     static let socketPath = "/tmp/notchi.sock"
 
     private var serverSocket: Int32 = -1
+    private var tcpSocket: Int32 = -1
     private var acceptSource: DispatchSourceRead?
+    private var tcpAcceptSource: DispatchSourceRead?
     private var eventHandler: HookEventHandler?
     private let queue = DispatchQueue(label: "com.ruban.notchi.socket", qos: .userInitiated)
+    private let clientQueue = DispatchQueue(label: "com.ruban.notchi.socket.clients", qos: .userInitiated, attributes: .concurrent)
+    private static let maxMessageSize = 65536 // 64KB max per message
+
+    // Tailscale CGNAT range: 100.64.0.0/10
+    private static let tailscaleBase: UInt32 = 0x64400000   // 100.64.0.0
+    private static let tailscaleMask: UInt32 = 0xFFC00000   // /10
 
     private init() {}
 
     func start(onEvent: @escaping HookEventHandler) {
         queue.async { [weak self] in
-            self?.startServer(onEvent: onEvent)
+            self?.eventHandler = onEvent
+            self?.startUnixServer()
+        }
+        if AppSettings.isRemoteTCPEnabled {
+            startTCPServer(port: AppSettings.remoteTCPPort)
         }
     }
 
-    private func startServer(onEvent: @escaping HookEventHandler) {
-        guard serverSocket < 0 else { return }
+    // MARK: - Unix Socket (local)
 
-        eventHandler = onEvent
+    private func startUnixServer() {
+        guard serverSocket < 0 else { return }
 
         unlink(Self.socketPath)
 
@@ -74,7 +86,7 @@ final class SocketServer {
 
         acceptSource = DispatchSource.makeReadSource(fileDescriptor: serverSocket, queue: queue)
         acceptSource?.setEventHandler { [weak self] in
-            self?.acceptConnection()
+            self?.drainAcceptQueue(from: self?.serverSocket ?? -1, isTCP: false)
         }
         acceptSource?.setCancelHandler { [weak self] in
             if let fd = self?.serverSocket, fd >= 0 {
@@ -85,29 +97,150 @@ final class SocketServer {
         acceptSource?.resume()
     }
 
+    // MARK: - TCP Socket (remote)
+
+    func startTCPServer(port: UInt16) {
+        queue.async { [weak self] in
+            self?.startTCPServerInternal(port: port)
+        }
+    }
+
+    private func startTCPServerInternal(port: UInt16) {
+        stopTCPServerInternal()
+
+        tcpSocket = socket(AF_INET, SOCK_STREAM, 0)
+        guard tcpSocket >= 0 else {
+            logger.error("Failed to create TCP socket: \(errno)")
+            return
+        }
+
+        var reuse: Int32 = 1
+        setsockopt(tcpSocket, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+
+        let flags = fcntl(tcpSocket, F_GETFL)
+        _ = fcntl(tcpSocket, F_SETFL, flags | O_NONBLOCK)
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = port.bigEndian
+        addr.sin_addr.s_addr = INADDR_ANY
+
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                bind(tcpSocket, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+
+        guard bindResult == 0 else {
+            logger.error("Failed to bind TCP socket on port \(port): \(errno)")
+            close(tcpSocket)
+            tcpSocket = -1
+            return
+        }
+
+        guard listen(tcpSocket, 10) == 0 else {
+            logger.error("Failed to listen on TCP: \(errno)")
+            close(tcpSocket)
+            tcpSocket = -1
+            return
+        }
+
+        logger.info("TCP listening on port \(port, privacy: .public)")
+
+        tcpAcceptSource = DispatchSource.makeReadSource(fileDescriptor: tcpSocket, queue: queue)
+        tcpAcceptSource?.setEventHandler { [weak self] in
+            self?.drainAcceptQueue(from: self?.tcpSocket ?? -1, isTCP: true)
+        }
+        tcpAcceptSource?.setCancelHandler { [weak self] in
+            if let fd = self?.tcpSocket, fd >= 0 {
+                close(fd)
+                self?.tcpSocket = -1
+            }
+        }
+        tcpAcceptSource?.resume()
+    }
+
+    func stopTCPServer() {
+        queue.async { [weak self] in
+            self?.stopTCPServerInternal()
+        }
+    }
+
+    private func stopTCPServerInternal() {
+        tcpAcceptSource?.cancel()
+        tcpAcceptSource = nil
+        if tcpSocket >= 0 {
+            close(tcpSocket)
+            tcpSocket = -1
+        }
+    }
+
     func stop() {
-        acceptSource?.cancel()
-        acceptSource = nil
-        unlink(Self.socketPath)
+        queue.async { [weak self] in
+            self?.acceptSource?.cancel()
+            self?.acceptSource = nil
+            unlink(Self.socketPath)
+            self?.stopTCPServerInternal()
+        }
     }
 
-    private func acceptConnection() {
-        let clientSocket = accept(serverSocket, nil, nil)
-        guard clientSocket >= 0 else { return }
+    // MARK: - Connection Handling
 
-        var nosigpipe: Int32 = 1
-        setsockopt(clientSocket, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, socklen_t(MemoryLayout<Int32>.size))
-
-        handleClient(clientSocket)
+    private static func isTailscaleAddress(_ addr: sockaddr_in) -> Bool {
+        let ip = UInt32(bigEndian: addr.sin_addr.s_addr)
+        return (ip & tailscaleMask) == tailscaleBase
     }
 
-    private func handleClient(_ clientSocket: Int32) {
+    private static func isAllowedAddress(_ addr: sockaddr_in) -> Bool {
+        let ip = UInt32(bigEndian: addr.sin_addr.s_addr)
+        // Allow localhost
+        if ip == 0x7F000001 { return true } // 127.0.0.1
+        // Allow Tailscale CGNAT range (100.64.0.0/10)
+        if isTailscaleAddress(addr) { return true }
+        return false
+    }
+
+    private func drainAcceptQueue(from listenSocket: Int32, isTCP: Bool) {
+        while true {
+            var clientAddr = sockaddr_in()
+            var addrLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+
+            let clientSocket = withUnsafeMutablePointer(to: &clientAddr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    accept(listenSocket, sockaddrPtr, &addrLen)
+                }
+            }
+            guard clientSocket >= 0 else { break }
+
+            // For TCP connections, only allow localhost and Tailscale IPs
+            if isTCP && !Self.isAllowedAddress(clientAddr) {
+                logger.warning("Rejected TCP connection from non-Tailscale IP")
+                close(clientSocket)
+                continue
+            }
+
+            var nosigpipe: Int32 = 1
+            setsockopt(clientSocket, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, socklen_t(MemoryLayout<Int32>.size))
+
+            // Set read timeout on client socket to prevent blocking
+            var timeout = timeval(tv_sec: 5, tv_usec: 0)
+            setsockopt(clientSocket, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+            // Handle client on concurrent queue to avoid blocking accept loop
+            let handler = eventHandler
+            clientQueue.async {
+                Self.handleClient(clientSocket, eventHandler: handler)
+            }
+        }
+    }
+
+    private static func handleClient(_ clientSocket: Int32, eventHandler: HookEventHandler?) {
         defer { close(clientSocket) }
 
         var allData = Data()
         var buffer = [UInt8](repeating: 0, count: 4096)
 
-        while true {
+        while allData.count < maxMessageSize {
             let bytesRead = read(clientSocket, &buffer, buffer.count)
             if bytesRead > 0 {
                 allData.append(contentsOf: buffer[0..<bytesRead])
@@ -127,7 +260,7 @@ final class SocketServer {
         eventHandler?(event)
     }
 
-    private func logEvent(_ event: HookEvent) {
+    private static func logEvent(_ event: HookEvent) {
         switch event.event {
         case "SessionStart":
             logger.info("Session started")

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -6,6 +6,7 @@ struct PanelSettingsView: View {
     @State private var hooksInstalled = HookInstaller.isInstalled()
     @State private var hooksError = false
     @State private var apiKeyInput = AppSettings.anthropicApiKey ?? ""
+    @State private var remoteTCPEnabled = AppSettings.isRemoteTCPEnabled
     @ObservedObject private var updateManager = UpdateManager.shared
     private var usageConnected: Bool { ClaudeUsageService.shared.isConnected }
     private var hasApiKey: Bool { !apiKeyInput.isEmpty }
@@ -78,6 +79,18 @@ struct PanelSettingsView: View {
             .buttonStyle(.plain)
 
             apiKeyRow
+
+            Button(action: toggleRemoteTCP) {
+                SettingsRowView(icon: "network", title: "Remote Sessions") {
+                    HStack(spacing: 4) {
+                        if remoteTCPEnabled {
+                            statusBadge("Port \(AppSettings.remoteTCPPort)", color: TerminalColors.green)
+                        }
+                        ToggleSwitch(isOn: remoteTCPEnabled)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
         }
     }
 
@@ -124,6 +137,16 @@ struct PanelSettingsView: View {
     private func saveApiKey() {
         let trimmed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         AppSettings.anthropicApiKey = trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func toggleRemoteTCP() {
+        remoteTCPEnabled.toggle()
+        AppSettings.isRemoteTCPEnabled = remoteTCPEnabled
+        if remoteTCPEnabled {
+            SocketServer.shared.startTCPServer(port: AppSettings.remoteTCPPort)
+        } else {
+            SocketServer.shared.stopTCPServer()
+        }
     }
 
     private var actionsSection: some View {


### PR DESCRIPTION
## Summary

Adds support for Notchi to receive hook events from Claude Code running on **remote machines** (e.g. via SSH/tmux over Tailscale). The mascot on your Mac reacts to sessions on headless servers in real time.

**My use case:** I run Claude Code in tmux on a remote Linux server connected via Tailscale, and wanted my Notchi mascot on macOS to react to those sessions too.

### What changed

- **TCP listener in SocketServer** — listens on a configurable port (default 9876) alongside the existing Unix socket
- **IP allowlist** — only accepts connections from `127.0.0.1` and Tailscale CGNAT range (`100.64.0.0/10`)
- **Non-blocking client handling** — clients are handled on a concurrent queue with a 5s read timeout, so a slow/malicious connection can't freeze event processing
- **Settings UI** — "Remote Sessions" toggle with port display
- **`notchi-hook-remote.sh`** — drop-in hook script for remote machines, sends events over TCP using `NOTCHI_HOST` and `NOTCHI_PORT` env vars
- **`NSAllowsLocalNetworking`** — ATS exception for local network HTTP connections

### Setup for remote machines

```bash
# On the remote machine:
# 1. Copy notchi-hook-remote.sh to ~/.claude/hooks/notchi-hook.sh
# 2. Set environment variables:
export NOTCHI_HOST=<mac-tailscale-ip>
export NOTCHI_PORT=9876
# 3. Configure Claude Code hooks in ~/.claude/settings.json (same format as local)
```

### Security considerations

- TCP connections are filtered to localhost + Tailscale IPs only
- 64KB max message size to prevent memory exhaustion
- 5s read timeout per client to prevent blocking
- Accept queue is drained in a loop to handle connection bursts

## Test plan

- [x] Tested with Claude Code running in tmux on remote Linux server via Tailscale
- [x] Verified mascot state changes (idle, working, waiting) sync from remote
- [x] Verified emotion analysis works for remote prompts (via Anthropic API on Mac side)
- [x] Verified non-Tailscale IPs are rejected
- [x] Verified toggling Remote Sessions on/off in settings works
- [x] Verified local Unix socket still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)