### PR TITLE
feat: add remote session support via TCP

### DIFF
--- a/notchi/Info.plist
+++ b/notchi/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUAutomaticallyUpdate</key>

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -6,6 +6,10 @@ struct AppSettings {
     private static let previousSoundKey = "previousNotificationSound"
     private static let isUsageEnabledKey = "isUsageEnabled"
     private static let claudeUsageRecoverySnapshotKey = "claudeUsageRecoverySnapshot"
+    private static let remoteTCPEnabledKey = "remoteTCPEnabled"
+    private static let remoteTCPPortKey = "remoteTCPPort"
+
+    static let defaultTCPPort: UInt16 = 9876
 
     static var isUsageEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: isUsageEnabledKey) }
@@ -31,6 +35,19 @@ struct AppSettings {
     static var anthropicApiKey: String? {
         get { KeychainManager.getAnthropicApiKey() }
         set { KeychainManager.setAnthropicApiKey(newValue) }
+    }
+
+    static var isRemoteTCPEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: remoteTCPEnabledKey) }
+        set { UserDefaults.standard.set(newValue, forKey: remoteTCPEnabledKey) }
+    }
+
+    static var remoteTCPPort: UInt16 {
+        get {
+            let val = UserDefaults.standard.integer(forKey: remoteTCPPortKey)
+            return (val > 0 && val <= Int(UInt16.max)) ? UInt16(val) : defaultTCPPort
+        }
+        set { UserDefaults.standard.set(Int(newValue), forKey: remoteTCPPortKey) }
     }
 
     static var notificationSound: NotificationSound {

--- a/notchi/notchi/Resources/notchi-hook-remote.sh
+++ b/notchi/notchi/Resources/notchi-hook-remote.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Notchi Remote Hook - forwards Claude Code events to Notchi app via TCP
+# Install this on remote machines where Claude Code runs.
+# Set NOTCHI_HOST and NOTCHI_PORT environment variables, or edit defaults below.
+
+NOTCHI_HOST="${NOTCHI_HOST:-}"
+NOTCHI_PORT="${NOTCHI_PORT:-9876}"
+
+# Exit silently if no host configured
+[ -n "$NOTCHI_HOST" ] || exit 0
+
+# Detect non-interactive (claude -p / --print) sessions
+IS_INTERACTIVE=true
+for CHECK_PID in $PPID $(ps -o ppid= -p $PPID 2>/dev/null | tr -d ' '); do
+    if ps -o args= -p "$CHECK_PID" 2>/dev/null | grep -qE '(^| )(-p|--print)( |$)'; then
+        IS_INTERACTIVE=false
+        break
+    fi
+done
+export NOTCHI_INTERACTIVE=$IS_INTERACTIVE
+
+# Parse input and send to Notchi via TCP
+/usr/bin/python3 -c "
+import json
+import os
+import socket
+import sys
+
+try:
+    input_data = json.load(sys.stdin)
+except:
+    sys.exit(0)
+
+hook_event = input_data.get('hook_event_name', '')
+
+status_map = {
+    'UserPromptSubmit': 'processing',
+    'PreCompact': 'compacting',
+    'SessionStart': 'waiting_for_input',
+    'SessionEnd': 'ended',
+    'PreToolUse': 'running_tool',
+    'PostToolUse': 'processing',
+    'PermissionRequest': 'waiting_for_input',
+    'Stop': 'waiting_for_input',
+    'SubagentStop': 'waiting_for_input'
+}
+
+output = {
+    'session_id': input_data.get('session_id', ''),
+    'cwd': input_data.get('cwd', ''),
+    'event': hook_event,
+    'status': input_data.get('status', status_map.get(hook_event, 'unknown')),
+    'pid': None,
+    'tty': None,
+    'interactive': os.environ.get('NOTCHI_INTERACTIVE', 'true') == 'true',
+    'permission_mode': input_data.get('permission_mode', 'default')
+}
+
+# Pass user prompt directly for UserPromptSubmit
+if hook_event == 'UserPromptSubmit':
+    prompt = input_data.get('prompt', '')
+    if prompt:
+        output['user_prompt'] = prompt
+
+tool = input_data.get('tool_name', '')
+if tool:
+    output['tool'] = tool
+
+tool_id = input_data.get('tool_use_id', '')
+if tool_id:
+    output['tool_use_id'] = tool_id
+
+tool_input = input_data.get('tool_input', {})
+if tool_input:
+    output['tool_input'] = tool_input
+
+host = os.environ.get('NOTCHI_HOST', '$NOTCHI_HOST')
+port = int(os.environ.get('NOTCHI_PORT', '$NOTCHI_PORT'))
+
+try:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(2)
+    sock.connect((host, port))
+    sock.sendall(json.dumps(output).encode())
+    sock.close()
+except:
+    pass
+"

--- a/notchi/notchi/Services/SocketServer.swift
+++ b/notchi/notchi/Services/SocketServer.swift
@@ -9,23 +9,42 @@ final class SocketServer {
     static let shared = SocketServer()
     static let socketPath = "/tmp/notchi.sock"
 
+    /// IPs that have sent events via TCP. Updated on main thread.
+    @MainActor private(set) var connectedRemotes: Set<String> = []
+    @MainActor private(set) var blockedRemotes: Set<String> = []
+    @MainActor private var remoteSessionIds: [String: Set<String>] = [:] // IP -> session IDs
+
     private var serverSocket: Int32 = -1
+    private var tcpSocket: Int32 = -1
     private var acceptSource: DispatchSourceRead?
+    private var tcpAcceptSource: DispatchSourceRead?
     private var eventHandler: HookEventHandler?
     private let queue = DispatchQueue(label: "com.ruban.notchi.socket", qos: .userInitiated)
+    private let clientQueue = DispatchQueue(label: "com.ruban.notchi.socket.clients", qos: .userInitiated, attributes: .concurrent)
+    private static let maxMessageSize = 65536 // 64KB max per message
+
+    // Tailscale CGNAT range: 100.64.0.0/10
+    private static let tailscaleBase: UInt32 = 0x64400000   // 100.64.0.0
+    private static let tailscaleMask: UInt32 = 0xFFC00000   // /10
 
     private init() {}
 
     func start(onEvent: @escaping HookEventHandler) {
+        let tcpEnabled = AppSettings.isRemoteTCPEnabled
+        let tcpPort = AppSettings.remoteTCPPort
         queue.async { [weak self] in
-            self?.startServer(onEvent: onEvent)
+            self?.eventHandler = onEvent
+            self?.startUnixServer()
+            if tcpEnabled {
+                self?.startTCPServerInternal(port: tcpPort)
+            }
         }
     }
 
-    private func startServer(onEvent: @escaping HookEventHandler) {
-        guard serverSocket < 0 else { return }
+    // MARK: - Unix Socket (local)
 
-        eventHandler = onEvent
+    private func startUnixServer() {
+        guard serverSocket < 0 else { return }
 
         unlink(Self.socketPath)
 
@@ -61,7 +80,7 @@ final class SocketServer {
             return
         }
 
-        chmod(Self.socketPath, 0o777)
+        chmod(Self.socketPath, 0o700)
 
         guard listen(serverSocket, 10) == 0 else {
             logger.error("Failed to listen: \(errno)")
@@ -74,7 +93,7 @@ final class SocketServer {
 
         acceptSource = DispatchSource.makeReadSource(fileDescriptor: serverSocket, queue: queue)
         acceptSource?.setEventHandler { [weak self] in
-            self?.acceptConnection()
+            self?.drainAcceptQueue(from: self?.serverSocket ?? -1, isTCP: false)
         }
         acceptSource?.setCancelHandler { [weak self] in
             if let fd = self?.serverSocket, fd >= 0 {
@@ -85,29 +104,213 @@ final class SocketServer {
         acceptSource?.resume()
     }
 
+    // MARK: - TCP Socket (remote)
+
+    func startTCPServer(port: UInt16) {
+        queue.async { [weak self] in
+            self?.startTCPServerInternal(port: port)
+        }
+    }
+
+    private func startTCPServerInternal(port: UInt16) {
+        stopTCPServerInternal()
+
+        tcpSocket = socket(AF_INET, SOCK_STREAM, 0)
+        guard tcpSocket >= 0 else {
+            logger.error("Failed to create TCP socket: \(errno)")
+            return
+        }
+
+        var reuse: Int32 = 1
+        setsockopt(tcpSocket, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+
+        let flags = fcntl(tcpSocket, F_GETFL)
+        _ = fcntl(tcpSocket, F_SETFL, flags | O_NONBLOCK)
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = port.bigEndian
+        addr.sin_addr.s_addr = INADDR_ANY
+
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                bind(tcpSocket, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+
+        guard bindResult == 0 else {
+            logger.error("Failed to bind TCP socket on port \(port): \(errno)")
+            close(tcpSocket)
+            tcpSocket = -1
+            return
+        }
+
+        guard listen(tcpSocket, 10) == 0 else {
+            logger.error("Failed to listen on TCP: \(errno)")
+            close(tcpSocket)
+            tcpSocket = -1
+            return
+        }
+
+        logger.info("TCP listening on port \(port, privacy: .public)")
+
+        tcpAcceptSource = DispatchSource.makeReadSource(fileDescriptor: tcpSocket, queue: queue)
+        tcpAcceptSource?.setEventHandler { [weak self] in
+            self?.drainAcceptQueue(from: self?.tcpSocket ?? -1, isTCP: true)
+        }
+        tcpAcceptSource?.setCancelHandler { [weak self] in
+            if let fd = self?.tcpSocket, fd >= 0 {
+                close(fd)
+                self?.tcpSocket = -1
+            }
+        }
+        tcpAcceptSource?.resume()
+    }
+
+    func stopTCPServer() {
+        queue.async { [weak self] in
+            self?.stopTCPServerInternal()
+        }
+    }
+
+    private func stopTCPServerInternal() {
+        tcpAcceptSource?.cancel()
+        tcpAcceptSource = nil
+        if tcpSocket >= 0 {
+            close(tcpSocket)
+            tcpSocket = -1
+        }
+    }
+
+    @MainActor func removeRemote(_ ip: String) {
+        connectedRemotes.remove(ip)
+        blockedRemotes.insert(ip)
+        // End sessions from this remote
+        if let sessionIds = remoteSessionIds.removeValue(forKey: ip) {
+            let store = NotchiStateMachine.shared.sessionStore
+            for sessionId in sessionIds {
+                store.dismissSession(sessionId)
+            }
+        }
+    }
+
+    @MainActor func unblockRemote(_ ip: String) {
+        blockedRemotes.remove(ip)
+    }
+
+    @MainActor func isBlocked(_ ip: String) -> Bool {
+        blockedRemotes.contains(ip)
+    }
+
     func stop() {
-        acceptSource?.cancel()
-        acceptSource = nil
-        unlink(Self.socketPath)
+        queue.async { [weak self] in
+            self?.acceptSource?.cancel()
+            self?.acceptSource = nil
+            unlink(Self.socketPath)
+            self?.stopTCPServerInternal()
+        }
     }
 
-    private func acceptConnection() {
-        let clientSocket = accept(serverSocket, nil, nil)
-        guard clientSocket >= 0 else { return }
+    // MARK: - Connection Handling
 
-        var nosigpipe: Int32 = 1
-        setsockopt(clientSocket, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, socklen_t(MemoryLayout<Int32>.size))
-
-        handleClient(clientSocket)
+    private static func ipString(from addr: sockaddr_in) -> String? {
+        let ip = UInt32(bigEndian: addr.sin_addr.s_addr)
+        guard ip != 0 else { return nil }
+        let a = (ip >> 24) & 0xFF
+        let b = (ip >> 16) & 0xFF
+        let c = (ip >> 8) & 0xFF
+        let d = ip & 0xFF
+        return "\(a).\(b).\(c).\(d)"
     }
 
-    private func handleClient(_ clientSocket: Int32) {
+    private static func isTailscaleAddress(_ addr: sockaddr_in) -> Bool {
+        let ip = UInt32(bigEndian: addr.sin_addr.s_addr)
+        return (ip & tailscaleMask) == tailscaleBase
+    }
+
+    private static func isAllowedAddress(_ addr: sockaddr_in) -> Bool {
+        let ip = UInt32(bigEndian: addr.sin_addr.s_addr)
+        // Allow localhost (127.0.0.0/8)
+        if (ip & 0xFF000000) == 0x7F000000 { return true }
+        // Allow Tailscale CGNAT range (100.64.0.0/10)
+        if isTailscaleAddress(addr) { return true }
+        // Allow private networks
+        if (ip & 0xFFFF0000) == 0xC0A80000 { return true } // 192.168.0.0/16
+        if (ip & 0xFF000000) == 0x0A000000 { return true } // 10.0.0.0/8
+        if (ip & 0xFFF00000) == 0xAC100000 { return true } // 172.16.0.0/12
+        return false
+    }
+
+    private func drainAcceptQueue(from listenSocket: Int32, isTCP: Bool) {
+        while true {
+            var clientStorage = sockaddr_storage()
+            var addrLen = socklen_t(MemoryLayout<sockaddr_storage>.size)
+
+            let clientSocket = withUnsafeMutablePointer(to: &clientStorage) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    accept(listenSocket, sockaddrPtr, &addrLen)
+                }
+            }
+            guard clientSocket >= 0 else { break }
+
+            // Extract sockaddr_in for TCP connections
+            let clientAddr: sockaddr_in? = isTCP ? withUnsafePointer(to: &clientStorage) { ptr in
+                ptr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { $0.pointee }
+            } : nil
+
+            // For TCP connections, only allow localhost and private/Tailscale IPs
+            if let addr = clientAddr, !Self.isAllowedAddress(addr) {
+                logger.warning("Rejected TCP connection from non-Tailscale IP")
+                close(clientSocket)
+                continue
+            }
+
+            var nosigpipe: Int32 = 1
+            setsockopt(clientSocket, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, socklen_t(MemoryLayout<Int32>.size))
+
+            // Set read timeout on client socket to prevent blocking
+            var timeout = timeval(tv_sec: 5, tv_usec: 0)
+            setsockopt(clientSocket, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+            // For TCP: track IP and check blocklist
+            if isTCP, let addr = clientAddr, let ip = Self.ipString(from: addr) {
+                let server = self
+                let handler = eventHandler
+                Task { @MainActor in
+                    if server.isBlocked(ip) {
+                        close(clientSocket)
+                        return
+                    }
+                    server.connectedRemotes.insert(ip)
+                    let capturedIP = ip
+                    server.clientQueue.async {
+                        let event = Self.handleClient(clientSocket, eventHandler: handler)
+                        if let sessionId = event?.sessionId {
+                            Task { @MainActor in
+                                server.remoteSessionIds[capturedIP, default: []].insert(sessionId)
+                            }
+                        }
+                    }
+                }
+                continue
+            }
+
+            // Handle client on concurrent queue to avoid blocking accept loop
+            let handler = eventHandler
+            clientQueue.async {
+                Self.handleClient(clientSocket, eventHandler: handler)
+            }
+        }
+    }
+
+    @discardableResult
+    private static func handleClient(_ clientSocket: Int32, eventHandler: HookEventHandler?) -> HookEvent? {
         defer { close(clientSocket) }
 
         var allData = Data()
         var buffer = [UInt8](repeating: 0, count: 4096)
 
-        while true {
+        while allData.count < maxMessageSize {
             let bytesRead = read(clientSocket, &buffer, buffer.count)
             if bytesRead > 0 {
                 allData.append(contentsOf: buffer[0..<bytesRead])
@@ -116,18 +319,19 @@ final class SocketServer {
             }
         }
 
-        guard !allData.isEmpty else { return }
+        guard !allData.isEmpty else { return nil }
 
         guard let event = try? JSONDecoder().decode(HookEvent.self, from: allData) else {
             logger.warning("Failed to parse event")
-            return
+            return nil
         }
 
         logEvent(event)
         eventHandler?(event)
+        return event
     }
 
-    private func logEvent(_ event: HookEvent) {
+    private static func logEvent(_ event: HookEvent) {
         switch event.event {
         case "SessionStart":
             logger.info("Session started")

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -6,6 +6,9 @@ struct PanelSettingsView: View {
     @State private var hooksInstalled = HookInstaller.isInstalled()
     @State private var hooksError = false
     @State private var apiKeyInput = AppSettings.anthropicApiKey ?? ""
+    @State private var remoteTCPEnabled = AppSettings.isRemoteTCPEnabled
+    @State private var copiedSetup = false
+    @State private var copiedUninstall = false
     @ObservedObject private var updateManager = UpdateManager.shared
     private var usageConnected: Bool { ClaudeUsageService.shared.isConnected }
     private var hasApiKey: Bool { !apiKeyInput.isEmpty }
@@ -78,6 +81,190 @@ struct PanelSettingsView: View {
             .buttonStyle(.plain)
 
             apiKeyRow
+
+            Button(action: toggleRemoteTCP) {
+                SettingsRowView(icon: "network", title: "Remote Sessions") {
+                    HStack(spacing: 4) {
+                        if remoteTCPEnabled {
+                            statusBadge("Port \(AppSettings.remoteTCPPort)", color: TerminalColors.green)
+                        }
+                        ToggleSwitch(isOn: remoteTCPEnabled)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+
+            if remoteTCPEnabled {
+                remoteSetupInfo
+            }
+        }
+    }
+
+    private var remoteSetupInfo: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            // Show connected remotes
+            if !SocketServer.shared.connectedRemotes.isEmpty {
+                ForEach(Array(SocketServer.shared.connectedRemotes.sorted()), id: \.self) { ip in
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(TerminalColors.green)
+                            .frame(width: 6, height: 6)
+                        Text(ip)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(TerminalColors.primaryText)
+
+                        Spacer()
+
+                        Button(action: { disconnectRemote(ip) }) {
+                            Image(systemName: "xmark.circle")
+                                .font(.system(size: 12))
+                                .foregroundColor(TerminalColors.red)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.leading, 28)
+                    .padding(.trailing, 4)
+                }
+            }
+
+            // Show blocked remotes
+            ForEach(Array(SocketServer.shared.blockedRemotes.sorted()), id: \.self) { ip in
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(TerminalColors.red)
+                        .frame(width: 6, height: 6)
+                    Text(ip)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(TerminalColors.dimmedText)
+                        .strikethrough()
+
+                    Spacer()
+
+                    Button(action: { SocketServer.shared.unblockRemote(ip) }) {
+                        Image(systemName: "arrow.counterclockwise")
+                            .font(.system(size: 11))
+                            .foregroundColor(TerminalColors.dimmedText)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.leading, 28)
+                .padding(.trailing, 4)
+            }
+
+            // Show uninstall command hint
+            if copiedUninstall {
+                Text("Uninstall command copied — run on the remote machine")
+                    .font(.system(size: 10))
+                    .foregroundColor(TerminalColors.amber)
+                    .padding(.leading, 28)
+            }
+
+            Text(SocketServer.shared.connectedRemotes.isEmpty ? "Run on remote machine:" : "Add another machine:")
+                .font(.system(size: 10))
+                .foregroundColor(TerminalColors.dimmedText)
+                .padding(.leading, 28)
+
+            HStack(spacing: 6) {
+                Text(setupCommand)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundColor(TerminalColors.secondaryText)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+
+                Button(action: copySetupCommand) {
+                    Image(systemName: copiedSetup ? "checkmark" : "doc.on.doc")
+                        .font(.system(size: 11))
+                        .foregroundColor(copiedSetup ? TerminalColors.green : TerminalColors.dimmedText)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(Color.white.opacity(0.04))
+            .cornerRadius(6)
+            .padding(.leading, 28)
+        }
+    }
+
+    private var setupCommand: String {
+        let host = detectedIP ?? "YOUR_MAC_IP"
+        let port = AppSettings.remoteTCPPort
+        return "curl -fsSL https://raw.githubusercontent.com/sk-ruban/notchi/main/scripts/remote-setup.sh | NOTCHI_HOST=\(host) NOTCHI_PORT=\(port) bash"
+    }
+
+    private var detectedIP: String? {
+        var ifaddr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddr) == 0, let firstAddr = ifaddr else { return nil }
+        defer { freeifaddrs(ifaddr) }
+
+        var tailscaleIP: String?
+        var privateIP: String?
+
+        for ptr in sequence(first: firstAddr, next: { $0.pointee.ifa_next }) {
+            let addr = ptr.pointee
+            guard addr.ifa_addr != nil,
+                  addr.ifa_addr.pointee.sa_family == sa_family_t(AF_INET) else { continue }
+
+            let ip = addr.ifa_addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { sockAddr in
+                UInt32(bigEndian: sockAddr.pointee.sin_addr.s_addr)
+            }
+
+            let a = (ip >> 24) & 0xFF
+            let b = (ip >> 16) & 0xFF
+            let c = (ip >> 8) & 0xFF
+            let d = ip & 0xFF
+            let ipStr = "\(a).\(b).\(c).\(d)"
+
+            // Tailscale CGNAT range: 100.64.0.0/10
+            if (ip & 0xFFC00000) == 0x64400000 {
+                tailscaleIP = ipStr
+            }
+            // Private ranges: 192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12
+            else if (ip & 0xFFFF0000) == 0xC0A80000 ||  // 192.168.x.x
+                    (ip & 0xFF000000) == 0x0A000000 ||   // 10.x.x.x
+                    (ip & 0xFFF00000) == 0xAC100000 {    // 172.16-31.x.x
+                if privateIP == nil { privateIP = ipStr }
+            }
+        }
+
+        // Prefer Tailscale, then private LAN
+        return tailscaleIP ?? privateIP
+    }
+
+    private static let uninstallCommand = """
+        rm -f ~/.claude/hooks/notchi-hook.sh && \
+        sed -i.bak '/NOTCHI_HOST/d;/NOTCHI_PORT/d;/Notchi remote/d' ~/.bashrc ~/.zshrc 2>/dev/null; \
+        python3 -c "
+        import json,os
+        p=os.path.expanduser('~/.claude/settings.json')
+        try:
+         s=json.load(open(p))
+         h=s.get('hooks',{})
+         for e in list(h):
+          h[e]=[x for x in h[e] if not any('notchi-hook.sh' in hk.get('command','') for hk in x.get('hooks',[]))]
+          if not h[e]: del h[e]
+         s['hooks']=h
+         json.dump(s,open(p,'w'),indent=2,sort_keys=True)
+        except: pass
+        " && echo 'Notchi hook removed'
+        """
+
+    private func disconnectRemote(_ ip: String) {
+        SocketServer.shared.removeRemote(ip)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(Self.uninstallCommand, forType: .string)
+        copiedUninstall = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            copiedUninstall = false
+        }
+    }
+
+    private func copySetupCommand() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(setupCommand, forType: .string)
+        copiedSetup = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            copiedSetup = false
         }
     }
 
@@ -124,6 +311,16 @@ struct PanelSettingsView: View {
     private func saveApiKey() {
         let trimmed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         AppSettings.anthropicApiKey = trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func toggleRemoteTCP() {
+        remoteTCPEnabled.toggle()
+        AppSettings.isRemoteTCPEnabled = remoteTCPEnabled
+        if remoteTCPEnabled {
+            SocketServer.shared.startTCPServer(port: AppSettings.remoteTCPPort)
+        } else {
+            SocketServer.shared.stopTCPServer()
+        }
     }
 
     private var actionsSection: some View {

--- a/scripts/notchi-hook-remote.sh
+++ b/scripts/notchi-hook-remote.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Notchi Remote Hook - forwards Claude Code events to Notchi app via TCP
+# Install this on remote machines where Claude Code runs.
+# Set NOTCHI_HOST and NOTCHI_PORT environment variables, or edit defaults below.
+
+NOTCHI_HOST="${NOTCHI_HOST:-}"
+NOTCHI_PORT="${NOTCHI_PORT:-9876}"
+
+# Exit silently if no host configured
+[ -n "$NOTCHI_HOST" ] || exit 0
+
+# Detect non-interactive (claude -p / --print) sessions
+IS_INTERACTIVE=true
+for CHECK_PID in $PPID $(ps -o ppid= -p $PPID 2>/dev/null | tr -d ' '); do
+    if ps -o args= -p "$CHECK_PID" 2>/dev/null | grep -qE '(^| )(-p|--print)( |$)'; then
+        IS_INTERACTIVE=false
+        break
+    fi
+done
+export NOTCHI_INTERACTIVE=$IS_INTERACTIVE
+
+# Parse input and send to Notchi via TCP
+/usr/bin/python3 -c "
+import json
+import os
+import socket
+import sys
+
+try:
+    input_data = json.load(sys.stdin)
+except:
+    sys.exit(0)
+
+hook_event = input_data.get('hook_event_name', '')
+
+status_map = {
+    'UserPromptSubmit': 'processing',
+    'PreCompact': 'compacting',
+    'SessionStart': 'waiting_for_input',
+    'SessionEnd': 'ended',
+    'PreToolUse': 'running_tool',
+    'PostToolUse': 'processing',
+    'PermissionRequest': 'waiting_for_input',
+    'Stop': 'waiting_for_input',
+    'SubagentStop': 'waiting_for_input'
+}
+
+output = {
+    'session_id': input_data.get('session_id', ''),
+    'cwd': input_data.get('cwd', ''),
+    'event': hook_event,
+    'status': input_data.get('status', status_map.get(hook_event, 'unknown')),
+    'pid': None,
+    'tty': None,
+    'interactive': os.environ.get('NOTCHI_INTERACTIVE', 'true') == 'true',
+    'permission_mode': input_data.get('permission_mode', 'default')
+}
+
+# Pass user prompt directly for UserPromptSubmit
+if hook_event == 'UserPromptSubmit':
+    prompt = input_data.get('prompt', '')
+    if prompt:
+        output['user_prompt'] = prompt
+
+tool = input_data.get('tool_name', '')
+if tool:
+    output['tool'] = tool
+
+tool_id = input_data.get('tool_use_id', '')
+if tool_id:
+    output['tool_use_id'] = tool_id
+
+tool_input = input_data.get('tool_input', {})
+if tool_input:
+    output['tool_input'] = tool_input
+
+host = os.environ.get('NOTCHI_HOST', '$NOTCHI_HOST')
+port = int(os.environ.get('NOTCHI_PORT', '$NOTCHI_PORT'))
+
+try:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(2)
+    sock.connect((host, port))
+    sock.sendall(json.dumps(output).encode())
+    sock.close()
+except:
+    pass
+"

--- a/scripts/remote-setup.sh
+++ b/scripts/remote-setup.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Notchi Remote Setup
+# Run on a remote machine to connect Claude Code sessions to Notchi on your Mac.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/sk-ruban/notchi/main/scripts/remote-setup.sh | NOTCHI_HOST=<mac-ip> NOTCHI_PORT=9876 bash
+
+set -e
+
+NOTCHI_HOST="${NOTCHI_HOST:-}"
+NOTCHI_PORT="${NOTCHI_PORT:-9876}"
+
+if [ -z "$NOTCHI_HOST" ]; then
+    echo "Error: NOTCHI_HOST is required."
+    echo "Usage: curl -fsSL <url> | NOTCHI_HOST=<mac-ip> bash"
+    exit 1
+fi
+
+echo "Setting up Notchi remote hook..."
+echo "  Host: $NOTCHI_HOST"
+echo "  Port: $NOTCHI_PORT"
+
+# Create hooks directory
+mkdir -p ~/.claude/hooks
+
+# Download hook script
+HOOK_URL="https://raw.githubusercontent.com/sk-ruban/notchi/main/scripts/notchi-hook-remote.sh"
+curl -fsSL "$HOOK_URL" -o ~/.claude/hooks/notchi-hook.sh
+chmod +x ~/.claude/hooks/notchi-hook.sh
+echo "  Installed hook script"
+
+# Add environment variables to shell profile
+add_env_to_profile() {
+    local profile="$1"
+    [ -f "$profile" ] || return 0
+    if grep -q "NOTCHI_HOST" "$profile" 2>/dev/null; then
+        # Update existing values
+        sed -i.bak "s|export NOTCHI_HOST=.*|export NOTCHI_HOST=$NOTCHI_HOST|" "$profile"
+        sed -i.bak "s|export NOTCHI_PORT=.*|export NOTCHI_PORT=$NOTCHI_PORT|" "$profile"
+        rm -f "${profile}.bak"
+        echo "  Updated $profile"
+    else
+        printf '\n# Notchi remote hook\nexport NOTCHI_HOST=%s\nexport NOTCHI_PORT=%s\n' "$NOTCHI_HOST" "$NOTCHI_PORT" >> "$profile"
+        echo "  Added env vars to $profile"
+    fi
+}
+
+# Try common shell profiles
+for profile in ~/.bashrc ~/.zshrc; do
+    add_env_to_profile "$profile"
+done
+
+# If no profile exists, create .bashrc
+if [ ! -f ~/.bashrc ] && [ ! -f ~/.zshrc ]; then
+    printf '# Notchi remote hook\nexport NOTCHI_HOST=%s\nexport NOTCHI_PORT=%s\n' "$NOTCHI_HOST" "$NOTCHI_PORT" > ~/.bashrc
+    echo "  Created ~/.bashrc with env vars"
+fi
+
+# Configure Claude Code hooks
+python3 -c "
+import json, os
+
+settings_path = os.path.expanduser('~/.claude/settings.json')
+try:
+    with open(settings_path) as f:
+        settings = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    settings = {}
+
+command = '~/.claude/hooks/notchi-hook.sh'
+hook_entry = [{'type': 'command', 'command': command}]
+with_matcher = [{'matcher': '*', 'hooks': hook_entry}]
+without_matcher = [{'hooks': hook_entry}]
+pre_compact = [
+    {'matcher': 'auto', 'hooks': hook_entry},
+    {'matcher': 'manual', 'hooks': hook_entry}
+]
+
+hooks = settings.get('hooks', {})
+
+events = {
+    'UserPromptSubmit': without_matcher,
+    'SessionStart': without_matcher,
+    'PreToolUse': with_matcher,
+    'PostToolUse': with_matcher,
+    'PermissionRequest': with_matcher,
+    'PreCompact': pre_compact,
+    'Stop': without_matcher,
+    'SubagentStop': without_matcher,
+    'SessionEnd': without_matcher,
+}
+
+for event, config in events.items():
+    existing = hooks.get(event, [])
+    has_notchi = any(
+        any('notchi-hook.sh' in h.get('command', '') for h in entry.get('hooks', []))
+        for entry in existing
+    )
+    if not has_notchi:
+        existing.extend(config)
+        hooks[event] = existing
+
+settings['hooks'] = hooks
+
+with open(settings_path, 'w') as f:
+    json.dump(settings, f, indent=2, sort_keys=True)
+" && echo "  Configured Claude Code hooks"
+
+echo ""
+echo "Done! Restart your shell or run: source ~/.bashrc"
+echo "Then start Claude Code — your Notchi mascot on $NOTCHI_HOST will react."

--- a/scripts/remote-uninstall.sh
+++ b/scripts/remote-uninstall.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Notchi Remote Uninstall
+# Run on a remote machine to remove the Notchi hook.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/sk-ruban/notchi/main/scripts/remote-uninstall.sh | bash
+
+set -e
+
+echo "Removing Notchi remote hook..."
+
+# Remove hook script
+rm -f ~/.claude/hooks/notchi-hook.sh
+echo "  Removed hook script"
+
+# Remove env vars from shell profiles
+for profile in ~/.bashrc ~/.zshrc; do
+    if [ -f "$profile" ] && grep -q "NOTCHI_HOST" "$profile" 2>/dev/null; then
+        sed -i.bak '/NOTCHI_HOST/d;/NOTCHI_PORT/d;/Notchi remote/d' "$profile"
+        rm -f "${profile}.bak"
+        echo "  Cleaned $profile"
+    fi
+done
+
+# Remove hooks from Claude Code settings
+python3 -c "
+import json, os
+
+p = os.path.expanduser('~/.claude/settings.json')
+try:
+    with open(p) as f:
+        s = json.load(f)
+    h = s.get('hooks', {})
+    for e in list(h):
+        h[e] = [x for x in h[e] if not any('notchi-hook.sh' in hk.get('command', '') for hk in x.get('hooks', []))]
+        if not h[e]:
+            del h[e]
+    if not h:
+        del s['hooks']
+    with open(p, 'w') as f:
+        json.dump(s, f, indent=2, sort_keys=True)
+    print('  Cleaned Claude Code settings')
+except Exception:
+    pass
+"
+
+echo ""
+echo "Done! Notchi hook removed."


### PR DESCRIPTION
## Summary

Adds support for Notchi to receive hook events from Claude Code running on **remote machines** (e.g. via SSH/tmux over Tailscale or LAN). The mascot on your Mac reacts to remote sessions in real time.

**Use case:** I run Claude Code in tmux on a remote Linux server connected via Tailscale, and wanted my Notchi mascot on macOS to react to those sessions.

### How it works

1. Enable **Remote Sessions** in Notchi settings
2. Notchi auto-detects your Mac's IP (Tailscale/LAN) and shows a one-liner setup command
3. Run that command on the remote machine — it installs the hook and configures Claude Code
4. Done — remote sessions appear in Notchi

### What changed

- **TCP listener** in SocketServer alongside existing Unix socket (default port 9876)
- **IP allowlist** — only localhost, Tailscale CGNAT (`100.64.0.0/10`), and private networks
- **Non-blocking client handling** — concurrent queue, 5s read timeout, 64KB max message
- **Settings UI** — Remote Sessions toggle, connected remotes with disconnect/block, auto-detected IP
- **Session cleanup** — disconnecting a remote blocks its IP and removes its sessions
- **`scripts/remote-setup.sh`** — one-command installer for remote machines
- **`scripts/remote-uninstall.sh`** — clean removal (hook, env vars, Claude Code settings)
- **`notchi-hook-remote.sh`** — hook script that sends events via TCP
- Unix socket permissions tightened from `0o777` to `0o700`
- `sockaddr_storage` for accept buffer (avoids overflow with Unix sockets)

### Note on URLs

The setup command in `PanelSettingsView.swift` and `scripts/remote-setup.sh` point to `sk-ruban/notchi/main` so they work after merge. For testing before merge, use the fork URL:
```bash
curl -fsSL https://raw.githubusercontent.com/Minniesse/notchi/feat/remote-session-support/scripts/remote-setup.sh | NOTCHI_HOST=<mac-ip> NOTCHI_PORT=9876 bash
```

### Security

- TCP connections filtered to localhost + Tailscale + private IPs only
- 64KB max message size
- 5s read timeout per client
- IP blocklist for disconnected remotes
- No authentication (relies on network-level trust via Tailscale/LAN)

### Remote setup

```bash
curl -fsSL https://raw.githubusercontent.com/sk-ruban/notchi/main/scripts/remote-setup.sh | NOTCHI_HOST=<mac-ip> NOTCHI_PORT=9876 bash
```

## Test plan

- [x] Remote Claude Code sessions sync to Notchi via Tailscale
- [x] Mascot state changes (idle, working, waiting) work from remote
- [x] Emotion analysis works for remote prompts
- [x] Non-allowed IPs are rejected
- [x] Disconnect removes sessions and blocks IP
- [x] Unblock allows reconnection
- [x] Local Unix socket still works as before
- [x] `remote-setup.sh` installs correctly on Linux
- [x] `remote-uninstall.sh` cleans up hooks and Claude Code settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)