### PR TITLE
Add sprite color picker and 10% smaller notch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve SPM dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project notchi/notchi.xcodeproj \
+            -scheme notchi
+
+      - name: Build
+        run: |
+          xcodebuild archive \
+            -project notchi/notchi.xcodeproj \
+            -scheme notchi \
+            -configuration Debug \
+            -archivePath $RUNNER_TEMP/notchi.xcarchive \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Create ZIP
+        run: |
+          ditto -c -k --keepParent \
+            "$RUNNER_TEMP/notchi.xcarchive/Products/Applications/Notchi.app" \
+            "$RUNNER_TEMP/Notchi.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Notchi
+          path: $RUNNER_TEMP/Notchi.zip

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -6,6 +6,7 @@ struct AppSettings {
     private static let previousSoundKey = "previousNotificationSound"
     private static let isUsageEnabledKey = "isUsageEnabled"
     private static let claudeUsageRecoverySnapshotKey = "claudeUsageRecoverySnapshot"
+    private static let spriteColorKey = "spriteColor"
 
     static var isUsageEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: isUsageEnabledKey) }
@@ -71,6 +72,30 @@ struct AppSettings {
         }
         set {
             UserDefaults.standard.set(newValue?.rawValue, forKey: previousSoundKey)
+        }
+    }
+
+    enum SpriteColor: String, CaseIterable {
+        case orange
+        case purple
+        case blue
+        case green
+
+        var displayName: String {
+            rawValue.capitalized
+        }
+    }
+
+    static var spriteColor: SpriteColor {
+        get {
+            guard let rawValue = UserDefaults.standard.string(forKey: spriteColorKey),
+                  let color = SpriteColor(rawValue: rawValue) else {
+                return .orange
+            }
+            return color
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: spriteColorKey)
         }
     }
 }

--- a/notchi/notchi/Services/NotchPanelManager.swift
+++ b/notchi/notchi/Services/NotchPanelManager.swift
@@ -21,7 +21,9 @@ final class NotchPanelManager {
     }
 
     func updateGeometry(for screen: NSScreen) {
-        let newNotchSize = screen.notchSize
+        let rawNotchSize = screen.notchSize
+        let notchScale: CGFloat = 0.9
+        let newNotchSize = CGSize(width: rawNotchSize.width * notchScale, height: rawNotchSize.height * notchScale)
         let screenFrame = screen.frame
 
         notchSize = newNotchSize

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -6,6 +6,7 @@ struct PanelSettingsView: View {
     @State private var hooksInstalled = HookInstaller.isInstalled()
     @State private var hooksError = false
     @State private var apiKeyInput = AppSettings.anthropicApiKey ?? ""
+    @State private var selectedColor = AppSettings.spriteColor
     @ObservedObject private var updateManager = UpdateManager.shared
     private var usageConnected: Bool { ClaudeUsageService.shared.isConnected }
     private var hasApiKey: Bool { !apiKeyInput.isEmpty }
@@ -48,6 +49,23 @@ struct PanelSettingsView: View {
             ScreenPickerRow(screenSelector: ScreenSelector.shared)
 
             SoundPickerView()
+
+            HStack {
+                Text("Sprite Color")
+                    .font(.system(size: 13))
+                    .foregroundColor(TerminalColors.primaryText)
+                Spacer()
+                Picker("Color", selection: $selectedColor) {
+                    ForEach(AppSettings.SpriteColor.allCases, id: \.self) { color in
+                        Text(color.displayName).tag(color)
+                    }
+                }
+                .pickerStyle(.menu)
+                .onChange(of: selectedColor) { _, newValue in
+                    AppSettings.spriteColor = newValue
+                }
+            }
+            .padding(.horizontal, 4)
         }
     }
 

--- a/notchi/notchi/Views/SessionSpriteView.swift
+++ b/notchi/notchi/Views/SessionSpriteView.swift
@@ -11,6 +11,19 @@ struct SessionSpriteView: View {
 
     private static let sobTrembleAmplitude: CGFloat = 0.2
 
+    private var tintColor: Color {
+        switch AppSettings.spriteColor {
+        case .orange:
+            return Color(red: 0.85, green: 0.47, blue: 0.34)
+        case .purple:
+            return Color(red: 0.6, green: 0.4, blue: 0.85)
+        case .blue:
+            return Color(red: 0.3, green: 0.55, blue: 0.95)
+        case .green:
+            return Color(red: 0.4, green: 0.75, blue: 0.45)
+        }
+    }
+
     var body: some View {
         TimelineView(.animation(minimumInterval: 1.0 / 30, paused: bobAmplitude == 0 && state.emotion != .sob)) { timeline in
             SpriteSheetView(
@@ -21,6 +34,7 @@ struct SessionSpriteView: View {
                 isAnimating: true
             )
             .frame(width: 32, height: 32)
+            .colorMultiply(tintColor)
             .offset(
                 x: trembleOffset(at: timeline.date, amplitude: state.emotion == .sob ? Self.sobTrembleAmplitude : 0),
                 y: bobOffset(at: timeline.date, duration: state.bobDuration, amplitude: bobAmplitude)


### PR DESCRIPTION
## Changes

1. **Sprite Color Picker** - Add user preference for sprite color (orange, purple, blue, green) persisted in UserDefaults, with color picker in Settings UI and `.colorMultiply()` applied to sprites

2. **10% Smaller Notch** - Scale notch dimensions by 0.9 for a smaller footprint

Would be nice to use purple for Hermes integration!