### PR TITLE
Fix Codex compaction detection

### DIFF
--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -310,6 +310,18 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(signals[secondThreadId]?.totalUsageTokens, 20_000)
     }
 
+    func testCodexCompactionSignalResolverIgnoresMalformedThreadIdsFromSQLiteOutput() {
+        let separator = "\u{1F}"
+        let body = """
+        session_loop{thread_id=not-a-uuid}:turn:run_turn: post sampling token usage turn_id=turn total_usage_tokens=256300 estimated_token_count=Some(177642) auto_compact_limit=244800 token_limit_reached=true
+        """
+        let output = "not-a-uuid\(separator)1775000000\(separator)0\(separator)\(body)"
+
+        let signals = CodexCompactionSignalResolver.latestSignals(fromSQLiteOutput: output)
+
+        XCTAssertTrue(signals.isEmpty)
+    }
+
     func testRefreshCodexCompactionSignalsMarksCurrentProcessingCodexSessionCompacting() {
         let store = SessionStore.shared
         let sessionId = "codex-compact-\(UUID().uuidString)"

--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -254,14 +254,15 @@ final class SessionStoreTests: XCTestCase {
 
     func testCodexCompactionSignalResolverParsesLatestTokenLimitLogRow() {
         let separator = "\u{1F}"
+        let threadId = "11111111-1111-1111-1111-111111111111"
         let timestamp: TimeInterval = 1_775_000_000
         let nanoseconds = 250_000_000
         let body = """
         session_loop{thread_id=thread}:turn:run_turn: post sampling token usage turn_id=turn total_usage_tokens=256300 estimated_token_count=Some(177642) auto_compact_limit=244800 token_limit_reached=true model_needs_follow_up=true has_pending_input=false needs_follow_up=true
         """
-        let output = "\(Int(timestamp))\(separator)\(nanoseconds)\(separator)\(body)"
+        let output = "\(threadId)\(separator)\(Int(timestamp))\(separator)\(nanoseconds)\(separator)\(body)"
 
-        let signal = CodexCompactionSignalResolver.latestSignal(fromSQLiteOutput: output)
+        let signal = CodexCompactionSignalResolver.latestSignals(fromSQLiteOutput: output)[threadId]
 
         XCTAssertEqual(signal?.observedAt, Date(timeIntervalSince1970: timestamp + 0.25))
         XCTAssertEqual(signal?.totalUsageTokens, 256300)
@@ -270,23 +271,49 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(signal?.tokenLimitReached, true)
     }
 
+    func testCodexCompactionSignalResolverDoesNotMatchPrefixedFields() {
+        let separator = "\u{1F}"
+        let threadId = "11111111-1111-1111-1111-111111111111"
+        let timestamp: TimeInterval = 1_775_000_000
+        let body = """
+        session_loop{thread_id=thread}:turn:run_turn: post sampling token usage turn_id=turn prefix_total_usage_tokens=1 total_usage_tokens=256300 prefix_auto_compact_limit=2 auto_compact_limit=244800 prefix_token_limit_reached=false token_limit_reached=true
+        """
+        let output = "\(threadId)\(separator)\(Int(timestamp))\(separator)0\(separator)\(body)"
+
+        let signal = CodexCompactionSignalResolver.latestSignals(fromSQLiteOutput: output)[threadId]
+
+        XCTAssertEqual(signal?.totalUsageTokens, 256_300)
+        XCTAssertEqual(signal?.autoCompactLimit, 244_800)
+        XCTAssertEqual(signal?.tokenLimitReached, true)
+    }
+
+    func testCodexCompactionSignalResolverParsesBatchedThreadRows() {
+        let separator = "\u{1F}"
+        let firstThreadId = "11111111-1111-1111-1111-111111111111"
+        let secondThreadId = "22222222-2222-2222-2222-222222222222"
+        let firstBody = """
+        session_loop{thread_id=\(firstThreadId)}:turn:run_turn: post sampling token usage turn_id=turn total_usage_tokens=256300 estimated_token_count=Some(177642) auto_compact_limit=244800 token_limit_reached=true
+        """
+        let secondBody = """
+        session_loop{thread_id=\(secondThreadId)}:turn:run_turn: post sampling token usage turn_id=turn total_usage_tokens=20000 estimated_token_count=Some(18000) auto_compact_limit=244800 token_limit_reached=false
+        """
+        let output = [
+            "\(firstThreadId)\(separator)1775000000\(separator)250000000\(separator)\(firstBody)",
+            "\(secondThreadId)\(separator)1775000001\(separator)0\(separator)\(secondBody)",
+        ].joined(separator: "\n")
+
+        let signals = CodexCompactionSignalResolver.latestSignals(fromSQLiteOutput: output)
+
+        XCTAssertEqual(signals[firstThreadId]?.tokenLimitReached, true)
+        XCTAssertEqual(signals[firstThreadId]?.totalUsageTokens, 256_300)
+        XCTAssertEqual(signals[secondThreadId]?.tokenLimitReached, false)
+        XCTAssertEqual(signals[secondThreadId]?.totalUsageTokens, 20_000)
+    }
+
     func testRefreshCodexCompactionSignalsMarksCurrentProcessingCodexSessionCompacting() {
         let store = SessionStore.shared
         let sessionId = "codex-compact-\(UUID().uuidString)"
         let transcriptPath = "/tmp/compact-rollout.jsonl"
-        let observedAt = Date(timeIntervalSinceNow: 1)
-        store.setCodexCompactionSignalResolverForTesting { threadId in
-            threadId == sessionId
-                ? CodexCompactionSignal(
-                    observedAt: observedAt,
-                    totalUsageTokens: 256_300,
-                    estimatedTokenCount: 177_642,
-                    autoCompactLimit: 244_800,
-                    tokenLimitReached: true
-                )
-                : nil
-        }
-
         let session = store.process(makeEvent(
             sessionId: sessionId,
             provider: .codex,
@@ -296,6 +323,19 @@ final class SessionStoreTests: XCTestCase {
             status: "processing",
             userPrompt: "hello"
         ))
+        let observedAt = Date()
+        store.setCodexCompactionSignalResolverForTesting { threadIds in
+            guard threadIds.contains(sessionId) else { return [:] }
+            return [
+                sessionId: CodexCompactionSignal(
+                    observedAt: observedAt,
+                    totalUsageTokens: 256_300,
+                    estimatedTokenCount: 177_642,
+                    autoCompactLimit: 244_800,
+                    tokenLimitReached: true
+                )
+            ]
+        }
 
         store.refreshCodexCompactionSignalsForTesting()
 
@@ -303,20 +343,62 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(session.task, .compacting)
     }
 
+    func testActiveCodexCompactionSignalPreventsWorkingEventFlicker() {
+        let store = SessionStore.shared
+        let sessionId = "codex-compact-no-flicker-\(UUID().uuidString)"
+        let transcriptPath = "/tmp/compact-no-flicker-rollout.jsonl"
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            provider: .codex,
+            cwd: "/tmp/notchi",
+            transcriptPath: transcriptPath,
+            event: .userPromptSubmitted,
+            status: "processing",
+            userPrompt: "hello"
+        ))
+        let compactingSignal = CodexCompactionSignal(
+            observedAt: Date(),
+            totalUsageTokens: 256_300,
+            estimatedTokenCount: 177_642,
+            autoCompactLimit: 244_800,
+            tokenLimitReached: true
+        )
+        store.setCodexCompactionSignalResolverForTesting { threadIds in
+            threadIds.contains(sessionId) ? [sessionId: compactingSignal] : [:]
+        }
+
+        store.refreshCodexCompactionSignalsForTesting()
+        XCTAssertEqual(session.task, .compacting)
+
+        _ = store.process(makeEvent(
+            sessionId: sessionId,
+            provider: .codex,
+            cwd: "/tmp/notchi",
+            transcriptPath: transcriptPath,
+            event: .postToolUse,
+            status: "processing",
+            tool: "Bash",
+            toolUseId: "tool-1"
+        ))
+
+        XCTAssertEqual(session.task, .compacting)
+    }
+
     func testStaleCodexCompactionSignalDoesNotOverrideNewPrompt() {
         let store = SessionStore.shared
         let sessionId = "codex-stale-compact-\(UUID().uuidString)"
         let transcriptPath = "/tmp/stale-compact-rollout.jsonl"
-        store.setCodexCompactionSignalResolverForTesting { threadId in
-            threadId == sessionId
-                ? CodexCompactionSignal(
+        store.setCodexCompactionSignalResolverForTesting { threadIds in
+            guard threadIds.contains(sessionId) else { return [:] }
+            return [
+                sessionId: CodexCompactionSignal(
                     observedAt: Date(timeIntervalSince1970: 1),
                     totalUsageTokens: 256_300,
                     estimatedTokenCount: nil,
                     autoCompactLimit: 244_800,
                     tokenLimitReached: true
                 )
-                : nil
+            ]
         }
 
         let session = store.process(makeEvent(
@@ -331,6 +413,7 @@ final class SessionStoreTests: XCTestCase {
 
         store.refreshCodexCompactionSignalsForTesting()
 
+        XCTAssertNil(session.codexCompactionSignal)
         XCTAssertEqual(session.task, .working)
     }
 
@@ -338,17 +421,6 @@ final class SessionStoreTests: XCTestCase {
         let store = SessionStore.shared
         let sessionId = "codex-compact-clears-\(UUID().uuidString)"
         let transcriptPath = "/tmp/compact-clears-rollout.jsonl"
-        let compactingSignal = CodexCompactionSignal(
-            observedAt: Date(timeIntervalSinceNow: 1),
-            totalUsageTokens: 256_300,
-            estimatedTokenCount: 177_642,
-            autoCompactLimit: 244_800,
-            tokenLimitReached: true
-        )
-        store.setCodexCompactionSignalResolverForTesting { threadId in
-            threadId == sessionId ? compactingSignal : nil
-        }
-
         let session = store.process(makeEvent(
             sessionId: sessionId,
             provider: .codex,
@@ -358,19 +430,29 @@ final class SessionStoreTests: XCTestCase {
             status: "processing",
             userPrompt: "hello"
         ))
+        let compactingSignal = CodexCompactionSignal(
+            observedAt: Date(),
+            totalUsageTokens: 256_300,
+            estimatedTokenCount: 177_642,
+            autoCompactLimit: 244_800,
+            tokenLimitReached: true
+        )
+        store.setCodexCompactionSignalResolverForTesting { threadIds in
+            threadIds.contains(sessionId) ? [sessionId: compactingSignal] : [:]
+        }
 
         store.refreshCodexCompactionSignalsForTesting()
         XCTAssertEqual(session.task, .compacting)
 
         let workingSignal = CodexCompactionSignal(
-            observedAt: Date(timeIntervalSinceNow: 2),
+            observedAt: Date(),
             totalUsageTokens: 20_000,
             estimatedTokenCount: 18_000,
             autoCompactLimit: 244_800,
             tokenLimitReached: false
         )
-        store.setCodexCompactionSignalResolverForTesting { threadId in
-            threadId == sessionId ? workingSignal : nil
+        store.setCodexCompactionSignalResolverForTesting { threadIds in
+            threadIds.contains(sessionId) ? [sessionId: workingSignal] : [:]
         }
 
         store.refreshCodexCompactionSignalsForTesting()

--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -252,6 +252,132 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(metadata, CodexThreadMetadata(title: "Archived", archived: true))
     }
 
+    func testCodexCompactionSignalResolverParsesLatestTokenLimitLogRow() {
+        let separator = "\u{1F}"
+        let timestamp: TimeInterval = 1_775_000_000
+        let nanoseconds = 250_000_000
+        let body = """
+        session_loop{thread_id=thread}:turn:run_turn: post sampling token usage turn_id=turn total_usage_tokens=256300 estimated_token_count=Some(177642) auto_compact_limit=244800 token_limit_reached=true model_needs_follow_up=true has_pending_input=false needs_follow_up=true
+        """
+        let output = "\(Int(timestamp))\(separator)\(nanoseconds)\(separator)\(body)"
+
+        let signal = CodexCompactionSignalResolver.latestSignal(fromSQLiteOutput: output)
+
+        XCTAssertEqual(signal?.observedAt, Date(timeIntervalSince1970: timestamp + 0.25))
+        XCTAssertEqual(signal?.totalUsageTokens, 256300)
+        XCTAssertEqual(signal?.estimatedTokenCount, 177642)
+        XCTAssertEqual(signal?.autoCompactLimit, 244800)
+        XCTAssertEqual(signal?.tokenLimitReached, true)
+    }
+
+    func testRefreshCodexCompactionSignalsMarksCurrentProcessingCodexSessionCompacting() {
+        let store = SessionStore.shared
+        let sessionId = "codex-compact-\(UUID().uuidString)"
+        let transcriptPath = "/tmp/compact-rollout.jsonl"
+        let observedAt = Date(timeIntervalSinceNow: 1)
+        store.setCodexCompactionSignalResolverForTesting { threadId in
+            threadId == sessionId
+                ? CodexCompactionSignal(
+                    observedAt: observedAt,
+                    totalUsageTokens: 256_300,
+                    estimatedTokenCount: 177_642,
+                    autoCompactLimit: 244_800,
+                    tokenLimitReached: true
+                )
+                : nil
+        }
+
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            provider: .codex,
+            cwd: "/tmp/notchi",
+            transcriptPath: transcriptPath,
+            event: .userPromptSubmitted,
+            status: "processing",
+            userPrompt: "hello"
+        ))
+
+        store.refreshCodexCompactionSignalsForTesting()
+
+        XCTAssertEqual(session.codexCompactionSignal?.totalUsageTokens, 256_300)
+        XCTAssertEqual(session.task, .compacting)
+    }
+
+    func testStaleCodexCompactionSignalDoesNotOverrideNewPrompt() {
+        let store = SessionStore.shared
+        let sessionId = "codex-stale-compact-\(UUID().uuidString)"
+        let transcriptPath = "/tmp/stale-compact-rollout.jsonl"
+        store.setCodexCompactionSignalResolverForTesting { threadId in
+            threadId == sessionId
+                ? CodexCompactionSignal(
+                    observedAt: Date(timeIntervalSince1970: 1),
+                    totalUsageTokens: 256_300,
+                    estimatedTokenCount: nil,
+                    autoCompactLimit: 244_800,
+                    tokenLimitReached: true
+                )
+                : nil
+        }
+
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            provider: .codex,
+            cwd: "/tmp/notchi",
+            transcriptPath: transcriptPath,
+            event: .userPromptSubmitted,
+            status: "processing",
+            userPrompt: "new prompt"
+        ))
+
+        store.refreshCodexCompactionSignalsForTesting()
+
+        XCTAssertEqual(session.task, .working)
+    }
+
+    func testNewerNonLimitCodexCompactionSignalReturnsCompactingSessionToWorking() {
+        let store = SessionStore.shared
+        let sessionId = "codex-compact-clears-\(UUID().uuidString)"
+        let transcriptPath = "/tmp/compact-clears-rollout.jsonl"
+        let compactingSignal = CodexCompactionSignal(
+            observedAt: Date(timeIntervalSinceNow: 1),
+            totalUsageTokens: 256_300,
+            estimatedTokenCount: 177_642,
+            autoCompactLimit: 244_800,
+            tokenLimitReached: true
+        )
+        store.setCodexCompactionSignalResolverForTesting { threadId in
+            threadId == sessionId ? compactingSignal : nil
+        }
+
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            provider: .codex,
+            cwd: "/tmp/notchi",
+            transcriptPath: transcriptPath,
+            event: .userPromptSubmitted,
+            status: "processing",
+            userPrompt: "hello"
+        ))
+
+        store.refreshCodexCompactionSignalsForTesting()
+        XCTAssertEqual(session.task, .compacting)
+
+        let workingSignal = CodexCompactionSignal(
+            observedAt: Date(timeIntervalSinceNow: 2),
+            totalUsageTokens: 20_000,
+            estimatedTokenCount: 18_000,
+            autoCompactLimit: 244_800,
+            tokenLimitReached: false
+        )
+        store.setCodexCompactionSignalResolverForTesting { threadId in
+            threadId == sessionId ? workingSignal : nil
+        }
+
+        store.refreshCodexCompactionSignalsForTesting()
+
+        XCTAssertEqual(session.task, .working)
+    }
+
     private func makeEvent(
         sessionId: String,
         provider: AgentProvider = .claude,

--- a/notchi/notchi/Models/SessionData.swift
+++ b/notchi/notchi/Models/SessionData.swift
@@ -179,8 +179,28 @@ final class SessionData: Identifiable {
     }
 
     func updateTask(_ newTask: NotchiTask) {
+        if newTask == .working, task == .compacting, hasActiveCodexCompactionSignal {
+            lastActivity = Date()
+            return
+        }
+
         task = newTask
         lastActivity = Date()
+    }
+
+    private var hasActiveCodexCompactionSignal: Bool {
+        guard provider == .codex,
+              isProcessing,
+              let signal = codexCompactionSignal,
+              signal.tokenLimitReached else {
+            return false
+        }
+
+        if let promptSubmitTime, signal.observedAt < promptSubmitTime {
+            return false
+        }
+
+        return true
     }
 
     func updateProcessingState(isProcessing: Bool) {
@@ -198,6 +218,9 @@ final class SessionData: Identifiable {
         }
         lastUserPromptHasAttachments = hasAttachments
         promptSubmitTime = now
+        if provider == .codex {
+            codexCompactionSignal = nil
+        }
         lastActivity = now
         logger.debug("Setting promptSubmitTime to: \(now)")
     }
@@ -246,16 +269,20 @@ final class SessionData: Identifiable {
     func updateCodexCompactionSignal(_ signal: CodexCompactionSignal?) {
         guard provider == .codex else { return }
 
-        codexCompactionSignal = signal
-
-        guard let signal,
-              isProcessing else {
+        guard let signal else {
+            codexCompactionSignal = nil
             return
         }
 
+        // WHY: the latest sqlite row can belong to the previous turn until Codex
+        // writes this turn's usage row, so don't let it re-enter compacting.
         if let promptSubmitTime, signal.observedAt < promptSubmitTime {
             return
         }
+
+        codexCompactionSignal = signal
+
+        guard isProcessing else { return }
 
         if signal.tokenLimitReached {
             updateTask(.compacting)

--- a/notchi/notchi/Models/SessionData.swift
+++ b/notchi/notchi/Models/SessionData.swift
@@ -42,6 +42,7 @@ final class SessionData: Identifiable {
     private(set) var codexTitle: String?
     private(set) var codexTranscriptPath: String?
     private(set) var codexArchived: Bool = false
+    private(set) var codexCompactionSignal: CodexCompactionSignal?
 
     private var durationTimer: Task<Void, Never>?
     private var sleepTimer: Task<Void, Never>?
@@ -240,6 +241,27 @@ final class SessionData: Identifiable {
         guard let metadata else { return }
         updateCodexTitle(metadata.title)
         codexArchived = metadata.archived
+    }
+
+    func updateCodexCompactionSignal(_ signal: CodexCompactionSignal?) {
+        guard provider == .codex else { return }
+
+        codexCompactionSignal = signal
+
+        guard let signal,
+              isProcessing else {
+            return
+        }
+
+        if let promptSubmitTime, signal.observedAt < promptSubmitTime {
+            return
+        }
+
+        if signal.tokenLimitReached {
+            updateTask(.compacting)
+        } else if task == .compacting {
+            updateTask(.working)
+        }
     }
 
     func setPendingQuestions(_ questions: [PendingQuestion]) {

--- a/notchi/notchi/Services/NotchiStateMachine.swift
+++ b/notchi/notchi/Services/NotchiStateMachine.swift
@@ -18,6 +18,7 @@ final class NotchiStateMachine {
     private var codexProcessMonitorTask: Task<Void, Never>?
     private var codexThreadMetadataMonitorTask: Task<Void, Never>?
     private var codexThreadMetadataRefreshTask: Task<Void, Never>?
+    private var codexCompactionSignalRefreshTask: Task<Void, Never>?
     private var codexThreadMetadataImmediateRefreshKeys: Set<ProviderSessionKey> = []
     private var codexThreadMetadataAutoRefreshEnabled = true
     private var codexProcessMissCounts: [ProviderSessionKey: Int] = [:]
@@ -34,6 +35,8 @@ final class NotchiStateMachine {
     private static let waitingClearGuard: TimeInterval = 2.0
     private static let codexProcessMonitorInterval: Duration = .seconds(2)
     private static let codexThreadMetadataMonitorInterval: Duration = .seconds(5)
+    private static let codexCompactionSignalRefreshDebounce: Duration = .milliseconds(150)
+    private static let codexCompactionSignalFollowUpInterval: Duration = .seconds(1)
     private static let codexProcessMissLimit = 2
     private static let pendingCodexSessionStartMaxAge: TimeInterval = 10 * 60
 
@@ -376,7 +379,11 @@ final class NotchiStateMachine {
         )
 
         source.setEventHandler { [weak self] in
-            self?.scheduleFileSync(sessionKey: sessionKey, transcriptPath: transcriptPath)
+            guard let self else { return }
+            self.scheduleFileSync(sessionKey: sessionKey, transcriptPath: transcriptPath)
+            if sessionKey.provider == .codex {
+                self.scheduleCodexCompactionSignalRefresh()
+            }
         }
 
         source.setCancelHandler {
@@ -442,6 +449,8 @@ final class NotchiStateMachine {
             codexThreadMetadataMonitorTask = nil
             codexThreadMetadataRefreshTask?.cancel()
             codexThreadMetadataRefreshTask = nil
+            codexCompactionSignalRefreshTask?.cancel()
+            codexCompactionSignalRefreshTask = nil
             codexThreadMetadataImmediateRefreshKeys.removeAll()
             clearCodexUsage()
         }
@@ -473,15 +482,68 @@ final class NotchiStateMachine {
             guard let self else { return }
             defer { self.codexThreadMetadataRefreshTask = nil }
 
+            let compactionRequests = self.sessionStore.codexCompactionSignalRequests()
             async let metadataUpdates = self.sessionStore.resolveCodexThreadMetadata(requests)
+            async let compactionUpdates = self.sessionStore.resolveCodexCompactionSignals(compactionRequests)
             async let usageRefresh: Void = CodexUsageService.shared.refresh(transcriptPaths: transcriptPaths)
             let updates = await metadataUpdates
+            let signals = await compactionUpdates
             _ = await usageRefresh
             guard !Task.isCancelled else { return }
 
             let archivedSessions = self.sessionStore.applyCodexThreadMetadata(updates)
+            self.sessionStore.applyCodexCompactionSignals(signals)
             self.endCodexArchivedSessions(archivedSessions)
             self.refreshCodexThreadMetadataMonitoring()
+            if self.hasActiveCodexCompaction {
+                self.scheduleCodexCompactionSignalRefresh(after: Self.codexCompactionSignalFollowUpInterval)
+            }
+        }
+    }
+
+    private var hasActiveCodexCompaction: Bool {
+        sessionStore.sessions.values.contains { session in
+            session.provider == .codex &&
+                session.isProcessing &&
+                session.task == .compacting
+        }
+    }
+
+    private func scheduleCodexCompactionSignalRefresh() {
+        scheduleCodexCompactionSignalRefresh(after: Self.codexCompactionSignalRefreshDebounce)
+    }
+
+    private func scheduleCodexCompactionSignalRefresh(after delay: Duration) {
+        guard codexThreadMetadataAutoRefreshEnabled else { return }
+
+        codexCompactionSignalRefreshTask?.cancel()
+        codexCompactionSignalRefreshTask = Task { [weak self] in
+            try? await Task.sleep(for: delay)
+            guard let self, !Task.isCancelled else { return }
+            await self.refreshCodexCompactionSignals()
+        }
+    }
+
+    private func refreshCodexCompactionSignals() async {
+        let requests = sessionStore.codexCompactionSignalRequests()
+        guard !requests.isEmpty else {
+            codexCompactionSignalRefreshTask = nil
+            refreshCodexThreadMetadataMonitoring()
+            return
+        }
+
+        let signals = await sessionStore.resolveCodexCompactionSignals(requests)
+        guard !Task.isCancelled else {
+            codexCompactionSignalRefreshTask = nil
+            return
+        }
+
+        sessionStore.applyCodexCompactionSignals(signals)
+        codexCompactionSignalRefreshTask = nil
+        refreshCodexThreadMetadataMonitoring()
+
+        if hasActiveCodexCompaction {
+            scheduleCodexCompactionSignalRefresh(after: Self.codexCompactionSignalFollowUpInterval)
         }
     }
 
@@ -507,6 +569,8 @@ final class NotchiStateMachine {
         codexThreadMetadataMonitorTask = nil
         codexThreadMetadataRefreshTask?.cancel()
         codexThreadMetadataRefreshTask = nil
+        codexCompactionSignalRefreshTask?.cancel()
+        codexCompactionSignalRefreshTask = nil
         codexThreadMetadataImmediateRefreshKeys.removeAll()
         codexThreadMetadataAutoRefreshEnabled = true
         codexProcessMissCounts.removeAll()
@@ -520,6 +584,7 @@ final class NotchiStateMachine {
 
     func reconcileCodexThreadMetadataForTesting() {
         let archivedSessions = sessionStore.refreshCodexThreadMetadataForTesting()
+        sessionStore.refreshCodexCompactionSignalsForTesting()
         endCodexArchivedSessions(archivedSessions)
         refreshCodexThreadMetadataMonitoring()
     }

--- a/notchi/notchi/Services/NotchiStateMachine.swift
+++ b/notchi/notchi/Services/NotchiStateMachine.swift
@@ -19,6 +19,7 @@ final class NotchiStateMachine {
     private var codexThreadMetadataMonitorTask: Task<Void, Never>?
     private var codexThreadMetadataRefreshTask: Task<Void, Never>?
     private var codexCompactionSignalRefreshTask: Task<Void, Never>?
+    private var codexCompactionSignalRefreshGeneration = 0
     private var codexThreadMetadataImmediateRefreshKeys: Set<ProviderSessionKey> = []
     private var codexThreadMetadataAutoRefreshEnabled = true
     private var codexProcessMissCounts: [ProviderSessionKey: Int] = [:]
@@ -36,7 +37,6 @@ final class NotchiStateMachine {
     private static let codexProcessMonitorInterval: Duration = .seconds(2)
     private static let codexThreadMetadataMonitorInterval: Duration = .seconds(5)
     private static let codexCompactionSignalRefreshDebounce: Duration = .milliseconds(150)
-    private static let codexCompactionSignalFollowUpInterval: Duration = .seconds(1)
     private static let codexProcessMissLimit = 2
     private static let pendingCodexSessionStartMaxAge: TimeInterval = 10 * 60
 
@@ -449,8 +449,7 @@ final class NotchiStateMachine {
             codexThreadMetadataMonitorTask = nil
             codexThreadMetadataRefreshTask?.cancel()
             codexThreadMetadataRefreshTask = nil
-            codexCompactionSignalRefreshTask?.cancel()
-            codexCompactionSignalRefreshTask = nil
+            cancelCodexCompactionSignalRefresh()
             codexThreadMetadataImmediateRefreshKeys.removeAll()
             clearCodexUsage()
         }
@@ -495,17 +494,6 @@ final class NotchiStateMachine {
             self.sessionStore.applyCodexCompactionSignals(signals)
             self.endCodexArchivedSessions(archivedSessions)
             self.refreshCodexThreadMetadataMonitoring()
-            if self.hasActiveCodexCompaction {
-                self.scheduleCodexCompactionSignalRefresh(after: Self.codexCompactionSignalFollowUpInterval)
-            }
-        }
-    }
-
-    private var hasActiveCodexCompaction: Bool {
-        sessionStore.sessions.values.contains { session in
-            session.provider == .codex &&
-                session.isProcessing &&
-                session.task == .compacting
         }
     }
 
@@ -516,35 +504,47 @@ final class NotchiStateMachine {
     private func scheduleCodexCompactionSignalRefresh(after delay: Duration) {
         guard codexThreadMetadataAutoRefreshEnabled else { return }
 
+        codexCompactionSignalRefreshGeneration += 1
+        let generation = codexCompactionSignalRefreshGeneration
         codexCompactionSignalRefreshTask?.cancel()
         codexCompactionSignalRefreshTask = Task { [weak self] in
             try? await Task.sleep(for: delay)
             guard let self, !Task.isCancelled else { return }
-            await self.refreshCodexCompactionSignals()
+            await self.refreshCodexCompactionSignals(generation: generation)
         }
     }
 
-    private func refreshCodexCompactionSignals() async {
+    private func refreshCodexCompactionSignals(generation: Int) async {
         let requests = sessionStore.codexCompactionSignalRequests()
         guard !requests.isEmpty else {
-            codexCompactionSignalRefreshTask = nil
+            clearCodexCompactionSignalRefreshTask(generation: generation)
             refreshCodexThreadMetadataMonitoring()
             return
         }
 
         let signals = await sessionStore.resolveCodexCompactionSignals(requests)
         guard !Task.isCancelled else {
-            codexCompactionSignalRefreshTask = nil
+            clearCodexCompactionSignalRefreshTask(generation: generation)
             return
         }
 
         sessionStore.applyCodexCompactionSignals(signals)
-        codexCompactionSignalRefreshTask = nil
+        clearCodexCompactionSignalRefreshTask(generation: generation)
         refreshCodexThreadMetadataMonitoring()
+    }
 
-        if hasActiveCodexCompaction {
-            scheduleCodexCompactionSignalRefresh(after: Self.codexCompactionSignalFollowUpInterval)
+    private func clearCodexCompactionSignalRefreshTask(generation: Int) {
+        guard generation == codexCompactionSignalRefreshGeneration else {
+            return
         }
+
+        codexCompactionSignalRefreshTask = nil
+    }
+
+    private func cancelCodexCompactionSignalRefresh() {
+        codexCompactionSignalRefreshGeneration += 1
+        codexCompactionSignalRefreshTask?.cancel()
+        codexCompactionSignalRefreshTask = nil
     }
 
     private nonisolated static func defaultCodexProcessAlive(_ processId: Int) -> Bool {
@@ -569,8 +569,7 @@ final class NotchiStateMachine {
         codexThreadMetadataMonitorTask = nil
         codexThreadMetadataRefreshTask?.cancel()
         codexThreadMetadataRefreshTask = nil
-        codexCompactionSignalRefreshTask?.cancel()
-        codexCompactionSignalRefreshTask = nil
+        cancelCodexCompactionSignalRefresh()
         codexThreadMetadataImmediateRefreshKeys.removeAll()
         codexThreadMetadataAutoRefreshEnabled = true
         codexProcessMissCounts.removeAll()

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -18,8 +18,8 @@ final class SessionStore {
     private var resolveCodexMetadata: @Sendable (String) -> CodexThreadMetadata? = { transcriptPath in
         CodexThreadMetadataResolver.metadata(for: transcriptPath)
     }
-    private var resolveCodexCompactionSignal: @Sendable (String) -> CodexCompactionSignal? = { threadId in
-        CodexCompactionSignalResolver.latestSignal(threadId: threadId)
+    private var resolveCodexCompactionSignals: @Sendable ([String]) -> [String: CodexCompactionSignal] = { threadIds in
+        CodexCompactionSignalResolver.latestSignals(threadIds: threadIds)
     }
 
     private init() {}
@@ -261,12 +261,13 @@ final class SessionStore {
     }
 
     func resolveCodexCompactionSignals(_ requests: [CodexCompactionSignalRequest]) async -> [CodexCompactionSignalUpdate] {
-        let resolver = resolveCodexCompactionSignal
+        let resolver = resolveCodexCompactionSignals
         return await Task.detached(priority: .utility) {
-            requests.map { request in
+            let signalsByThreadId = resolver(Array(Set(requests.map(\.threadId))))
+            return requests.map { request in
                 CodexCompactionSignalUpdate(
                     sessionKey: request.sessionKey,
-                    signal: resolver(request.threadId)
+                    signal: signalsByThreadId[request.threadId]
                 )
             }
         }.value
@@ -322,10 +323,12 @@ final class SessionStore {
     }
 
     func refreshCodexCompactionSignalsForTesting() {
-        let updates = codexCompactionSignalRequests().map { request in
+        let requests = codexCompactionSignalRequests()
+        let signalsByThreadId = resolveCodexCompactionSignals(Array(Set(requests.map(\.threadId))))
+        let updates = requests.map { request in
             CodexCompactionSignalUpdate(
                 sessionKey: request.sessionKey,
-                signal: resolveCodexCompactionSignal(request.threadId)
+                signal: signalsByThreadId[request.threadId]
             )
         }
         applyCodexCompactionSignals(updates)
@@ -335,16 +338,16 @@ final class SessionStore {
         resolveCodexMetadata = resolver
     }
 
-    func setCodexCompactionSignalResolverForTesting(_ resolver: @escaping @Sendable (String) -> CodexCompactionSignal?) {
-        resolveCodexCompactionSignal = resolver
+    func setCodexCompactionSignalResolverForTesting(_ resolver: @escaping @Sendable ([String]) -> [String: CodexCompactionSignal]) {
+        resolveCodexCompactionSignals = resolver
     }
 
     func resetTestingHooks() {
         resolveCodexMetadata = { transcriptPath in
             CodexThreadMetadataResolver.metadata(for: transcriptPath)
         }
-        resolveCodexCompactionSignal = { threadId in
-            CodexCompactionSignalResolver.latestSignal(threadId: threadId)
+        resolveCodexCompactionSignals = { threadIds in
+            CodexCompactionSignalResolver.latestSignals(threadIds: threadIds)
         }
     }
 #endif
@@ -458,13 +461,15 @@ nonisolated struct CodexCompactionSignalUpdate: Sendable, Equatable {
     let signal: CodexCompactionSignal?
 }
 
-nonisolated enum CodexThreadMetadataResolver {
+nonisolated enum CodexFileSystem {
+    static let sqliteSeparator = "\u{1F}"
+
     private static var codexDirectoryURL: URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".codex", isDirectory: true)
     }
 
-    private static var stateURL: URL? {
+    static func latestSQLiteURL(prefix: String) -> URL? {
         guard let entries = try? FileManager.default.contentsOfDirectory(
             at: codexDirectoryURL,
             includingPropertiesForKeys: nil
@@ -474,9 +479,9 @@ nonisolated enum CodexThreadMetadataResolver {
 
         return entries.compactMap { url -> (version: Int, url: URL)? in
             let name = url.deletingPathExtension().lastPathComponent
-            guard name.hasPrefix("state_"),
+            guard name.hasPrefix(prefix),
                   url.pathExtension == "sqlite",
-                  let version = Int(name.dropFirst("state_".count)) else {
+                  let version = Int(name.dropFirst(prefix.count)) else {
                 return nil
             }
             return (version, url)
@@ -485,51 +490,10 @@ nonisolated enum CodexThreadMetadataResolver {
         .url
     }
 
-    static func metadata(for transcriptPath: String) -> CodexThreadMetadata? {
-        let trimmedPath = transcriptPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedPath.isEmpty,
-              let stateURL,
-              FileManager.default.fileExists(atPath: stateURL.path) else {
-            return nil
-        }
-
-        let query = "SELECT id, rollout_path, hex(title), archived FROM threads;"
-        guard let output = runSQLite(query: query, databasePath: stateURL.path) else {
-            return nil
-        }
-
-        return metadata(fromSQLiteOutput: output, matchingTranscriptPath: trimmedPath)
-    }
-
-    static func metadata(fromSQLiteOutput output: String, matchingTranscriptPath transcriptPath: String) -> CodexThreadMetadata? {
-        let threadId = codexThreadId(from: transcriptPath)
-
-        for row in output.split(separator: "\n", omittingEmptySubsequences: false) {
-            let parts = row.split(separator: "\u{1F}", omittingEmptySubsequences: false)
-            guard parts.count >= 4 else { continue }
-
-            let rowId = String(parts[0])
-            let rolloutPath = String(parts[1])
-            let matchesThreadId = threadId.map { $0 == rowId } ?? false
-            guard rolloutPath == transcriptPath || matchesThreadId else { continue }
-
-            let title = decodeHexString(String(parts[2]))?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            let archived = String(parts[3]).trimmingCharacters(in: .whitespacesAndNewlines) != "0"
-
-            return CodexThreadMetadata(
-                title: title?.isEmpty == false ? title : nil,
-                archived: archived
-            )
-        }
-
-        return nil
-    }
-
-    private static func runSQLite(query: String, databasePath: String) -> String? {
+    static func runSQLite(query: String, databasePath: String) -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
-        process.arguments = ["-batch", "-noheader", "-separator", "\u{1F}", databasePath, query]
+        process.arguments = ["-batch", "-noheader", "-separator", sqliteSeparator, databasePath, query]
 
         let stdoutPipe = Pipe()
         process.standardOutput = stdoutPipe
@@ -554,6 +518,53 @@ nonisolated enum CodexThreadMetadataResolver {
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         return output?.isEmpty == false ? output : nil
+    }
+}
+
+nonisolated enum CodexThreadMetadataResolver {
+    private static var stateURL: URL? {
+        CodexFileSystem.latestSQLiteURL(prefix: "state_")
+    }
+
+    static func metadata(for transcriptPath: String) -> CodexThreadMetadata? {
+        let trimmedPath = transcriptPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPath.isEmpty,
+              let stateURL,
+              FileManager.default.fileExists(atPath: stateURL.path) else {
+            return nil
+        }
+
+        let query = "SELECT id, rollout_path, hex(title), archived FROM threads;"
+        guard let output = CodexFileSystem.runSQLite(query: query, databasePath: stateURL.path) else {
+            return nil
+        }
+
+        return metadata(fromSQLiteOutput: output, matchingTranscriptPath: trimmedPath)
+    }
+
+    static func metadata(fromSQLiteOutput output: String, matchingTranscriptPath transcriptPath: String) -> CodexThreadMetadata? {
+        let threadId = codexThreadId(from: transcriptPath)
+
+        for row in output.split(separator: "\n", omittingEmptySubsequences: false) {
+            let parts = row.split(separator: Character(CodexFileSystem.sqliteSeparator), omittingEmptySubsequences: false)
+            guard parts.count >= 4 else { continue }
+
+            let rowId = String(parts[0])
+            let rolloutPath = String(parts[1])
+            let matchesThreadId = threadId.map { $0 == rowId } ?? false
+            guard rolloutPath == transcriptPath || matchesThreadId else { continue }
+
+            let title = decodeHexString(String(parts[2]))?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let archived = String(parts[3]).trimmingCharacters(in: .whitespacesAndNewlines) != "0"
+
+            return CodexThreadMetadata(
+                title: title?.isEmpty == false ? title : nil,
+                archived: archived
+            )
+        }
+
+        return nil
     }
 
     private static func codexThreadId(from transcriptPath: String) -> String? {
@@ -586,76 +597,70 @@ nonisolated enum CodexThreadMetadataResolver {
     }
 }
 
+// WHY: Codex does not currently emit a documented compaction hook, and the
+// rollout JSONL exposes token counts but not a stable "compacting" state. Until
+// there is a public event, use Codex's local token-usage log as a best-effort
+// internal signal and fail closed if its shape changes.
 nonisolated enum CodexCompactionSignalResolver {
-    private static var codexDirectoryURL: URL {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".codex", isDirectory: true)
-    }
-
     private static var logsURL: URL? {
-        guard let entries = try? FileManager.default.contentsOfDirectory(
-            at: codexDirectoryURL,
-            includingPropertiesForKeys: nil
-        ) else {
-            return nil
-        }
-
-        return entries.compactMap { url -> (version: Int, url: URL)? in
-            let name = url.deletingPathExtension().lastPathComponent
-            guard name.hasPrefix("logs_"),
-                  url.pathExtension == "sqlite",
-                  let version = Int(name.dropFirst("logs_".count)) else {
-                return nil
-            }
-            return (version, url)
-        }
-        .max { lhs, rhs in lhs.version < rhs.version }?
-        .url
+        CodexFileSystem.latestSQLiteURL(prefix: "logs_")
     }
 
-    static func latestSignal(threadId: String) -> CodexCompactionSignal? {
-        let trimmedThreadId = threadId.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedThreadId.isEmpty,
+    static func latestSignals(threadIds: [String]) -> [String: CodexCompactionSignal] {
+        let validThreadIds = Array(Set(threadIds.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }))
+            .filter { UUID(uuidString: $0) != nil }
+
+        guard !validThreadIds.isEmpty,
               let logsURL,
               FileManager.default.fileExists(atPath: logsURL.path) else {
-            return nil
+            return [:]
         }
 
-        let escapedThreadId = trimmedThreadId.replacingOccurrences(of: "'", with: "''")
+        let threadIdList = validThreadIds
+            .map { "'\($0.replacingOccurrences(of: "'", with: "''"))'" }
+            .joined(separator: ", ")
         let query = """
-        SELECT ts, ts_nanos, feedback_log_body
-        FROM logs
-        WHERE thread_id = '\(escapedThreadId)'
-          AND target = 'codex_core::session::turn'
-          AND feedback_log_body LIKE '%post sampling token usage%'
-        ORDER BY ts DESC, ts_nanos DESC, id DESC
-        LIMIT 1;
+        SELECT thread_id, ts, ts_nanos, feedback_log_body
+        FROM (
+            SELECT thread_id, ts, ts_nanos, feedback_log_body,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY thread_id
+                       ORDER BY ts DESC, ts_nanos DESC, id DESC
+                   ) AS row_number
+            FROM logs
+            WHERE thread_id IN (\(threadIdList))
+              AND target = 'codex_core::session::turn'
+              AND feedback_log_body LIKE '%post sampling token usage%'
+        )
+        WHERE row_number = 1;
         """
 
-        guard let output = runSQLite(query: query, databasePath: logsURL.path) else {
-            return nil
+        guard let output = CodexFileSystem.runSQLite(query: query, databasePath: logsURL.path) else {
+            return [:]
         }
 
-        return latestSignal(fromSQLiteOutput: output)
+        return latestSignals(fromSQLiteOutput: output)
     }
 
-    static func latestSignal(fromSQLiteOutput output: String) -> CodexCompactionSignal? {
-        guard let row = output.split(separator: "\n", omittingEmptySubsequences: true).first else {
-            return nil
+    static func latestSignals(fromSQLiteOutput output: String) -> [String: CodexCompactionSignal] {
+        var signals: [String: CodexCompactionSignal] = [:]
+
+        for row in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let parts = row.split(separator: Character(CodexFileSystem.sqliteSeparator), maxSplits: 3, omittingEmptySubsequences: false)
+            guard parts.count == 4,
+                  let seconds = TimeInterval(String(parts[1])),
+                  let nanoseconds = TimeInterval(String(parts[2])),
+                  let signal = parseLogBody(
+                    String(parts[3]),
+                    observedAt: Date(timeIntervalSince1970: seconds + (nanoseconds / 1_000_000_000))
+                  ) else {
+                continue
+            }
+
+            signals[String(parts[0])] = signal
         }
 
-        let parts = row.split(separator: "\u{1F}", maxSplits: 2, omittingEmptySubsequences: false)
-        guard parts.count == 3,
-              let seconds = TimeInterval(String(parts[0])),
-              let nanoseconds = TimeInterval(String(parts[1])),
-              let signal = parseLogBody(
-                String(parts[2]),
-                observedAt: Date(timeIntervalSince1970: seconds + (nanoseconds / 1_000_000_000))
-              ) else {
-            return nil
-        }
-
-        return signal
+        return signals
     }
 
     private static func parseLogBody(_ body: String, observedAt: Date) -> CodexCompactionSignal? {
@@ -676,7 +681,7 @@ nonisolated enum CodexCompactionSignalResolver {
 
     private static func intValue(named name: String, in text: String) -> Int? {
         guard let range = text.range(
-            of: "\(name)=([0-9]+)",
+            of: "\\b\(name)=([0-9]+)",
             options: .regularExpression
         ) else {
             return nil
@@ -688,7 +693,7 @@ nonisolated enum CodexCompactionSignalResolver {
 
     private static func optionalIntValue(named name: String, in text: String) -> Int? {
         guard let range = text.range(
-            of: "\(name)=Some\\(([0-9]+)\\)",
+            of: "\\b\(name)=Some\\(([0-9]+)\\)",
             options: .regularExpression
         ) else {
             return nil
@@ -705,7 +710,7 @@ nonisolated enum CodexCompactionSignalResolver {
 
     private static func boolValue(named name: String, in text: String) -> Bool? {
         guard let range = text.range(
-            of: "\(name)=(true|false)",
+            of: "\\b\(name)=(true|false)",
             options: .regularExpression
         ) else {
             return nil
@@ -714,31 +719,4 @@ nonisolated enum CodexCompactionSignalResolver {
         return text[range].hasSuffix("true")
     }
 
-    private static func runSQLite(query: String, databasePath: String) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
-        process.arguments = ["-batch", "-noheader", "-separator", "\u{1F}", databasePath, query]
-
-        let stdoutPipe = Pipe()
-        process.standardOutput = stdoutPipe
-        process.standardError = FileHandle.nullDevice
-
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-
-        let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-
-        guard process.terminationStatus == 0 else {
-            return nil
-        }
-
-        let output = String(data: data, encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-        return output?.isEmpty == false ? output : nil
-    }
 }

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -648,6 +648,7 @@ nonisolated enum CodexCompactionSignalResolver {
         for row in output.split(separator: "\n", omittingEmptySubsequences: true) {
             let parts = row.split(separator: Character(CodexFileSystem.sqliteSeparator), maxSplits: 3, omittingEmptySubsequences: false)
             guard parts.count == 4,
+                  UUID(uuidString: String(parts[0])) != nil,
                   let seconds = TimeInterval(String(parts[1])),
                   let nanoseconds = TimeInterval(String(parts[2])),
                   let signal = parseLogBody(
@@ -700,12 +701,8 @@ nonisolated enum CodexCompactionSignalResolver {
         }
 
         let matched = text[range]
-        guard let start = matched.firstIndex(of: "("),
-              let end = matched.firstIndex(of: ")") else {
-            return nil
-        }
-
-        return Int(matched[matched.index(after: start)..<end])
+        let prefix = "\(name)=Some("
+        return Int(matched.dropFirst(prefix.count).dropLast())
     }
 
     private static func boolValue(named name: String, in text: String) -> Bool? {

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -18,6 +18,9 @@ final class SessionStore {
     private var resolveCodexMetadata: @Sendable (String) -> CodexThreadMetadata? = { transcriptPath in
         CodexThreadMetadataResolver.metadata(for: transcriptPath)
     }
+    private var resolveCodexCompactionSignal: @Sendable (String) -> CodexCompactionSignal? = { threadId in
+        CodexCompactionSignalResolver.latestSignal(threadId: threadId)
+    }
 
     private init() {}
 
@@ -234,6 +237,16 @@ final class SessionStore {
         }
     }
 
+    func codexCompactionSignalRequests() -> [CodexCompactionSignalRequest] {
+        sessions.values.compactMap { session in
+            guard session.isCodexThreadBacked else { return nil }
+            return CodexCompactionSignalRequest(
+                sessionKey: session.sessionKey,
+                threadId: session.rawSessionId
+            )
+        }
+    }
+
     func resolveCodexThreadMetadata(_ requests: [CodexThreadMetadataRequest]) async -> [CodexThreadMetadataUpdate] {
         let resolver = resolveCodexMetadata
         return await Task.detached(priority: .utility) {
@@ -242,6 +255,18 @@ final class SessionStore {
                     sessionKey: request.sessionKey,
                     transcriptPath: request.transcriptPath,
                     metadata: resolver(request.transcriptPath)
+                )
+            }
+        }.value
+    }
+
+    func resolveCodexCompactionSignals(_ requests: [CodexCompactionSignalRequest]) async -> [CodexCompactionSignalUpdate] {
+        let resolver = resolveCodexCompactionSignal
+        return await Task.detached(priority: .utility) {
+            requests.map { request in
+                CodexCompactionSignalUpdate(
+                    sessionKey: request.sessionKey,
+                    signal: resolver(request.threadId)
                 )
             }
         }.value
@@ -269,6 +294,12 @@ final class SessionStore {
         return archivedSessions
     }
 
+    func applyCodexCompactionSignals(_ updates: [CodexCompactionSignalUpdate]) {
+        for update in updates {
+            sessions[update.sessionKey]?.updateCodexCompactionSignal(update.signal)
+        }
+    }
+
     func recordAssistantMessages(_ messages: [AssistantMessage], for sessionKey: ProviderSessionKey) {
         guard let session = sessions[sessionKey] else { return }
         session.recordAssistantMessages(messages)
@@ -290,13 +321,30 @@ final class SessionStore {
         return applyCodexThreadMetadata(updates)
     }
 
+    func refreshCodexCompactionSignalsForTesting() {
+        let updates = codexCompactionSignalRequests().map { request in
+            CodexCompactionSignalUpdate(
+                sessionKey: request.sessionKey,
+                signal: resolveCodexCompactionSignal(request.threadId)
+            )
+        }
+        applyCodexCompactionSignals(updates)
+    }
+
     func setCodexMetadataResolverForTesting(_ resolver: @escaping @Sendable (String) -> CodexThreadMetadata?) {
         resolveCodexMetadata = resolver
+    }
+
+    func setCodexCompactionSignalResolverForTesting(_ resolver: @escaping @Sendable (String) -> CodexCompactionSignal?) {
+        resolveCodexCompactionSignal = resolver
     }
 
     func resetTestingHooks() {
         resolveCodexMetadata = { transcriptPath in
             CodexThreadMetadataResolver.metadata(for: transcriptPath)
+        }
+        resolveCodexCompactionSignal = { threadId in
+            CodexCompactionSignalResolver.latestSignal(threadId: threadId)
         }
     }
 #endif
@@ -390,6 +438,24 @@ nonisolated struct CodexThreadMetadataUpdate: Sendable, Equatable {
     let sessionKey: ProviderSessionKey
     let transcriptPath: String
     let metadata: CodexThreadMetadata?
+}
+
+nonisolated struct CodexCompactionSignal: Sendable, Equatable {
+    let observedAt: Date
+    let totalUsageTokens: Int
+    let estimatedTokenCount: Int?
+    let autoCompactLimit: Int
+    let tokenLimitReached: Bool
+}
+
+nonisolated struct CodexCompactionSignalRequest: Sendable, Equatable {
+    let sessionKey: ProviderSessionKey
+    let threadId: String
+}
+
+nonisolated struct CodexCompactionSignalUpdate: Sendable, Equatable {
+    let sessionKey: ProviderSessionKey
+    let signal: CodexCompactionSignal?
 }
 
 nonisolated enum CodexThreadMetadataResolver {
@@ -517,5 +583,162 @@ nonisolated enum CodexThreadMetadataResolver {
         }
 
         return String(bytes: bytes, encoding: .utf8)
+    }
+}
+
+nonisolated enum CodexCompactionSignalResolver {
+    private static var codexDirectoryURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex", isDirectory: true)
+    }
+
+    private static var logsURL: URL? {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: codexDirectoryURL,
+            includingPropertiesForKeys: nil
+        ) else {
+            return nil
+        }
+
+        return entries.compactMap { url -> (version: Int, url: URL)? in
+            let name = url.deletingPathExtension().lastPathComponent
+            guard name.hasPrefix("logs_"),
+                  url.pathExtension == "sqlite",
+                  let version = Int(name.dropFirst("logs_".count)) else {
+                return nil
+            }
+            return (version, url)
+        }
+        .max { lhs, rhs in lhs.version < rhs.version }?
+        .url
+    }
+
+    static func latestSignal(threadId: String) -> CodexCompactionSignal? {
+        let trimmedThreadId = threadId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedThreadId.isEmpty,
+              let logsURL,
+              FileManager.default.fileExists(atPath: logsURL.path) else {
+            return nil
+        }
+
+        let escapedThreadId = trimmedThreadId.replacingOccurrences(of: "'", with: "''")
+        let query = """
+        SELECT ts, ts_nanos, feedback_log_body
+        FROM logs
+        WHERE thread_id = '\(escapedThreadId)'
+          AND target = 'codex_core::session::turn'
+          AND feedback_log_body LIKE '%post sampling token usage%'
+        ORDER BY ts DESC, ts_nanos DESC, id DESC
+        LIMIT 1;
+        """
+
+        guard let output = runSQLite(query: query, databasePath: logsURL.path) else {
+            return nil
+        }
+
+        return latestSignal(fromSQLiteOutput: output)
+    }
+
+    static func latestSignal(fromSQLiteOutput output: String) -> CodexCompactionSignal? {
+        guard let row = output.split(separator: "\n", omittingEmptySubsequences: true).first else {
+            return nil
+        }
+
+        let parts = row.split(separator: "\u{1F}", maxSplits: 2, omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              let seconds = TimeInterval(String(parts[0])),
+              let nanoseconds = TimeInterval(String(parts[1])),
+              let signal = parseLogBody(
+                String(parts[2]),
+                observedAt: Date(timeIntervalSince1970: seconds + (nanoseconds / 1_000_000_000))
+              ) else {
+            return nil
+        }
+
+        return signal
+    }
+
+    private static func parseLogBody(_ body: String, observedAt: Date) -> CodexCompactionSignal? {
+        guard let totalUsageTokens = intValue(named: "total_usage_tokens", in: body),
+              let autoCompactLimit = intValue(named: "auto_compact_limit", in: body),
+              let tokenLimitReached = boolValue(named: "token_limit_reached", in: body) else {
+            return nil
+        }
+
+        return CodexCompactionSignal(
+            observedAt: observedAt,
+            totalUsageTokens: totalUsageTokens,
+            estimatedTokenCount: optionalIntValue(named: "estimated_token_count", in: body),
+            autoCompactLimit: autoCompactLimit,
+            tokenLimitReached: tokenLimitReached
+        )
+    }
+
+    private static func intValue(named name: String, in text: String) -> Int? {
+        guard let range = text.range(
+            of: "\(name)=([0-9]+)",
+            options: .regularExpression
+        ) else {
+            return nil
+        }
+
+        let value = text[range].dropFirst(name.count + 1)
+        return Int(value)
+    }
+
+    private static func optionalIntValue(named name: String, in text: String) -> Int? {
+        guard let range = text.range(
+            of: "\(name)=Some\\(([0-9]+)\\)",
+            options: .regularExpression
+        ) else {
+            return nil
+        }
+
+        let matched = text[range]
+        guard let start = matched.firstIndex(of: "("),
+              let end = matched.firstIndex(of: ")") else {
+            return nil
+        }
+
+        return Int(matched[matched.index(after: start)..<end])
+    }
+
+    private static func boolValue(named name: String, in text: String) -> Bool? {
+        guard let range = text.range(
+            of: "\(name)=(true|false)",
+            options: .regularExpression
+        ) else {
+            return nil
+        }
+
+        return text[range].hasSuffix("true")
+    }
+
+    private static func runSQLite(query: String, databasePath: String) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
+        process.arguments = ["-batch", "-noheader", "-separator", "\u{1F}", databasePath, query]
+
+        let stdoutPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        let output = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return output?.isEmpty == false ? output : nil
     }
 }


### PR DESCRIPTION
## Summary
- detect Codex auto-compaction from local token-usage logs when no hook event exists
- harden refresh scheduling against stale task ownership and stale log rows
- batch SQLite lookups, validate thread IDs, and prevent compacting/working flicker

## Tests
- ./scripts/test.sh focused
- ./scripts/test.sh all
- git diff --check