### PR TITLE
Add emotion analysis provider settings

### DIFF
--- a/notchi/Tests/EmotionAnalyzerTests.swift
+++ b/notchi/Tests/EmotionAnalyzerTests.swift
@@ -59,6 +59,23 @@ final class EmotionAnalyzerTests: XCTestCase {
         )
     }
 
+    func testCuratedEmotionModelsAreProviderScoped() {
+        XCTAssertEqual(
+            EmotionAnalysisModel.models(for: .claude),
+            [.claudeHaiku45, .claudeSonnet46]
+        )
+        XCTAssertEqual(
+            EmotionAnalysisModel.models(for: .openAI),
+            [.openAIGPT54Nano, .openAIGPT54Mini]
+        )
+    }
+
+    func testDefaultEmotionModelsStayFastAndCheap() {
+        XCTAssertEqual(ClaudeSettingsConfig.defaultModel, EmotionAnalysisModel.claudeHaiku45.rawValue)
+        XCTAssertEqual(EmotionAnalysisModel.defaultModel(for: .claude), .claudeHaiku45)
+        XCTAssertEqual(EmotionAnalysisModel.defaultModel(for: .openAI), .openAIGPT54Nano)
+    }
+
     func testLoadClaudeSettingsConfigReadsCustomResolvedSettingsFile() throws {
         let settingsURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(UUID().uuidString)-settings.json")
@@ -72,7 +89,7 @@ final class EmotionAnalyzerTests: XCTestCase {
             try? FileManager.default.removeItem(at: settingsURL)
         }
 
-        let config = EmotionAnalyzer.loadClaudeSettingsConfig(from: settingsURL)
+        let config = ClaudeSettingsConfig.load(from: settingsURL)
 
         XCTAssertEqual(config?.apiURL, URL(string: "https://example.com/proxy/v1/messages"))
         XCTAssertEqual(config?.apiKey, "token-xyz")

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -1,5 +1,83 @@
 import Foundation
 
+enum EmotionAnalysisProvider: String, CaseIterable, Identifiable {
+    case claude
+    case openAI = "openai"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .claude:
+            "Claude"
+        case .openAI:
+            "OpenAI"
+        }
+    }
+
+    var apiKeyPlaceholder: String {
+        switch self {
+        case .claude:
+            "Anthropic API Key"
+        case .openAI:
+            "OpenAI API Key"
+        }
+    }
+}
+
+enum EmotionAnalysisModel: String, CaseIterable, Identifiable {
+    case claudeHaiku45 = "claude-haiku-4-5-20251001"
+    case claudeSonnet46 = "claude-sonnet-4-6"
+    case openAIGPT54Nano = "gpt-5.4-nano"
+    case openAIGPT54Mini = "gpt-5.4-mini"
+
+    var id: String { rawValue }
+
+    var provider: EmotionAnalysisProvider {
+        switch self {
+        case .claudeHaiku45, .claudeSonnet46:
+            .claude
+        case .openAIGPT54Nano, .openAIGPT54Mini:
+            .openAI
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .claudeHaiku45:
+            "Claude Haiku 4.5"
+        case .claudeSonnet46:
+            "Claude Sonnet 4.6"
+        case .openAIGPT54Nano:
+            "GPT-5.4 nano"
+        case .openAIGPT54Mini:
+            "GPT-5.4 mini"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .claudeHaiku45, .openAIGPT54Nano:
+            "Fastest"
+        case .claudeSonnet46, .openAIGPT54Mini:
+            "Balanced"
+        }
+    }
+
+    static func models(for provider: EmotionAnalysisProvider) -> [EmotionAnalysisModel] {
+        allCases.filter { $0.provider == provider }
+    }
+
+    static func defaultModel(for provider: EmotionAnalysisProvider) -> EmotionAnalysisModel {
+        switch provider {
+        case .claude:
+            .claudeHaiku45
+        case .openAI:
+            .openAIGPT54Nano
+        }
+    }
+}
+
 struct AppSettings {
     static let hideSpriteWhenIdleKey = "hideSpriteWhenIdle"
 
@@ -9,6 +87,9 @@ struct AppSettings {
     private static let isUsageEnabledKey = "isUsageEnabled"
     private static let claudeUsageRecoverySnapshotKey = "claudeUsageRecoverySnapshot"
     private static let claudeExtraUsageObservationKey = "claudeExtraUsageObservation"
+    private static let emotionAnalysisProviderKey = "emotionAnalysisProvider"
+    private static let emotionAnalysisClaudeModelKey = "emotionAnalysisClaudeModel"
+    private static let emotionAnalysisOpenAIModelKey = "emotionAnalysisOpenAIModel"
 
     static var isUsageEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: isUsageEnabledKey) }
@@ -55,6 +136,81 @@ struct AppSettings {
     static var anthropicApiKey: String? {
         get { KeychainManager.getAnthropicApiKey(allowInteraction: true) }
         set { KeychainManager.setAnthropicApiKey(newValue) }
+    }
+
+    static var openAIApiKey: String? {
+        get { KeychainManager.getOpenAIApiKey(allowInteraction: true) }
+        set { KeychainManager.setOpenAIApiKey(newValue) }
+    }
+
+    static var emotionAnalysisProvider: EmotionAnalysisProvider {
+        get {
+            if let rawValue = UserDefaults.standard.string(forKey: emotionAnalysisProviderKey),
+               let provider = EmotionAnalysisProvider(rawValue: rawValue) {
+                return provider
+            }
+
+            let hasAnthropicKey = KeychainManager.getAnthropicApiKey(allowInteraction: false)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty == false
+            let hasOpenAIKey = KeychainManager.getOpenAIApiKey(allowInteraction: false)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty == false
+
+            if hasOpenAIKey && !hasAnthropicKey {
+                return .openAI
+            }
+
+            return .claude
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: emotionAnalysisProviderKey)
+        }
+    }
+
+    static func apiKey(for provider: EmotionAnalysisProvider) -> String? {
+        switch provider {
+        case .claude:
+            anthropicApiKey
+        case .openAI:
+            openAIApiKey
+        }
+    }
+
+    static func setApiKey(_ key: String?, for provider: EmotionAnalysisProvider) {
+        switch provider {
+        case .claude:
+            anthropicApiKey = key
+        case .openAI:
+            openAIApiKey = key
+        }
+    }
+
+    static func selectedEmotionAnalysisModel(for provider: EmotionAnalysisProvider) -> EmotionAnalysisModel {
+        storedEmotionAnalysisModel(for: provider) ?? EmotionAnalysisModel.defaultModel(for: provider)
+    }
+
+    static func storedEmotionAnalysisModel(for provider: EmotionAnalysisProvider) -> EmotionAnalysisModel? {
+        guard let rawValue = UserDefaults.standard.string(forKey: emotionAnalysisModelKey(for: provider)),
+              let model = EmotionAnalysisModel(rawValue: rawValue),
+              model.provider == provider else {
+            return nil
+        }
+        return model
+    }
+
+    static func setEmotionAnalysisModel(_ model: EmotionAnalysisModel, for provider: EmotionAnalysisProvider) {
+        guard model.provider == provider else { return }
+        UserDefaults.standard.set(model.rawValue, forKey: emotionAnalysisModelKey(for: provider))
+    }
+
+    private static func emotionAnalysisModelKey(for provider: EmotionAnalysisProvider) -> String {
+        switch provider {
+        case .claude:
+            emotionAnalysisClaudeModelKey
+        case .openAI:
+            emotionAnalysisOpenAIModelKey
+        }
     }
 
     static var notificationSound: NotificationSound {

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -23,6 +23,15 @@ enum EmotionAnalysisProvider: String, CaseIterable, Identifiable {
             "OpenAI API Key"
         }
     }
+
+    var apiKeyURL: URL {
+        switch self {
+        case .claude:
+            URL(string: "https://console.anthropic.com/settings/keys")!
+        case .openAI:
+            URL(string: "https://platform.openai.com/api-keys")!
+        }
+    }
 }
 
 enum EmotionAnalysisModel: String, CaseIterable, Identifiable {
@@ -52,15 +61,6 @@ enum EmotionAnalysisModel: String, CaseIterable, Identifiable {
             "GPT-5.4 nano"
         case .openAIGPT54Mini:
             "GPT-5.4 mini"
-        }
-    }
-
-    var detail: String {
-        switch self {
-        case .claudeHaiku45, .openAIGPT54Nano:
-            "Fastest"
-        case .claudeSonnet46, .openAIGPT54Mini:
-            "Balanced"
         }
     }
 

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -47,6 +47,7 @@ struct NotchContentView: View {
     @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @ObservedObject private var updateManager = UpdateManager.shared
     @State private var showingPanelSettings = false
+    @State private var showingPanelSettingsDetail = false
     @State private var showingSessionActivity = false
     @State private var isMuted = AppSettings.isMuted
     @State private var isActivityCollapsed = false
@@ -289,6 +290,7 @@ struct NotchContentView: View {
             startSpriteHandoff(for: expanded)
             if !expanded {
                 showingPanelSettings = false
+                showingPanelSettingsDetail = false
                 showingSessionActivity = false
                 hoveredSessionId = nil
             }
@@ -313,6 +315,7 @@ struct NotchContentView: View {
                         usageService: usageService,
                         codexUsageService: CodexUsageService.shared,
                         showingSettings: $showingPanelSettings,
+                        showingSettingsDetail: $showingPanelSettingsDetail,
                         showingSessionActivity: $showingSessionActivity,
                         isActivityCollapsed: $isActivityCollapsed,
                         hoveredSessionId: $hoveredSessionId
@@ -361,6 +364,7 @@ struct NotchContentView: View {
                 showsIndicator: updateManager.hasPendingUpdate,
                 action: {
                     haptics.playNavigationTap()
+                    showingPanelSettingsDetail = false
                     showingPanelSettings = true
                 }
             )
@@ -384,7 +388,11 @@ struct NotchContentView: View {
 
     private func goBack() {
         if showingPanelSettings {
-            showingPanelSettings = false
+            if showingPanelSettingsDetail {
+                showingPanelSettingsDetail = false
+            } else {
+                showingPanelSettings = false
+            }
         } else if showingSessionActivity {
             showingSessionActivity = false
             sessionStore.clearSelectedSession()

--- a/notchi/notchi/Services/EmotionAnalyzer.swift
+++ b/notchi/notchi/Services/EmotionAnalyzer.swift
@@ -111,6 +111,40 @@ private struct EmotionResponse: Decodable {
     let intensity: Double
 }
 
+struct EmotionAnalysisTestResult {
+    let emotion: String
+    let intensity: Double
+    let latencyMilliseconds: Int
+}
+
+enum EmotionAnalysisRequestError: LocalizedError {
+    case missingAPIKey(EmotionAnalysisProvider)
+    case httpStatus(provider: String, statusCode: Int)
+    case invalidResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey(let provider):
+            "Missing \(provider.displayName) API key"
+        case .httpStatus(let provider, let statusCode):
+            "\(provider) API returned HTTP \(statusCode)"
+        case .invalidResponse:
+            "Invalid emotion analysis response"
+        }
+    }
+
+    var shortLabel: String {
+        switch self {
+        case .missingAPIKey:
+            "Missing"
+        case .httpStatus(_, let statusCode):
+            "HTTP \(statusCode)"
+        case .invalidResponse:
+            "Invalid"
+        }
+    }
+}
+
 private struct EmotionAnalysisResponseParser {
     private static let validEmotions: Set<String> = ["happy", "sad", "neutral"]
 
@@ -179,18 +213,18 @@ private struct ClaudeEmotionAnalysisProvider: EmotionAnalysisProviding {
         let (data, response) = try await URLSession.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            throw URLError(.badServerResponse)
+            throw EmotionAnalysisRequestError.invalidResponse
         }
 
         guard httpResponse.statusCode == 200 else {
             logger.warning("Claude API returned HTTP \(httpResponse.statusCode)")
-            throw URLError(.badServerResponse)
+            throw EmotionAnalysisRequestError.httpStatus(provider: providerName, statusCode: httpResponse.statusCode)
         }
 
         let haikuResponse = try JSONDecoder().decode(HaikuResponse.self, from: data)
 
         guard let text = haikuResponse.content.first?.text else {
-            throw URLError(.cannotParseResponse)
+            throw EmotionAnalysisRequestError.invalidResponse
         }
 
         logger.debug("Claude raw response: \(text, privacy: .private)")
@@ -247,18 +281,18 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
         let (data, response) = try await URLSession.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            throw URLError(.badServerResponse)
+            throw EmotionAnalysisRequestError.invalidResponse
         }
 
         guard httpResponse.statusCode == 200 else {
             logger.warning("OpenAI API returned HTTP \(httpResponse.statusCode)")
-            throw URLError(.badServerResponse)
+            throw EmotionAnalysisRequestError.httpStatus(provider: providerName, statusCode: httpResponse.statusCode)
         }
 
         let chatResponse = try JSONDecoder().decode(OpenAIChatCompletionResponse.self, from: data)
 
         guard let text = chatResponse.choices.first?.message.content else {
-            throw URLError(.cannotParseResponse)
+            throw EmotionAnalysisRequestError.invalidResponse
         }
 
         logger.debug("OpenAI raw response: \(text, privacy: .private)")
@@ -280,6 +314,7 @@ final class EmotionAnalyzer {
         Intensity: 0.0 (barely noticeable) to 1.0 (very strong). ALL CAPS text indicates stronger emotion — increase intensity by 0.2-0.3 compared to the same message in lowercase.
         Reply with ONLY valid JSON: {"emotion": "...", "intensity": ...}
         """
+    private static let testPrompt = "Thanks, this looks great!"
 
     private init() {}
 
@@ -346,5 +381,62 @@ final class EmotionAnalyzer {
             apiKey: apiKey,
             model: AppSettings.selectedEmotionAnalysisModel(for: .openAI).rawValue
         )
+    }
+
+    func testConfiguration(
+        provider: EmotionAnalysisProvider,
+        model: EmotionAnalysisModel,
+        apiKey: String?
+    ) async throws -> EmotionAnalysisTestResult {
+        let analysisProvider = try resolveProvider(provider: provider, model: model, apiKey: apiKey)
+        let start = ContinuousClock.now
+        let result = try await analysisProvider.analyze(prompt: Self.testPrompt, systemPrompt: Self.systemPrompt)
+        let elapsed = (ContinuousClock.now - start).components
+        let latency = Int(elapsed.seconds * 1_000 + elapsed.attoseconds / 1_000_000_000_000_000)
+
+        return EmotionAnalysisTestResult(
+            emotion: result.emotion,
+            intensity: result.intensity,
+            latencyMilliseconds: latency
+        )
+    }
+
+    private func resolveProvider(
+        provider: EmotionAnalysisProvider,
+        model: EmotionAnalysisModel,
+        apiKey: String?
+    ) throws -> EmotionAnalysisProviding {
+        let trimmedKey = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        switch provider {
+        case .claude:
+            if !trimmedKey.isEmpty {
+                return ClaudeEmotionAnalysisProvider(
+                    apiURL: ClaudeSettingsConfig.defaultAPIURL,
+                    apiKey: trimmedKey,
+                    model: model.rawValue
+                )
+            }
+
+            if let config = ClaudeSettingsConfig.loadFromDefaultLocation() {
+                return ClaudeEmotionAnalysisProvider(
+                    apiURL: config.apiURL,
+                    apiKey: config.apiKey,
+                    model: model.rawValue
+                )
+            }
+
+            throw EmotionAnalysisRequestError.missingAPIKey(provider)
+        case .openAI:
+            guard !trimmedKey.isEmpty else {
+                throw EmotionAnalysisRequestError.missingAPIKey(provider)
+            }
+
+            return OpenAIEmotionAnalysisProvider(
+                apiURL: OpenAISettingsConfig.defaultAPIURL,
+                apiKey: trimmedKey,
+                model: model.rawValue
+            )
+        }
     }
 }

--- a/notchi/notchi/Services/EmotionAnalyzer.swift
+++ b/notchi/notchi/Services/EmotionAnalyzer.swift
@@ -10,7 +10,29 @@ struct ClaudeSettingsConfig {
 
     nonisolated static let defaultBaseURL = "https://api.anthropic.com"
     nonisolated static let defaultAPIURL = URL(string: "\(defaultBaseURL)/v1/messages")!
-    nonisolated static let defaultModel = "claude-haiku-4-5-20251001"
+    nonisolated static let defaultModel = EmotionAnalysisModel.claudeHaiku45.rawValue
+
+    nonisolated static func load(from settingsURL: URL) -> ClaudeSettingsConfig? {
+        let logger = Logger(subsystem: "com.ruban.notchi", category: "EmotionAnalyzer")
+        guard let data = try? Data(contentsOf: settingsURL) else {
+            return nil
+        }
+
+        do {
+            return try parse(from: data)
+        } catch {
+            logger.error("Failed to parse Claude settings.json: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    nonisolated static func loadFromDefaultLocation() -> ClaudeSettingsConfig? {
+        load(from: ClaudeConfigDirectoryResolver.resolve().settingsURL)
+    }
+
+    nonisolated static func existsAtDefaultLocation() -> Bool {
+        loadFromDefaultLocation() != nil
+    }
 
     nonisolated static func parse(from data: Data) throws -> ClaudeSettingsConfig? {
         let logger = Logger(subsystem: "com.ruban.notchi", category: "EmotionAnalyzer")
@@ -60,6 +82,10 @@ struct ClaudeSettingsConfig {
     }
 }
 
+enum OpenAISettingsConfig {
+    nonisolated static let defaultAPIURL = URL(string: "https://api.openai.com/v1/chat/completions")!
+}
+
 private struct HaikuResponse: Decodable {
     let content: [ContentBlock]
 
@@ -68,16 +94,181 @@ private struct HaikuResponse: Decodable {
     }
 }
 
+private struct OpenAIChatCompletionResponse: Decodable {
+    let choices: [Choice]
+
+    struct Choice: Decodable {
+        let message: Message
+    }
+
+    struct Message: Decodable {
+        let content: String?
+    }
+}
+
 private struct EmotionResponse: Decodable {
     let emotion: String
     let intensity: Double
 }
 
+private struct EmotionAnalysisResponseParser {
+    private static let validEmotions: Set<String> = ["happy", "sad", "neutral"]
+
+    static func parse(_ text: String) throws -> (emotion: String, intensity: Double) {
+        let jsonString = extractJSON(from: text)
+        let emotionResponse = try JSONDecoder().decode(EmotionResponse.self, from: Data(jsonString.utf8))
+
+        let emotion = validEmotions.contains(emotionResponse.emotion) ? emotionResponse.emotion : "neutral"
+        let intensity = min(max(emotionResponse.intensity, 0.0), 1.0)
+
+        return (emotion, intensity)
+    }
+
+    static func extractJSON(from text: String) -> String {
+        var cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Strip markdown code blocks: ```json ... ``` or ``` ... ```
+        if cleaned.hasPrefix("```") {
+            if let firstNewline = cleaned.firstIndex(of: "\n") {
+                cleaned = String(cleaned[cleaned.index(after: firstNewline)...])
+            }
+            if cleaned.hasSuffix("```") {
+                cleaned = String(cleaned.dropLast(3))
+            }
+            cleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        if let start = cleaned.firstIndex(of: "{"),
+           let end = cleaned.lastIndex(of: "}") {
+            cleaned = String(cleaned[start...end])
+        }
+
+        return cleaned
+    }
+}
+
+private protocol EmotionAnalysisProviding {
+    var providerName: String { get }
+    func analyze(prompt: String, systemPrompt: String) async throws -> (emotion: String, intensity: Double)
+}
+
+private struct ClaudeEmotionAnalysisProvider: EmotionAnalysisProviding {
+    let apiURL: URL
+    let apiKey: String
+    let model: String
+
+    var providerName: String { "Claude" }
+
+    func analyze(prompt: String, systemPrompt: String) async throws -> (emotion: String, intensity: Double) {
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 50,
+            "system": systemPrompt,
+            "messages": [
+                ["role": "user", "content": prompt]
+            ]
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            logger.warning("Claude API returned HTTP \(httpResponse.statusCode)")
+            throw URLError(.badServerResponse)
+        }
+
+        let haikuResponse = try JSONDecoder().decode(HaikuResponse.self, from: data)
+
+        guard let text = haikuResponse.content.first?.text else {
+            throw URLError(.cannotParseResponse)
+        }
+
+        logger.debug("Claude raw response: \(text, privacy: .private)")
+        return try EmotionAnalysisResponseParser.parse(text)
+    }
+}
+
+private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
+    let apiURL: URL
+    let apiKey: String
+    let model: String
+
+    var providerName: String { "OpenAI" }
+
+    func analyze(prompt: String, systemPrompt: String) async throws -> (emotion: String, intensity: Double) {
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+
+        let body: [String: Any] = [
+            "model": model,
+            "max_completion_tokens": 80,
+            "response_format": [
+                "type": "json_schema",
+                "json_schema": [
+                    "name": "emotion_analysis",
+                    "strict": true,
+                    "schema": [
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": [
+                            "emotion": [
+                                "type": "string",
+                                "enum": ["happy", "sad", "neutral"]
+                            ],
+                            "intensity": [
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                            ]
+                        ],
+                        "required": ["emotion", "intensity"]
+                    ]
+                ]
+            ],
+            "messages": [
+                ["role": "system", "content": systemPrompt],
+                ["role": "user", "content": prompt]
+            ]
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            logger.warning("OpenAI API returned HTTP \(httpResponse.statusCode)")
+            throw URLError(.badServerResponse)
+        }
+
+        let chatResponse = try JSONDecoder().decode(OpenAIChatCompletionResponse.self, from: data)
+
+        guard let text = chatResponse.choices.first?.message.content else {
+            throw URLError(.cannotParseResponse)
+        }
+
+        logger.debug("OpenAI raw response: \(text, privacy: .private)")
+        return try EmotionAnalysisResponseParser.parse(text)
+    }
+}
+
 @MainActor
 final class EmotionAnalyzer {
     static let shared = EmotionAnalyzer()
-
-    private static let validEmotions: Set<String> = ["happy", "sad", "neutral"]
 
     private static let systemPrompt = """
         Classify the emotional tone of the user's message into exactly one emotion and an intensity score.
@@ -95,134 +286,65 @@ final class EmotionAnalyzer {
     func analyze(_ prompt: String) async -> (emotion: String, intensity: Double) {
         let start = ContinuousClock.now
 
-        guard let config = resolveAPIConfig() else {
+        guard let provider = resolveProvider() else {
             logger.info("No emotion analysis configuration available, using neutral fallback")
             return ("neutral", 0.0)
         }
 
         do {
-            let result = try await callHaiku(
-                prompt: prompt,
-                apiURL: config.apiURL,
-                apiKey: config.apiKey,
-                model: config.model
-            )
+            let result = try await provider.analyze(prompt: prompt, systemPrompt: Self.systemPrompt)
             let elapsed = ContinuousClock.now - start
-            logger.info("Analysis took \(elapsed, privacy: .public)")
+            logger.info("\(provider.providerName, privacy: .public) analysis took \(elapsed, privacy: .public)")
             return result
         } catch {
             let elapsed = ContinuousClock.now - start
-            logger.error("Haiku API failed (\(elapsed, privacy: .public)): \(error.localizedDescription)")
+            logger.error("\(provider.providerName, privacy: .public) API failed (\(elapsed, privacy: .public)): \(error.localizedDescription)")
             return ("neutral", 0.0)
         }
     }
 
-    private static func extractJSON(from text: String) -> String {
-        var cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Strip markdown code blocks: ```json ... ``` or ``` ... ```
-        if cleaned.hasPrefix("```") {
-            // Remove opening ``` (with optional language tag)
-            if let firstNewline = cleaned.firstIndex(of: "\n") {
-                cleaned = String(cleaned[cleaned.index(after: firstNewline)...])
-            }
-            // Remove closing ```
-            if cleaned.hasSuffix("```") {
-                cleaned = String(cleaned.dropLast(3))
-            }
-            cleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+    private func resolveProvider() -> EmotionAnalysisProviding? {
+        switch AppSettings.emotionAnalysisProvider {
+        case .claude:
+            return resolveClaudeProvider()
+        case .openAI:
+            return resolveOpenAIProvider()
         }
-
-        // Find first { to last } in case of surrounding text
-        if let start = cleaned.firstIndex(of: "{"),
-           let end = cleaned.lastIndex(of: "}") {
-            cleaned = String(cleaned[start...end])
-        }
-
-        return cleaned
     }
 
-    private func resolveAPIConfig() -> (apiURL: URL, apiKey: String, model: String)? {
-        guard let apiKey = KeychainManager.getAnthropicApiKey(allowInteraction: false)?
+    private func resolveClaudeProvider() -> ClaudeEmotionAnalysisProvider? {
+        if let apiKey = KeychainManager.getAnthropicApiKey(allowInteraction: false)?
             .trimmingCharacters(in: .whitespacesAndNewlines),
-              !apiKey.isEmpty else {
-            return loadClaudeSettingsConfig()
+           !apiKey.isEmpty {
+            return ClaudeEmotionAnalysisProvider(
+                apiURL: ClaudeSettingsConfig.defaultAPIURL,
+                apiKey: apiKey,
+                model: AppSettings.selectedEmotionAnalysisModel(for: .claude).rawValue
+            )
         }
 
-        return (
-            apiURL: ClaudeSettingsConfig.defaultAPIURL,
-            apiKey: apiKey,
-            model: ClaudeSettingsConfig.defaultModel
+        guard let config = ClaudeSettingsConfig.loadFromDefaultLocation() else {
+            return nil
+        }
+
+        return ClaudeEmotionAnalysisProvider(
+            apiURL: config.apiURL,
+            apiKey: config.apiKey,
+            model: AppSettings.storedEmotionAnalysisModel(for: .claude)?.rawValue ?? config.model
         )
     }
 
-    private func loadClaudeSettingsConfig() -> (apiURL: URL, apiKey: String, model: String)? {
-        Self.loadClaudeSettingsConfig(from: ClaudeConfigDirectoryResolver.resolve().settingsURL)
-    }
-
-    nonisolated static func loadClaudeSettingsConfig(from settingsURL: URL) -> (apiURL: URL, apiKey: String, model: String)? {
-        let logger = Logger(subsystem: "com.ruban.notchi", category: "EmotionAnalyzer")
-        guard let data = try? Data(contentsOf: settingsURL) else {
+    private func resolveOpenAIProvider() -> OpenAIEmotionAnalysisProvider? {
+        guard let apiKey = KeychainManager.getOpenAIApiKey(allowInteraction: false)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !apiKey.isEmpty else {
             return nil
         }
 
-        do {
-            guard let config = try ClaudeSettingsConfig.parse(from: data) else {
-                return nil
-            }
-            return (
-                apiURL: config.apiURL,
-                apiKey: config.apiKey,
-                model: config.model
-            )
-        } catch {
-            logger.error("Failed to parse Claude settings.json: \(error.localizedDescription)")
-            return nil
-        }
-    }
-
-    private func callHaiku(prompt: String, apiURL: URL, apiKey: String, model: String) async throws -> (emotion: String, intensity: Double) {
-        var request = URLRequest(url: apiURL)
-        request.httpMethod = "POST"
-        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
-        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
-        request.setValue("application/json", forHTTPHeaderField: "content-type")
-
-        let body: [String: Any] = [
-            "model": model,
-            "max_tokens": 50,
-            "system": Self.systemPrompt,
-            "messages": [
-                ["role": "user", "content": prompt]
-            ]
-        ]
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw URLError(.badServerResponse)
-        }
-
-        guard httpResponse.statusCode == 200 else {
-            logger.warning("Haiku API returned HTTP \(httpResponse.statusCode)")
-            throw URLError(.badServerResponse)
-        }
-
-        let haikuResponse = try JSONDecoder().decode(HaikuResponse.self, from: data)
-
-        guard let text = haikuResponse.content.first?.text else {
-            throw URLError(.cannotParseResponse)
-        }
-
-        logger.debug("Haiku raw response: \(text, privacy: .public)")
-
-        let jsonString = Self.extractJSON(from: text)
-        let emotionResponse = try JSONDecoder().decode(EmotionResponse.self, from: Data(jsonString.utf8))
-
-        let emotion = Self.validEmotions.contains(emotionResponse.emotion) ? emotionResponse.emotion : "neutral"
-        let intensity = min(max(emotionResponse.intensity, 0.0), 1.0)
-
-        return (emotion, intensity)
+        return OpenAIEmotionAnalysisProvider(
+            apiURL: OpenAISettingsConfig.defaultAPIURL,
+            apiKey: apiKey,
+            model: AppSettings.selectedEmotionAnalysisModel(for: .openAI).rawValue
+        )
     }
 }

--- a/notchi/notchi/Services/KeychainManager.swift
+++ b/notchi/notchi/Services/KeychainManager.swift
@@ -14,6 +14,7 @@ enum KeychainManager {
     private static let claudeCodeService = "Claude Code-credentials"
     private static let notchiService = "com.ruban.notchi"
     private static let anthropicApiKeyAccount = "anthropicApiKey"
+    private static let openAIApiKeyAccount = "openAIApiKey"
     private static let cachedOAuthTokenAccount = "cachedOAuthToken"
     private static let recentCredentialCacheTTL: TimeInterval = 5
     private static let securityCLIBackoffInterval: TimeInterval = 60
@@ -62,6 +63,22 @@ enum KeychainManager {
             saveString(key, service: notchiService, account: anthropicApiKeyAccount)
         } else {
             deleteItem(service: notchiService, account: anthropicApiKeyAccount)
+        }
+    }
+
+    static func getOpenAIApiKey(allowInteraction: Bool = false) -> String? {
+        readString(
+            service: notchiService,
+            account: openAIApiKeyAccount,
+            allowInteraction: allowInteraction
+        )
+    }
+
+    static func setOpenAIApiKey(_ key: String?) {
+        if let key, !key.isEmpty {
+            saveString(key, service: notchiService, account: openAIApiKeyAccount)
+        } else {
+            deleteItem(service: notchiService, account: openAIApiKeyAccount)
         }
     }
 

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -163,6 +163,7 @@ struct ExpandedPanelView: View {
     let usageService: ClaudeUsageService
     let codexUsageService: CodexUsageService
     @Binding var showingSettings: Bool
+    @Binding var showingSettingsDetail: Bool
     @Binding var showingSessionActivity: Bool
     @Binding var isActivityCollapsed: Bool
     @Binding var hoveredSessionId: String?
@@ -172,6 +173,7 @@ struct ExpandedPanelView: View {
         usageService: ClaudeUsageService,
         codexUsageService: CodexUsageService,
         showingSettings: Binding<Bool>,
+        showingSettingsDetail: Binding<Bool>,
         showingSessionActivity: Binding<Bool>,
         isActivityCollapsed: Binding<Bool>,
         hoveredSessionId: Binding<String?>
@@ -180,6 +182,7 @@ struct ExpandedPanelView: View {
         self.usageService = usageService
         self.codexUsageService = codexUsageService
         _showingSettings = showingSettings
+        _showingSettingsDetail = showingSettingsDetail
         _showingSessionActivity = showingSessionActivity
         _isActivityCollapsed = isActivityCollapsed
         _hoveredSessionId = hoveredSessionId
@@ -337,7 +340,7 @@ struct ExpandedPanelView: View {
                 }
 
                 if showingSettings {
-                    PanelSettingsView()
+                    PanelSettingsView(showingEmotionAnalysisSettings: $showingSettingsDetail)
                         .frame(width: geometry.size.width)
                         .transition(settingsContentTransition)
                 }
@@ -347,6 +350,7 @@ struct ExpandedPanelView: View {
         .animation(.easeInOut(duration: 0.25), value: shouldShowSessionPicker)
         .onChange(of: showingSettings) { _, isShowing in
             if !isShowing {
+                showingSettingsDetail = false
                 UpdateManager.shared.clearTransientStatus()
             }
         }

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -81,7 +81,6 @@ struct PanelSettingsView: View {
                     Divider().background(Color.white.opacity(0.08))
                     aboutSection
                 }
-                .padding(.top, SettingsLayout.topPadding)
             }
             .scrollIndicators(.hidden)
 
@@ -367,11 +366,19 @@ struct PanelSettingsView: View {
 }
 
 private struct EmotionAnalysisSettingsView: View {
+    private enum TestState {
+        case idle
+        case testing
+        case success(EmotionAnalysisTestResult)
+        case failure(String)
+    }
+
     @State private var provider = AppSettings.emotionAnalysisProvider
     @State private var model = AppSettings.selectedEmotionAnalysisModel(for: AppSettings.emotionAnalysisProvider)
     @State private var apiKeyInput = AppSettings.apiKey(for: AppSettings.emotionAnalysisProvider) ?? ""
     @State private var isProviderPickerExpanded = false
     @State private var isModelPickerExpanded = false
+    @State private var testState: TestState = .idle
 
     private var hasApiKey: Bool {
         !apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -379,15 +386,17 @@ private struct EmotionAnalysisSettingsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
-                    providerSection
-                    modelSection
-                    apiKeySection
-                }
-                .padding(.top, SettingsLayout.topPadding)
+            VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
+                descriptionSection
+                providerSection
+                modelSection
+                apiKeySection
+                testSection
             }
-            .scrollIndicators(.hidden)
+
+            Spacer(minLength: SettingsLayout.sectionSpacing)
+
+            setupSection
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onDisappear {
@@ -395,6 +404,16 @@ private struct EmotionAnalysisSettingsView: View {
         }
         .animation(.spring(response: 0.3), value: isProviderPickerExpanded)
         .animation(.spring(response: 0.3), value: isModelPickerExpanded)
+        .onChange(of: apiKeyInput) { _, _ in
+            resetTestState()
+        }
+    }
+
+    private var descriptionSection: some View {
+        Text("Prompts are sent to the selected provider for emotion classification.")
+            .font(.system(size: 10))
+            .foregroundColor(TerminalColors.dimmedText)
+            .fixedSize(horizontal: false, vertical: true)
     }
 
     private var providerSection: some View {
@@ -458,12 +477,37 @@ private struct EmotionAnalysisSettingsView: View {
     }
 
     private var apiKeySection: some View {
-        VStack(alignment: .leading, spacing: SettingsLayout.apiKeySpacing) {
-            SettingsRowView(icon: "key", title: "API Key") {
-                statusBadge(hasApiKey ? "Saved" : fallbackStatusText, color: hasApiKey ? TerminalColors.green : fallbackStatusColor)
-            }
+        HStack {
+            Image(systemName: "key")
+                .font(.system(size: 12))
+                .foregroundColor(TerminalColors.secondaryText)
+                .frame(width: 20)
 
-            HStack(spacing: 6) {
+            Text("API Key")
+                .font(.system(size: 12))
+                .foregroundColor(TerminalColors.primaryText)
+                .layoutPriority(1)
+
+            Spacer(minLength: 12)
+
+            apiKeyStatusView
+            apiKeyField
+        }
+        .padding(.vertical, SettingsLayout.rowVerticalPadding)
+    }
+
+    @ViewBuilder
+    private var apiKeyStatusView: some View {
+        if hasApiKey {
+            statusBadge("Saved", color: TerminalColors.green)
+        } else if provider == .claude, hasClaudeCodeFallback {
+            statusBadge("Claude Code", color: TerminalColors.green)
+        }
+    }
+
+    private var apiKeyField: some View {
+        HStack(spacing: 6) {
+            ZStack(alignment: .leading) {
                 SecureField("", text: $apiKeyInput)
                     .textFieldStyle(.plain)
                     .font(.system(size: 11, design: .monospaced))
@@ -473,24 +517,62 @@ private struct EmotionAnalysisSettingsView: View {
                     .background(Color.white.opacity(0.06))
                     .cornerRadius(6)
                     .onSubmit { saveApiKey(for: provider) }
-                    .overlay(alignment: .leading) {
-                        if apiKeyInput.isEmpty {
-                            Text(provider.apiKeyPlaceholder)
-                                .font(.system(size: 11, design: .monospaced))
-                                .foregroundColor(TerminalColors.dimmedText)
-                                .padding(.leading, SettingsLayout.fieldHorizontalPadding)
-                                .allowsHitTesting(false)
-                        }
-                    }
 
-                Button(action: { saveApiKey(for: provider) }) {
-                    Image(systemName: hasApiKey ? "checkmark.circle.fill" : "arrow.right.circle")
-                        .font(.system(size: 14))
-                        .foregroundColor(hasApiKey ? TerminalColors.green : TerminalColors.dimmedText)
+                if apiKeyInput.isEmpty {
+                    Text(provider.apiKeyPlaceholder)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(TerminalColors.dimmedText)
+                        .padding(.leading, SettingsLayout.fieldHorizontalPadding)
+                        .allowsHitTesting(false)
                 }
-                .buttonStyle(.plain)
             }
-            .padding(.leading, SettingsLayout.fieldLeadingInset)
+            .frame(minWidth: 220, maxWidth: 300)
+
+            Button(action: { saveApiKey(for: provider) }) {
+                Image(systemName: hasApiKey ? "checkmark.circle.fill" : "arrow.right.circle")
+                    .font(.system(size: 14))
+                    .foregroundColor(hasApiKey ? TerminalColors.green : TerminalColors.dimmedText)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var setupSection: some View {
+        Button(action: openAPIKeyPage) {
+            SettingsRowView(icon: "arrow.up.right.square", title: "Get API Key") {
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 10))
+                    .foregroundColor(TerminalColors.dimmedText)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var testSection: some View {
+        Button(action: testEmotionAnalysis) {
+            SettingsRowView(icon: "bolt.horizontal", title: "Test") {
+                testStatusView
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(isTesting)
+    }
+
+    @ViewBuilder
+    private var testStatusView: some View {
+        switch testState {
+        case .idle:
+            Image(systemName: "play.circle")
+                .font(.system(size: 13))
+                .foregroundColor(canTest ? TerminalColors.dimmedText : TerminalColors.red)
+        case .testing:
+            ProgressView()
+                .controlSize(.mini)
+                .frame(width: 16, height: 16)
+        case .success(let result):
+            statusBadge(testResultText(result), color: TerminalColors.green)
+        case .failure(let message):
+            statusBadge(message, color: TerminalColors.red)
         }
     }
 
@@ -538,14 +620,10 @@ private struct EmotionAnalysisSettingsView: View {
                     .fill(model == option ? TerminalColors.green : Color.clear)
                     .frame(width: 6, height: 6)
 
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(option.displayName)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(model == option ? TerminalColors.primaryText : TerminalColors.secondaryText)
-                    Text(option.detail)
-                        .font(.system(size: 9))
-                        .foregroundColor(TerminalColors.dimmedText)
-                }
+                Text(option.displayName)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(model == option ? TerminalColors.primaryText : TerminalColors.secondaryText)
+                    .lineLimit(1)
 
                 Spacer()
             }
@@ -580,6 +658,17 @@ private struct EmotionAnalysisSettingsView: View {
         ClaudeSettingsConfig.existsAtDefaultLocation()
     }
 
+    private var canTest: Bool {
+        hasApiKey || (provider == .claude && hasClaudeCodeFallback)
+    }
+
+    private var isTesting: Bool {
+        if case .testing = testState {
+            return true
+        }
+        return false
+    }
+
     private func selectProvider(_ newProvider: EmotionAnalysisProvider) {
         guard newProvider != provider else { return }
         saveApiKey(for: provider)
@@ -587,16 +676,81 @@ private struct EmotionAnalysisSettingsView: View {
         AppSettings.emotionAnalysisProvider = newProvider
         model = AppSettings.selectedEmotionAnalysisModel(for: newProvider)
         apiKeyInput = AppSettings.apiKey(for: newProvider) ?? ""
+        resetTestState()
     }
 
     private func selectModel(_ newModel: EmotionAnalysisModel) {
         model = newModel
         AppSettings.setEmotionAnalysisModel(newModel, for: provider)
+        resetTestState()
     }
 
     private func saveApiKey(for provider: EmotionAnalysisProvider) {
         let trimmed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         AppSettings.setApiKey(trimmed.isEmpty ? nil : trimmed, for: provider)
+    }
+
+    private func openAPIKeyPage() {
+        NSWorkspace.shared.open(provider.apiKeyURL)
+    }
+
+    private func testEmotionAnalysis() {
+        guard !isTesting else { return }
+        testState = .testing
+
+        let currentProvider = provider
+        let currentModel = model
+        let currentAPIKey = apiKeyInput
+
+        Task { @MainActor in
+            do {
+                let result = try await EmotionAnalyzer.shared.testConfiguration(
+                    provider: currentProvider,
+                    model: currentModel,
+                    apiKey: currentAPIKey
+                )
+                guard isCurrentTestSnapshot(provider: currentProvider, model: currentModel, apiKey: currentAPIKey) else { return }
+                testState = .success(result)
+            } catch {
+                guard isCurrentTestSnapshot(provider: currentProvider, model: currentModel, apiKey: currentAPIKey) else { return }
+                testState = .failure(testErrorText(error))
+            }
+        }
+    }
+
+    private func resetTestState() {
+        testState = .idle
+    }
+
+    private func isCurrentTestSnapshot(
+        provider: EmotionAnalysisProvider,
+        model: EmotionAnalysisModel,
+        apiKey: String
+    ) -> Bool {
+        self.provider == provider && self.model == model && apiKeyInput == apiKey
+    }
+
+    private func testResultText(_ result: EmotionAnalysisTestResult) -> String {
+        "\(result.emotion.capitalized) \(String(format: "%.2f", result.intensity)) / \(result.latencyMilliseconds)ms"
+    }
+
+    private func testErrorText(_ error: Error) -> String {
+        if let requestError = error as? EmotionAnalysisRequestError {
+            return requestError.shortLabel
+        }
+
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .notConnectedToInternet:
+                return "Offline"
+            case .timedOut:
+                return "Timeout"
+            default:
+                return "Failed"
+            }
+        }
+
+        return "Failed"
     }
 
     private func statusBadge(_ text: String, color: Color) -> some View {

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -33,18 +33,45 @@ private enum HookInstallBadgeState {
 }
 
 struct PanelSettingsView: View {
+    @Binding private var showingEmotionAnalysisSettings: Bool
     @AppStorage(AppSettings.hideSpriteWhenIdleKey) private var hideSpriteWhenIdle = false
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var claudeHooksInstalled = IntegrationCoordinator.shared.isInstalled(for: .claude)
     @State private var claudeHooksError = false
     @State private var codexHooksInstalled = IntegrationCoordinator.shared.isInstalled(for: .codex)
     @State private var codexHooksError = false
-    @State private var apiKeyInput = AppSettings.anthropicApiKey ?? ""
     @ObservedObject private var updateManager = UpdateManager.shared
     private var usageConnected: Bool { ClaudeUsageService.shared.isConnected }
-    private var hasApiKey: Bool { !apiKeyInput.isEmpty }
+
+    init(showingEmotionAnalysisSettings: Binding<Bool> = .constant(false)) {
+        _showingEmotionAnalysisSettings = showingEmotionAnalysisSettings
+    }
 
     var body: some View {
+        ZStack {
+            if !showingEmotionAnalysisSettings {
+                mainSettings
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .leading).combined(with: .opacity),
+                        removal: .move(edge: .leading).combined(with: .opacity)
+                    ))
+            }
+
+            if showingEmotionAnalysisSettings {
+                EmotionAnalysisSettingsView()
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .trailing).combined(with: .opacity),
+                        removal: .move(edge: .trailing).combined(with: .opacity)
+                    ))
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: showingEmotionAnalysisSettings)
+        .padding(.horizontal, SettingsLayout.panelHorizontalPadding)
+        .padding(.top, SettingsLayout.topPadding)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var mainSettings: some View {
         VStack(alignment: .leading, spacing: 0) {
             ScrollView {
                 VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
@@ -62,8 +89,6 @@ struct PanelSettingsView: View {
 
             quitSection
         }
-        .padding(.horizontal, SettingsLayout.panelHorizontalPadding)
-        .padding(.top, SettingsLayout.topPadding)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
@@ -121,53 +146,23 @@ struct PanelSettingsView: View {
             }
             .buttonStyle(.plain)
 
-            apiKeyRow
+            emotionAnalysisRow
         }
     }
 
-    private var apiKeyRow: some View {
-        VStack(alignment: .leading, spacing: SettingsLayout.apiKeySpacing) {
+    private var emotionAnalysisRow: some View {
+        Button(action: { showingEmotionAnalysisSettings = true }) {
             SettingsRowView(icon: "brain", title: "Emotion Analysis") {
-                statusBadge(
-                    hasApiKey ? "Active" : "No Key",
-                    color: hasApiKey ? TerminalColors.green : TerminalColors.red
-                )
-            }
-
-            HStack(spacing: 6) {
-                SecureField("", text: $apiKeyInput)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(TerminalColors.primaryText)
-                    .padding(.horizontal, SettingsLayout.fieldHorizontalPadding)
-                    .padding(.vertical, SettingsLayout.fieldVerticalPadding)
-                    .background(Color.white.opacity(0.06))
-                    .cornerRadius(6)
-                    .onSubmit { saveApiKey() }
-                    .overlay(alignment: .leading) {
-                        if apiKeyInput.isEmpty {
-                            Text("Anthropic API Key")
-                                .font(.system(size: 11, design: .monospaced))
-                                .foregroundColor(TerminalColors.dimmedText)
-                                .padding(.leading, SettingsLayout.fieldHorizontalPadding)
-                                .allowsHitTesting(false)
-                        }
-                    }
-
-                Button(action: saveApiKey) {
-                    Image(systemName: hasApiKey ? "checkmark.circle.fill" : "arrow.right.circle")
-                        .font(.system(size: 14))
-                        .foregroundColor(hasApiKey ? TerminalColors.green : TerminalColors.dimmedText)
+                HStack(spacing: 6) {
+                    let status = emotionAnalysisStatus()
+                    statusBadge(status.text, color: status.color)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(TerminalColors.dimmedText)
                 }
-                .buttonStyle(.plain)
             }
-            .padding(.leading, SettingsLayout.fieldLeadingInset)
         }
-    }
-
-    private func saveApiKey() {
-        let trimmed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        AppSettings.anthropicApiKey = trimmed.isEmpty ? nil : trimmed
+        .buttonStyle(.plain)
     }
 
     private var aboutSection: some View {
@@ -316,6 +311,26 @@ struct PanelSettingsView: View {
             .frame(maxWidth: 160, alignment: .trailing)
     }
 
+    private func emotionAnalysisStatus() -> (text: String, color: Color) {
+        let provider = AppSettings.emotionAnalysisProvider
+        if hasStoredApiKey(for: provider) {
+            return (provider.displayName, TerminalColors.green)
+        }
+
+        if provider == .claude,
+           ClaudeSettingsConfig.existsAtDefaultLocation() {
+            return ("Claude Code", TerminalColors.green)
+        }
+
+        return ("No Key", TerminalColors.red)
+    }
+
+    private func hasStoredApiKey(for provider: EmotionAnalysisProvider) -> Bool {
+        AppSettings.apiKey(for: provider)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty == false
+    }
+
     @ViewBuilder
     private var updateStatusView: some View {
         switch updateManager.state {
@@ -348,6 +363,253 @@ struct PanelSettingsView: View {
                 .font(.system(size: 10))
                 .foregroundColor(TerminalColors.dimmedText)
         }
+    }
+}
+
+private struct EmotionAnalysisSettingsView: View {
+    @State private var provider = AppSettings.emotionAnalysisProvider
+    @State private var model = AppSettings.selectedEmotionAnalysisModel(for: AppSettings.emotionAnalysisProvider)
+    @State private var apiKeyInput = AppSettings.apiKey(for: AppSettings.emotionAnalysisProvider) ?? ""
+    @State private var isProviderPickerExpanded = false
+    @State private var isModelPickerExpanded = false
+
+    private var hasApiKey: Bool {
+        !apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
+                    providerSection
+                    modelSection
+                    apiKeySection
+                }
+                .padding(.top, SettingsLayout.topPadding)
+            }
+            .scrollIndicators(.hidden)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onDisappear {
+            saveApiKey(for: provider)
+        }
+        .animation(.spring(response: 0.3), value: isProviderPickerExpanded)
+        .animation(.spring(response: 0.3), value: isModelPickerExpanded)
+    }
+
+    private var providerSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: { isProviderPickerExpanded.toggle() }) {
+                SettingsRowView(icon: "switch.2", title: "Provider") {
+                    HStack(spacing: 4) {
+                        Text(provider.displayName)
+                            .font(.system(size: 11))
+                            .foregroundColor(TerminalColors.secondaryText)
+                        Image(systemName: isProviderPickerExpanded ? "chevron.up" : "chevron.down")
+                            .font(.system(size: 9))
+                            .foregroundColor(TerminalColors.dimmedText)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isProviderPickerExpanded {
+                providerPicker
+            }
+        }
+    }
+
+    private var providerPicker: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(EmotionAnalysisProvider.allCases) { option in
+                    providerRow(option)
+                }
+            }
+            .padding(.vertical, SettingsLayout.pickerInset)
+        }
+        .frame(height: pickerHeight(optionCount: EmotionAnalysisProvider.allCases.count))
+        .background(TerminalColors.subtleBackground)
+        .cornerRadius(8)
+        .padding(.top, SettingsLayout.pickerInset)
+    }
+
+    private func providerRow(_ option: EmotionAnalysisProvider) -> some View {
+        Button(action: { selectProvider(option) }) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(provider == option ? TerminalColors.green : Color.clear)
+                    .frame(width: 6, height: 6)
+
+                Text(option.displayName)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(provider == option ? TerminalColors.primaryText : TerminalColors.secondaryText)
+                    .lineLimit(1)
+
+                Spacer()
+            }
+            .padding(.horizontal, SettingsLayout.pickerOptionHorizontalPadding)
+            .padding(.vertical, SettingsLayout.pickerOptionVerticalPadding)
+            .background(provider == option ? TerminalColors.hoverBackground : Color.clear)
+            .cornerRadius(4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var apiKeySection: some View {
+        VStack(alignment: .leading, spacing: SettingsLayout.apiKeySpacing) {
+            SettingsRowView(icon: "key", title: "API Key") {
+                statusBadge(hasApiKey ? "Saved" : fallbackStatusText, color: hasApiKey ? TerminalColors.green : fallbackStatusColor)
+            }
+
+            HStack(spacing: 6) {
+                SecureField("", text: $apiKeyInput)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(TerminalColors.primaryText)
+                    .padding(.horizontal, SettingsLayout.fieldHorizontalPadding)
+                    .padding(.vertical, SettingsLayout.fieldVerticalPadding)
+                    .background(Color.white.opacity(0.06))
+                    .cornerRadius(6)
+                    .onSubmit { saveApiKey(for: provider) }
+                    .overlay(alignment: .leading) {
+                        if apiKeyInput.isEmpty {
+                            Text(provider.apiKeyPlaceholder)
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundColor(TerminalColors.dimmedText)
+                                .padding(.leading, SettingsLayout.fieldHorizontalPadding)
+                                .allowsHitTesting(false)
+                        }
+                    }
+
+                Button(action: { saveApiKey(for: provider) }) {
+                    Image(systemName: hasApiKey ? "checkmark.circle.fill" : "arrow.right.circle")
+                        .font(.system(size: 14))
+                        .foregroundColor(hasApiKey ? TerminalColors.green : TerminalColors.dimmedText)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.leading, SettingsLayout.fieldLeadingInset)
+        }
+    }
+
+    private var modelSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: { isModelPickerExpanded.toggle() }) {
+                SettingsRowView(icon: "cpu", title: "Model") {
+                    HStack(spacing: 4) {
+                        Text(model.displayName)
+                            .font(.system(size: 11))
+                            .foregroundColor(TerminalColors.secondaryText)
+                        Image(systemName: isModelPickerExpanded ? "chevron.up" : "chevron.down")
+                            .font(.system(size: 9))
+                            .foregroundColor(TerminalColors.dimmedText)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isModelPickerExpanded {
+                modelPicker
+            }
+        }
+    }
+
+    private var modelPicker: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(EmotionAnalysisModel.models(for: provider)) { option in
+                    modelRow(option)
+                }
+            }
+            .padding(.vertical, SettingsLayout.pickerInset)
+        }
+        .frame(height: pickerHeight(optionCount: EmotionAnalysisModel.models(for: provider).count))
+        .background(TerminalColors.subtleBackground)
+        .cornerRadius(8)
+        .padding(.top, SettingsLayout.pickerInset)
+    }
+
+    private func modelRow(_ option: EmotionAnalysisModel) -> some View {
+        Button(action: { selectModel(option) }) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(model == option ? TerminalColors.green : Color.clear)
+                    .frame(width: 6, height: 6)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(option.displayName)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(model == option ? TerminalColors.primaryText : TerminalColors.secondaryText)
+                    Text(option.detail)
+                        .font(.system(size: 9))
+                        .foregroundColor(TerminalColors.dimmedText)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, SettingsLayout.pickerOptionHorizontalPadding)
+            .padding(.vertical, SettingsLayout.pickerOptionVerticalPadding)
+            .background(model == option ? TerminalColors.hoverBackground : Color.clear)
+            .cornerRadius(4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func pickerHeight(optionCount: Int) -> CGFloat {
+        let rowHeight: CGFloat = 28
+        let rowSpacing: CGFloat = 4
+        let visibleCount = min(optionCount, 6)
+        return CGFloat(visibleCount) * rowHeight + CGFloat(max(visibleCount - 1, 0)) * rowSpacing
+    }
+
+    private var fallbackStatusText: String {
+        if provider == .claude, hasClaudeCodeFallback {
+            return "Claude Code"
+        }
+        return "Missing"
+    }
+
+    private var fallbackStatusColor: Color {
+        provider == .claude && hasClaudeCodeFallback ? TerminalColors.green : TerminalColors.red
+    }
+
+    private var hasClaudeCodeFallback: Bool {
+        ClaudeSettingsConfig.existsAtDefaultLocation()
+    }
+
+    private func selectProvider(_ newProvider: EmotionAnalysisProvider) {
+        guard newProvider != provider else { return }
+        saveApiKey(for: provider)
+        provider = newProvider
+        AppSettings.emotionAnalysisProvider = newProvider
+        model = AppSettings.selectedEmotionAnalysisModel(for: newProvider)
+        apiKeyInput = AppSettings.apiKey(for: newProvider) ?? ""
+    }
+
+    private func selectModel(_ newModel: EmotionAnalysisModel) {
+        model = newModel
+        AppSettings.setEmotionAnalysisModel(newModel, for: provider)
+    }
+
+    private func saveApiKey(for provider: EmotionAnalysisProvider) {
+        let trimmed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        AppSettings.setApiKey(trimmed.isEmpty ? nil : trimmed, for: provider)
+    }
+
+    private func statusBadge(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .medium))
+            .foregroundColor(color)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15))
+            .cornerRadius(4)
+            .frame(maxWidth: 160, alignment: .trailing)
     }
 }
 

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -379,6 +379,8 @@ private struct EmotionAnalysisSettingsView: View {
     @State private var isProviderPickerExpanded = false
     @State private var isModelPickerExpanded = false
     @State private var testState: TestState = .idle
+    @State private var setupLinkShakePhase: CGFloat = 0
+    @FocusState private var isAPIKeyFocused: Bool
 
     private var hasApiKey: Bool {
         !apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -392,11 +394,8 @@ private struct EmotionAnalysisSettingsView: View {
                 modelSection
                 apiKeySection
                 testSection
+                setupSection
             }
-
-            Spacer(minLength: SettingsLayout.sectionSpacing)
-
-            setupSection
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onDisappear {
@@ -407,18 +406,27 @@ private struct EmotionAnalysisSettingsView: View {
         .onChange(of: apiKeyInput) { _, _ in
             resetTestState()
         }
+        .onChange(of: isAPIKeyFocused) { _, focused in
+            guard focused else { return }
+            withAnimation(.linear(duration: 0.28)) {
+                setupLinkShakePhase += 1
+            }
+        }
     }
 
     private var descriptionSection: some View {
         Text("Prompts are sent to the selected provider for emotion classification.")
-            .font(.system(size: 10))
-            .foregroundColor(TerminalColors.dimmedText)
+            .font(.system(size: 11))
+            .foregroundColor(TerminalColors.secondaryText)
             .fixedSize(horizontal: false, vertical: true)
     }
 
     private var providerSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Button(action: { isProviderPickerExpanded.toggle() }) {
+            Button(action: {
+                blurAPIKeyField()
+                isProviderPickerExpanded.toggle()
+            }) {
                 SettingsRowView(icon: "switch.2", title: "Provider") {
                     HStack(spacing: 4) {
                         Text(provider.displayName)
@@ -498,9 +506,7 @@ private struct EmotionAnalysisSettingsView: View {
 
     @ViewBuilder
     private var apiKeyStatusView: some View {
-        if hasApiKey {
-            statusBadge("Saved", color: TerminalColors.green)
-        } else if provider == .claude, hasClaudeCodeFallback {
+        if !hasApiKey, provider == .claude, hasClaudeCodeFallback {
             statusBadge("Claude Code", color: TerminalColors.green)
         }
     }
@@ -516,6 +522,7 @@ private struct EmotionAnalysisSettingsView: View {
                     .padding(.vertical, SettingsLayout.fieldVerticalPadding)
                     .background(Color.white.opacity(0.06))
                     .cornerRadius(6)
+                    .focused($isAPIKeyFocused)
                     .onSubmit { saveApiKey(for: provider) }
 
                 if apiKeyInput.isEmpty {
@@ -528,7 +535,10 @@ private struct EmotionAnalysisSettingsView: View {
             }
             .frame(minWidth: 220, maxWidth: 300)
 
-            Button(action: { saveApiKey(for: provider) }) {
+            Button(action: {
+                blurAPIKeyField()
+                saveApiKey(for: provider)
+            }) {
                 Image(systemName: hasApiKey ? "checkmark.circle.fill" : "arrow.right.circle")
                     .font(.system(size: 14))
                     .foregroundColor(hasApiKey ? TerminalColors.green : TerminalColors.dimmedText)
@@ -544,41 +554,91 @@ private struct EmotionAnalysisSettingsView: View {
                     .font(.system(size: 10))
                     .foregroundColor(TerminalColors.dimmedText)
             }
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isAPIKeyFocused ? TerminalColors.hoverBackground : Color.clear)
+                    .padding(.horizontal, -4)
+                    .padding(.vertical, -2)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isAPIKeyFocused ? Color.white.opacity(0.08) : Color.clear, lineWidth: 1)
+                    .padding(.horizontal, -4)
+                    .padding(.vertical, -2)
+            )
         }
         .buttonStyle(.plain)
+        .modifier(HorizontalShake(animatableData: setupLinkShakePhase))
+        .animation(.easeInOut(duration: 0.15), value: isAPIKeyFocused)
     }
 
     private var testSection: some View {
-        Button(action: testEmotionAnalysis) {
-            SettingsRowView(icon: "bolt.horizontal", title: "Test") {
-                testStatusView
+        VStack(alignment: .leading, spacing: 4) {
+            Button(action: testEmotionAnalysis) {
+                SettingsRowView(icon: "bolt.horizontal", title: "Test") {
+                    testStatusView
+                }
             }
+            .buttonStyle(.plain)
+            .disabled(isTesting || !canTest)
+
+            testDetailView
         }
-        .buttonStyle(.plain)
-        .disabled(isTesting)
     }
 
     @ViewBuilder
     private var testStatusView: some View {
         switch testState {
         case .idle:
-            Image(systemName: "play.circle")
-                .font(.system(size: 13))
-                .foregroundColor(canTest ? TerminalColors.dimmedText : TerminalColors.red)
+            if canTest {
+                Image(systemName: "play.circle")
+                    .font(.system(size: 13))
+                    .foregroundColor(TerminalColors.dimmedText)
+            } else {
+                statusBadge("Missing key", color: TerminalColors.red)
+            }
         case .testing:
             ProgressView()
                 .controlSize(.mini)
                 .frame(width: 16, height: 16)
-        case .success(let result):
-            statusBadge(testResultText(result), color: TerminalColors.green)
+        case .success:
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 13))
+                .foregroundColor(TerminalColors.green)
         case .failure(let message):
             statusBadge(message, color: TerminalColors.red)
         }
     }
 
+    @ViewBuilder
+    private var testDetailView: some View {
+        switch testState {
+        case .idle:
+            EmptyView()
+        case .testing:
+            testDetailText("Testing \(provider.displayName) with \(model.displayName)...")
+        case .success(let result):
+            testDetailText("Result: \(testResultText(result))")
+        case .failure:
+            testDetailText(canTest ? "Could not verify this configuration." : "Add an API key to test this configuration.")
+        }
+    }
+
+    private func testDetailText(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10))
+            .foregroundColor(TerminalColors.dimmedText)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.leading, 28)
+    }
+
     private var modelSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Button(action: { isModelPickerExpanded.toggle() }) {
+            Button(action: {
+                blurAPIKeyField()
+                isModelPickerExpanded.toggle()
+            }) {
                 SettingsRowView(icon: "cpu", title: "Model") {
                     HStack(spacing: 4) {
                         Text(model.displayName)
@@ -670,6 +730,7 @@ private struct EmotionAnalysisSettingsView: View {
     }
 
     private func selectProvider(_ newProvider: EmotionAnalysisProvider) {
+        blurAPIKeyField()
         guard newProvider != provider else { return }
         saveApiKey(for: provider)
         provider = newProvider
@@ -680,6 +741,8 @@ private struct EmotionAnalysisSettingsView: View {
     }
 
     private func selectModel(_ newModel: EmotionAnalysisModel) {
+        blurAPIKeyField()
+        guard newModel != model else { return }
         model = newModel
         AppSettings.setEmotionAnalysisModel(newModel, for: provider)
         resetTestState()
@@ -691,10 +754,12 @@ private struct EmotionAnalysisSettingsView: View {
     }
 
     private func openAPIKeyPage() {
+        blurAPIKeyField()
         NSWorkspace.shared.open(provider.apiKeyURL)
     }
 
     private func testEmotionAnalysis() {
+        blurAPIKeyField()
         guard !isTesting else { return }
         testState = .testing
 
@@ -730,8 +795,12 @@ private struct EmotionAnalysisSettingsView: View {
         self.provider == provider && self.model == model && apiKeyInput == apiKey
     }
 
+    private func blurAPIKeyField() {
+        isAPIKeyFocused = false
+    }
+
     private func testResultText(_ result: EmotionAnalysisTestResult) -> String {
-        "\(result.emotion.capitalized) \(String(format: "%.2f", result.intensity)) / \(result.latencyMilliseconds)ms"
+        "\(result.emotion.capitalized) \(String(format: "%.2f", result.intensity)) - \(result.latencyMilliseconds)ms"
     }
 
     private func testErrorText(_ error: Error) -> String {
@@ -764,6 +833,21 @@ private struct EmotionAnalysisSettingsView: View {
             .background(color.opacity(0.15))
             .cornerRadius(4)
             .frame(maxWidth: 160, alignment: .trailing)
+    }
+}
+
+private struct HorizontalShake: GeometryEffect {
+    var travelDistance: CGFloat = 3
+    var cyclesPerUnit: CGFloat = 1
+    var animatableData: CGFloat
+
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        ProjectionTransform(
+            CGAffineTransform(
+                translationX: travelDistance * sin(animatableData * .pi * 2 * cyclesPerUnit),
+                y: 0
+            )
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

- add provider-scoped emotion analysis settings for Claude and OpenAI
- add curated model pickers, per-provider API key storage, and API key links
- add a test action that verifies the selected provider/model/key and reports result latency
- polish the emotion analysis settings detail page with focus-aware affordances

## Validation

- ./scripts/test.sh all