### PR TITLE
Add custom notification sounds

### DIFF
--- a/notchi/Tests/NotificationSoundTests.swift
+++ b/notchi/Tests/NotificationSoundTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import notchi
+
+final class NotificationSoundTests: XCTestCase {
+    func testBuiltInDisplayOrderKeepsNoneFirstThenSortsSoundsByName() {
+        XCTAssertEqual(NotificationSound.displayOrder.first, NotificationSound.none)
+        XCTAssertEqual(NotificationSound.displayOrder.dropFirst().map(\.displayName), [
+            "Basso",
+            "Blow",
+            "Bottle",
+            "Frog",
+            "Funk",
+            "Glass",
+            "Hero",
+            "Morse",
+            "Ping",
+            "Pop",
+            "Purr",
+            "Sosumi",
+            "Submarine",
+            "Tink"
+        ])
+    }
+
+    func testDeletingSelectedCustomSoundFallsBackToDefaultSound() {
+        let id = UUID()
+
+        XCTAssertEqual(
+            NotificationSoundSelection.custom(id).fallbackIfDeletingCustomSound(id: id),
+            .defaultValue
+        )
+    }
+
+    func testDeletingDifferentCustomSoundLeavesSelectionUnchanged() {
+        let selectedID = UUID()
+        let deletedID = UUID()
+        let selection = NotificationSoundSelection.custom(selectedID)
+
+        XCTAssertEqual(selection.fallbackIfDeletingCustomSound(id: deletedID), selection)
+    }
+}

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -90,8 +90,11 @@ struct AppSettings {
     static let hideSpriteWhenIdleKey = "hideSpriteWhenIdle"
 
     private static let notificationSoundKey = "notificationSound"
+    private static let notificationSoundSelectionKey = "notificationSoundSelection"
+    private static let customNotificationSoundsKey = "customNotificationSounds"
     private static let isMutedKey = "isMuted"
     private static let previousSoundKey = "previousNotificationSound"
+    private static let previousSoundSelectionKey = "previousNotificationSoundSelection"
     private static let isUsageEnabledKey = "isUsageEnabled"
     private static let claudeUsageRecoverySnapshotKey = "claudeUsageRecoverySnapshot"
     private static let claudeExtraUsageObservationKey = "claudeExtraUsageObservation"
@@ -235,17 +238,119 @@ struct AppSettings {
         }
     }
 
-    static var notificationSound: NotificationSound {
+    static var notificationSoundSelection: NotificationSoundSelection {
         get {
+            if let data = UserDefaults.standard.data(forKey: notificationSoundSelectionKey),
+               let selection = try? JSONDecoder().decode(NotificationSoundSelection.self, from: data) {
+                return selection
+            }
+
             guard let rawValue = UserDefaults.standard.string(forKey: notificationSoundKey),
                   let sound = NotificationSound(rawValue: rawValue) else {
-                return .purr
+                return .defaultValue
             }
-            return sound
+            return .system(sound)
         }
         set {
-            UserDefaults.standard.set(newValue.rawValue, forKey: notificationSoundKey)
+            if let data = try? JSONEncoder().encode(newValue) {
+                UserDefaults.standard.set(data, forKey: notificationSoundSelectionKey)
+            }
+            if case .system(let sound) = newValue {
+                UserDefaults.standard.set(sound.rawValue, forKey: notificationSoundKey)
+            }
+            UserDefaults.standard.set(newValue == .system(.none), forKey: isMutedKey)
         }
+    }
+
+    static var customNotificationSounds: [CustomNotificationSound] {
+        get {
+            guard let data = UserDefaults.standard.data(forKey: customNotificationSoundsKey),
+                  let sounds = try? JSONDecoder().decode([CustomNotificationSound].self, from: data) else {
+                return []
+            }
+            return sounds.sorted { $0.createdAt > $1.createdAt }
+        }
+        set {
+            let newestFirst = newValue.sorted { $0.createdAt > $1.createdAt }
+            if let data = try? JSONEncoder().encode(newestFirst) {
+                UserDefaults.standard.set(data, forKey: customNotificationSoundsKey)
+            }
+        }
+    }
+
+    static func importCustomNotificationSound(from sourceURL: URL) throws -> CustomNotificationSound {
+        let directory = try customNotificationSoundsDirectory()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let displayName = sourceURL.deletingPathExtension().lastPathComponent
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let destinationFileName = uniqueCustomSoundFileName(for: sourceURL)
+        let destinationURL = directory.appendingPathComponent(destinationFileName)
+
+        try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+
+        let sound = CustomNotificationSound(
+            id: UUID(),
+            displayName: displayName.isEmpty ? sourceURL.lastPathComponent : displayName,
+            fileName: destinationFileName,
+            createdAt: Date()
+        )
+        customNotificationSounds = [sound] + customNotificationSounds
+        return sound
+    }
+
+    static func customNotificationSoundURL(for sound: CustomNotificationSound) -> URL? {
+        try? customNotificationSoundsDirectory().appendingPathComponent(sound.fileName)
+    }
+
+    static func renameCustomNotificationSound(id: UUID, displayName: String) {
+        let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        customNotificationSounds = customNotificationSounds.map { sound in
+            guard sound.id == id else { return sound }
+            var renamed = sound
+            renamed.displayName = trimmed
+            return renamed
+        }
+    }
+
+    static func deleteCustomNotificationSound(id: UUID) {
+        if let sound = customNotificationSounds.first(where: { $0.id == id }),
+           let url = customNotificationSoundURL(for: sound) {
+            try? FileManager.default.removeItem(at: url)
+        }
+
+        customNotificationSounds = customNotificationSounds.filter { $0.id != id }
+        notificationSoundSelection = notificationSoundSelection.fallbackIfDeletingCustomSound(id: id)
+        previousSoundSelection = previousSoundSelection?.fallbackIfDeletingCustomSound(id: id)
+    }
+
+    private static func customNotificationSoundsDirectory() throws -> URL {
+        let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        return applicationSupport
+            .appendingPathComponent("Notchi", isDirectory: true)
+            .appendingPathComponent("Sounds", isDirectory: true)
+    }
+
+    private static func uniqueCustomSoundFileName(for sourceURL: URL) -> String {
+        let fileExtension = sourceURL.pathExtension
+        let baseName = sourceURL.deletingPathExtension().lastPathComponent
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let safeBaseName = sanitizedFileName(baseName.isEmpty ? "sound" : baseName)
+        let id = UUID().uuidString
+
+        if fileExtension.isEmpty {
+            return "\(safeBaseName)-\(id)"
+        }
+        return "\(safeBaseName)-\(id).\(fileExtension)"
+    }
+
+    private static func sanitizedFileName(_ name: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_ ."))
+        let scalars = name.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        let sanitized = String(scalars).trimmingCharacters(in: .whitespacesAndNewlines)
+        return sanitized.isEmpty ? "sound" : sanitized
     }
 
     static var isMuted: Bool {
@@ -255,12 +360,35 @@ struct AppSettings {
 
     static func toggleMute() {
         if isMuted {
-            notificationSound = previousSound ?? .purr
+            notificationSoundSelection = previousSoundSelection ?? previousSound.map(NotificationSoundSelection.system) ?? .defaultValue
             isMuted = false
         } else {
-            previousSound = notificationSound
-            notificationSound = .none
+            previousSoundSelection = notificationSoundSelection
+            if case .system(let sound) = notificationSoundSelection {
+                previousSound = sound
+            } else {
+                previousSound = nil
+            }
+            notificationSoundSelection = .system(.none)
             isMuted = true
+        }
+    }
+
+    private static var previousSoundSelection: NotificationSoundSelection? {
+        get {
+            guard let data = UserDefaults.standard.data(forKey: previousSoundSelectionKey) else {
+                return nil
+            }
+            return try? JSONDecoder().decode(NotificationSoundSelection.self, from: data)
+        }
+        set {
+            guard let newValue else {
+                UserDefaults.standard.removeObject(forKey: previousSoundSelectionKey)
+                return
+            }
+            if let data = try? JSONEncoder().encode(newValue) {
+                UserDefaults.standard.set(data, forKey: previousSoundSelectionKey)
+            }
         }
     }
 
@@ -272,7 +400,11 @@ struct AppSettings {
             return NotificationSound(rawValue: rawValue)
         }
         set {
-            UserDefaults.standard.set(newValue?.rawValue, forKey: previousSoundKey)
+            guard let newValue else {
+                UserDefaults.standard.removeObject(forKey: previousSoundKey)
+                return
+            }
+            UserDefaults.standard.set(newValue.rawValue, forKey: previousSoundKey)
         }
     }
 }

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -279,7 +279,7 @@ struct AppSettings {
     }
 
     static func importCustomNotificationSound(from sourceURL: URL) throws -> CustomNotificationSound {
-        let directory = try customNotificationSoundsDirectory()
+        let directory = customNotificationSoundsDirectory()
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 
         let displayName = sourceURL.deletingPathExtension().lastPathComponent
@@ -299,8 +299,8 @@ struct AppSettings {
         return sound
     }
 
-    static func customNotificationSoundURL(for sound: CustomNotificationSound) -> URL? {
-        try? customNotificationSoundsDirectory().appendingPathComponent(sound.fileName)
+    static func customNotificationSoundURL(for sound: CustomNotificationSound) -> URL {
+        customNotificationSoundsDirectory().appendingPathComponent(sound.fileName)
     }
 
     static func renameCustomNotificationSound(id: UUID, displayName: String) {
@@ -316,8 +316,8 @@ struct AppSettings {
     }
 
     static func deleteCustomNotificationSound(id: UUID) {
-        if let sound = customNotificationSounds.first(where: { $0.id == id }),
-           let url = customNotificationSoundURL(for: sound) {
+        if let sound = customNotificationSounds.first(where: { $0.id == id }) {
+            let url = customNotificationSoundURL(for: sound)
             try? FileManager.default.removeItem(at: url)
         }
 
@@ -326,7 +326,7 @@ struct AppSettings {
         previousSoundSelection = previousSoundSelection?.fallbackIfDeletingCustomSound(id: id)
     }
 
-    private static func customNotificationSoundsDirectory() throws -> URL {
+    private static func customNotificationSoundsDirectory() -> URL {
         let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
         return applicationSupport
             .appendingPathComponent("Notchi", isDirectory: true)

--- a/notchi/notchi/Core/SoundSelector.swift
+++ b/notchi/notchi/Core/SoundSelector.swift
@@ -9,8 +9,8 @@ final class SoundSelector {
     private static let rowSpacing: CGFloat = 4
     private static let maxVisibleRows = 6
 
-    var expandedHeight: CGFloat {
-        let soundCount = NotificationSound.allCases.count
+    func expandedHeight(customSoundCount: Int) -> CGFloat {
+        let soundCount = 1 + customSoundCount + NotificationSound.allCases.count
         let visibleCount = min(soundCount, Self.maxVisibleRows)
         return CGFloat(visibleCount) * Self.rowHeight + CGFloat(visibleCount - 1) * Self.rowSpacing
     }

--- a/notchi/notchi/Models/NotificationSound.swift
+++ b/notchi/notchi/Models/NotificationSound.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum NotificationSound: String, CaseIterable {
+enum NotificationSound: String, CaseIterable, Codable {
     case none
     case pop
     case ping
@@ -55,5 +55,74 @@ enum NotificationSound: String, CaseIterable {
         case .submarine: return "Submarine"
         case .basso: return "Basso"
         }
+    }
+
+    static var displayOrder: [NotificationSound] {
+        [.none] + allCases
+            .filter { $0 != .none }
+            .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+    }
+}
+
+struct CustomNotificationSound: Codable, Identifiable, Hashable {
+    let id: UUID
+    var displayName: String
+    let fileName: String
+    let createdAt: Date
+}
+
+enum NotificationSoundSelection: Codable, Hashable {
+    case system(NotificationSound)
+    case custom(UUID)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case sound
+        case id
+    }
+
+    private enum SelectionType: String, Codable {
+        case system
+        case custom
+    }
+
+    static let defaultValue: NotificationSoundSelection = .system(.purr)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(SelectionType.self, forKey: .type)
+
+        switch type {
+        case .system:
+            self = .system(try container.decode(NotificationSound.self, forKey: .sound))
+        case .custom:
+            self = .custom(try container.decode(UUID.self, forKey: .id))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .system(let sound):
+            try container.encode(SelectionType.system, forKey: .type)
+            try container.encode(sound, forKey: .sound)
+        case .custom(let id):
+            try container.encode(SelectionType.custom, forKey: .type)
+            try container.encode(id, forKey: .id)
+        }
+    }
+
+    func displayName(customSounds: [CustomNotificationSound]) -> String {
+        switch self {
+        case .system(let sound):
+            sound.displayName
+        case .custom(let id):
+            customSounds.first { $0.id == id }?.displayName ?? "Custom Sound"
+        }
+    }
+
+    func fallbackIfDeletingCustomSound(id deletedID: UUID) -> NotificationSoundSelection {
+        self == .custom(deletedID) ? .defaultValue : self
     }
 }

--- a/notchi/notchi/Services/SoundService.swift
+++ b/notchi/notchi/Services/SoundService.swift
@@ -1,4 +1,5 @@
 import AppKit
+import AVFoundation
 import os.log
 
 private let logger = Logger(subsystem: "com.ruban.notchi", category: "SoundService")
@@ -11,6 +12,8 @@ final class SoundService {
     private static let cooldown: TimeInterval = 2.0
     @ObservationIgnored
     private var lastSoundTimes: [ProviderSessionKey: Date] = [:]
+    @ObservationIgnored
+    private var activeCustomPlayers: [UUID: AVAudioPlayer] = [:]
 
     private init() {}
 
@@ -20,8 +23,8 @@ final class SoundService {
             return
         }
 
-        let sound = AppSettings.notificationSound
-        guard let soundName = sound.soundName else {
+        let selection = AppSettings.notificationSoundSelection
+        guard selection != .system(.none) else {
             logger.debug("Notification sound disabled")
             return
         }
@@ -39,7 +42,7 @@ final class SoundService {
         }
 
         lastSoundTimes[sessionKey] = now
-        playSound(named: soundName)
+        playSound(selection)
     }
 
     func clearCooldown(for sessionKey: ProviderSessionKey) {
@@ -47,16 +50,59 @@ final class SoundService {
     }
 
     func previewSound(_ sound: NotificationSound) {
-        guard let soundName = sound.soundName else { return }
-        playSound(named: soundName)
+        playSound(.system(sound))
     }
 
-    private func playSound(named soundName: String) {
+    func previewSound(_ selection: NotificationSoundSelection) {
+        playSound(selection)
+    }
+
+    private func playSound(_ selection: NotificationSoundSelection) {
+        switch selection {
+        case .system(let sound):
+            guard let soundName = sound.soundName else { return }
+            playSystemSound(named: soundName)
+        case .custom(let id):
+            guard let customSound = AppSettings.customNotificationSounds.first(where: { $0.id == id }),
+                  let url = AppSettings.customNotificationSoundURL(for: customSound) else {
+                logger.warning("Custom sound not found: \(id.uuidString, privacy: .public)")
+                return
+            }
+            playCustomSound(id: id, url: url)
+        }
+    }
+
+    private func playSystemSound(named soundName: String) {
         guard let nsSound = NSSound(named: NSSound.Name(soundName)) else {
             logger.warning("Sound not found: \(soundName, privacy: .public)")
             return
         }
         nsSound.play()
         logger.debug("Playing sound: \(soundName, privacy: .public)")
+    }
+
+    private func playCustomSound(id: UUID, url: URL) {
+        do {
+            let player = try AVAudioPlayer(contentsOf: url)
+            player.prepareToPlay()
+            activeCustomPlayers[id] = player
+            player.play()
+            logger.debug("Playing custom sound: \(url.lastPathComponent, privacy: .public)")
+
+            let nanoseconds = UInt64((max(player.duration, 0.1) + 0.5) * 1_000_000_000)
+            Task { [weak self, weak player] in
+                try? await Task.sleep(nanoseconds: nanoseconds)
+                await MainActor.run {
+                    guard let self,
+                          let player,
+                          self.activeCustomPlayers[id] === player else {
+                        return
+                    }
+                    self.activeCustomPlayers[id] = nil
+                }
+            }
+        } catch {
+            logger.warning("Failed to play custom sound: \(error.localizedDescription, privacy: .public)")
+        }
     }
 }

--- a/notchi/notchi/Services/SoundService.swift
+++ b/notchi/notchi/Services/SoundService.swift
@@ -63,11 +63,11 @@ final class SoundService {
             guard let soundName = sound.soundName else { return }
             playSystemSound(named: soundName)
         case .custom(let id):
-            guard let customSound = AppSettings.customNotificationSounds.first(where: { $0.id == id }),
-                  let url = AppSettings.customNotificationSoundURL(for: customSound) else {
+            guard let customSound = AppSettings.customNotificationSounds.first(where: { $0.id == id }) else {
                 logger.warning("Custom sound not found: \(id.uuidString, privacy: .public)")
                 return
             }
+            let url = AppSettings.customNotificationSoundURL(for: customSound)
             playCustomSound(id: id, url: url)
         }
     }
@@ -85,21 +85,20 @@ final class SoundService {
         do {
             let player = try AVAudioPlayer(contentsOf: url)
             player.prepareToPlay()
-            activeCustomPlayers[id] = player
+            let playbackID = UUID()
+            activeCustomPlayers[playbackID] = player
             player.play()
             logger.debug("Playing custom sound: \(url.lastPathComponent, privacy: .public)")
 
             let nanoseconds = UInt64((max(player.duration, 0.1) + 0.5) * 1_000_000_000)
             Task { [weak self, weak player] in
                 try? await Task.sleep(nanoseconds: nanoseconds)
-                await MainActor.run {
-                    guard let self,
-                          let player,
-                          self.activeCustomPlayers[id] === player else {
-                        return
-                    }
-                    self.activeCustomPlayers[id] = nil
+                guard let self,
+                      let player,
+                      self.activeCustomPlayers[playbackID] === player else {
+                    return
                 }
+                self.activeCustomPlayers[playbackID] = nil
             }
         } catch {
             logger.warning("Failed to play custom sound: \(error.localizedDescription, privacy: .public)")

--- a/notchi/notchi/Views/Components/SoundPickerView.swift
+++ b/notchi/notchi/Views/Components/SoundPickerView.swift
@@ -1,8 +1,16 @@
+import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct SoundPickerView: View {
     @State private var selector = SoundSelector()
-    @State private var selectedSound = AppSettings.notificationSound
+    @State private var selectedSound = AppSettings.notificationSoundSelection
+    @State private var customSounds = AppSettings.customNotificationSounds
+    @State private var importErrorMessage: String?
+    @State private var editingSoundID: UUID?
+    @State private var editingSoundName = ""
+    @State private var inlineRenameEventMonitor: Any?
+    @FocusState private var focusedRenameSoundID: UUID?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -12,10 +20,27 @@ struct SoundPickerView: View {
             }
         }
         .animation(.spring(response: 0.3), value: selector.isPickerExpanded)
+        .onChange(of: focusedRenameSoundID) { _, newValue in
+            if newValue == nil {
+                commitInlineRename()
+            }
+        }
+        .onDisappear {
+            removeInlineRenameMonitor()
+        }
+        .alert("Sound Import Failed", isPresented: Binding(
+            get: { importErrorMessage != nil },
+            set: { if !$0 { importErrorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(importErrorMessage ?? "")
+        }
     }
 
     private var collapsedRow: some View {
         Button(action: {
+            commitInlineRename()
             selector.isPickerExpanded.toggle()
         }) {
             HStack {
@@ -31,7 +56,7 @@ struct SoundPickerView: View {
                 Spacer()
 
                 HStack(spacing: 4) {
-                    Text(AppSettings.isMuted ? "Muted" : selectedSound.displayName)
+                    Text(AppSettings.isMuted ? "Muted" : selectedSound.displayName(customSounds: customSounds))
                         .font(.system(size: 11))
                         .foregroundColor(TerminalColors.secondaryText)
                     Image(systemName: selector.isPickerExpanded ? "chevron.up" : "chevron.down")
@@ -48,16 +73,44 @@ struct SoundPickerView: View {
     private var expandedPicker: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 4) {
-                ForEach(NotificationSound.allCases, id: \.self) { sound in
+                addCustomSoundRow
+
+                ForEach(customSounds) { sound in
+                    customSoundRow(sound)
+                }
+
+                ForEach(NotificationSound.displayOrder, id: \.self) { sound in
                     soundRow(sound)
                 }
             }
             .padding(.vertical, SettingsLayout.pickerInset)
         }
-        .frame(height: selector.expandedHeight)
+        .frame(height: selector.expandedHeight(customSoundCount: customSounds.count))
         .background(TerminalColors.subtleBackground)
         .cornerRadius(8)
         .padding(.top, SettingsLayout.pickerInset)
+    }
+
+    private var addCustomSoundRow: some View {
+        Button(action: addCustomSound) {
+            HStack {
+                Image(systemName: "plus")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(TerminalColors.green)
+                    .frame(width: 6, height: 6)
+
+                Text("Add")
+                    .font(.system(size: 11))
+                    .foregroundColor(TerminalColors.primaryText)
+
+                Spacer()
+            }
+            .padding(.horizontal, SettingsLayout.pickerOptionHorizontalPadding)
+            .padding(.vertical, SettingsLayout.pickerOptionVerticalPadding)
+            .contentShape(Rectangle())
+            .cornerRadius(4)
+        }
+        .buttonStyle(.plain)
     }
 
     private func soundRow(_ sound: NotificationSound) -> some View {
@@ -66,12 +119,12 @@ struct SoundPickerView: View {
         }) {
             HStack {
                 Circle()
-                    .fill(selectedSound == sound ? TerminalColors.green : Color.clear)
+                    .fill(selectedSound == .system(sound) ? TerminalColors.green : Color.clear)
                     .frame(width: 6, height: 6)
 
                 Text(sound.displayName)
                     .font(.system(size: 11))
-                    .foregroundColor(selectedSound == sound ? TerminalColors.primaryText : TerminalColors.secondaryText)
+                    .foregroundColor(selectedSound == .system(sound) ? TerminalColors.primaryText : TerminalColors.secondaryText)
 
                 Spacer()
 
@@ -83,17 +136,231 @@ struct SoundPickerView: View {
             }
             .padding(.horizontal, SettingsLayout.pickerOptionHorizontalPadding)
             .padding(.vertical, SettingsLayout.pickerOptionVerticalPadding)
-            .background(selectedSound == sound ? TerminalColors.hoverBackground : Color.clear)
+            .background(selectedSound == .system(sound) ? TerminalColors.hoverBackground : Color.clear)
             .contentShape(Rectangle())
             .cornerRadius(4)
         }
         .buttonStyle(.plain)
     }
 
+    private func customSoundRow(_ sound: CustomNotificationSound) -> some View {
+        HStack(spacing: 8) {
+            if editingSoundID == sound.id {
+                HStack {
+                    Circle()
+                        .fill(selectedSound == .custom(sound.id) ? TerminalColors.green : Color.clear)
+                        .frame(width: 6, height: 6)
+
+                    TextField("", text: $editingSoundName)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 11))
+                        .foregroundColor(TerminalColors.primaryText)
+                        .accessibilityIdentifier(renameAccessibilityIdentifier(for: sound.id))
+                        .focused($focusedRenameSoundID, equals: sound.id)
+                        .onSubmit {
+                            commitInlineRename()
+                        }
+                        .onExitCommand {
+                            cancelInlineRename()
+                        }
+
+                    Spacer()
+                }
+            } else {
+                Button(action: {
+                    selectCustomSound(sound)
+                }) {
+                    HStack {
+                        Circle()
+                            .fill(selectedSound == .custom(sound.id) ? TerminalColors.green : Color.clear)
+                            .frame(width: 6, height: 6)
+
+                        Text(sound.displayName)
+                            .font(.system(size: 11))
+                            .lineLimit(1)
+                            .foregroundColor(selectedSound == .custom(sound.id) ? TerminalColors.primaryText : TerminalColors.secondaryText)
+
+                        Spacer()
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+
+            Button(action: {
+                beginInlineRename(sound)
+            }) {
+                Image(systemName: "pencil")
+                    .font(.system(size: 9))
+                    .foregroundColor(TerminalColors.dimmedText)
+                    .frame(width: 16, height: 16)
+            }
+            .buttonStyle(.plain)
+
+            Button(action: {
+                deleteCustomSound(sound)
+            }) {
+                Image(systemName: "trash")
+                    .font(.system(size: 9))
+                    .foregroundColor(TerminalColors.dimmedText)
+                    .frame(width: 16, height: 16)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, SettingsLayout.pickerOptionHorizontalPadding)
+        .padding(.vertical, SettingsLayout.pickerOptionVerticalPadding)
+        .background(selectedSound == .custom(sound.id) ? TerminalColors.hoverBackground : Color.clear)
+        .contentShape(Rectangle())
+        .cornerRadius(4)
+    }
+
     private func selectSound(_ sound: NotificationSound) {
-        selectedSound = sound
-        AppSettings.notificationSound = sound
-        SoundService.shared.previewSound(sound)
+        commitInlineRename()
+        selectedSound = .system(sound)
+        AppSettings.notificationSoundSelection = selectedSound
+        SoundService.shared.previewSound(selectedSound)
+    }
+
+    private func selectCustomSound(_ sound: CustomNotificationSound) {
+        commitInlineRename()
+        selectedSound = .custom(sound.id)
+        AppSettings.notificationSoundSelection = selectedSound
+        SoundService.shared.previewSound(selectedSound)
+    }
+
+    private func addCustomSound() {
+        commitInlineRename()
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [.audio]
+
+        guard panel.runModal() == .OK,
+              let url = panel.url else {
+            return
+        }
+
+        let isAccessing = url.startAccessingSecurityScopedResource()
+        defer {
+            if isAccessing {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        do {
+            let sound = try AppSettings.importCustomNotificationSound(from: url)
+            refreshCustomSounds()
+            selectCustomSound(sound)
+        } catch {
+            importErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func beginInlineRename(_ sound: CustomNotificationSound) {
+        if editingSoundID == sound.id {
+            focusedRenameSoundID = sound.id
+            return
+        }
+        commitInlineRename()
+        editingSoundID = sound.id
+        editingSoundName = sound.displayName
+        installInlineRenameMonitor()
+        Task { @MainActor in
+            focusedRenameSoundID = sound.id
+        }
+    }
+
+    private func commitInlineRename() {
+        guard let editingSoundID else { return }
+        AppSettings.renameCustomNotificationSound(id: editingSoundID, displayName: editingSoundName)
+        refreshCustomSounds()
+        self.editingSoundID = nil
+        editingSoundName = ""
+        focusedRenameSoundID = nil
+        removeInlineRenameMonitor()
+    }
+
+    private func cancelInlineRename() {
+        editingSoundID = nil
+        editingSoundName = ""
+        focusedRenameSoundID = nil
+        removeInlineRenameMonitor()
+    }
+
+    private func installInlineRenameMonitor() {
+        removeInlineRenameMonitor()
+        inlineRenameEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { event in
+            Task { @MainActor in
+                handleInlineRenameMouseDown(event)
+            }
+            return event
+        }
+    }
+
+    private func removeInlineRenameMonitor() {
+        guard let inlineRenameEventMonitor else { return }
+        NSEvent.removeMonitor(inlineRenameEventMonitor)
+        self.inlineRenameEventMonitor = nil
+    }
+
+    private func handleInlineRenameMouseDown(_ event: NSEvent) {
+        guard let editingSoundID else { return }
+        guard let hitView = event.window?.contentView?.hitTest(event.locationInWindow) else {
+            commitInlineRename()
+            return
+        }
+
+        if viewTreeContainsTextField(hitView) {
+            return
+        }
+
+        if viewTreeContainsAccessibilityIdentifier(hitView, renameAccessibilityIdentifier(for: editingSoundID)) {
+            return
+        }
+
+        commitInlineRename()
+    }
+
+    private func renameAccessibilityIdentifier(for id: UUID) -> String {
+        "custom-sound-rename-\(id.uuidString)"
+    }
+
+    private func viewTreeContainsTextField(_ view: NSView) -> Bool {
+        var currentView: NSView? = view
+        while let view = currentView {
+            if view is NSTextField {
+                return true
+            }
+            currentView = view.superview
+        }
+        return false
+    }
+
+    private func viewTreeContainsAccessibilityIdentifier(_ view: NSView, _ identifier: String) -> Bool {
+        var currentView: NSView? = view
+        while let view = currentView {
+            if view.accessibilityIdentifier() == identifier {
+                return true
+            }
+            currentView = view.superview
+        }
+        return false
+    }
+
+    private func deleteCustomSound(_ sound: CustomNotificationSound) {
+        if editingSoundID == sound.id {
+            cancelInlineRename()
+        } else {
+            commitInlineRename()
+        }
+        AppSettings.deleteCustomNotificationSound(id: sound.id)
+        refreshCustomSounds()
+        selectedSound = AppSettings.notificationSoundSelection
+    }
+
+    private func refreshCustomSounds() {
+        customSounds = AppSettings.customNotificationSounds
     }
 }
 


### PR DESCRIPTION
## Summary

Adds custom notification sound support for issue #54.

- Adds an `Add` row to the notification sound picker for importing audio files.
- Copies imported files into `Application Support/Notchi/Sounds` so they continue working if the original file moves.
- Persists custom sound metadata and selected sound state, including migration from the legacy built-in sound setting.
- Plays custom sounds through `AVAudioPlayer`, while keeping built-in macOS sounds on `NSSound`.
- Shows custom sounds newest-first with inline rename and delete controls.
- Falls back to Purr when the selected custom sound is deleted.

## Validation

- `./scripts/test.sh focused`
- `./scripts/test.sh all`