### PR TITLE
Add terminal jump support for agent sessions

### DIFF
--- a/notchi/Tests/AgentProviderAdapterTests.swift
+++ b/notchi/Tests/AgentProviderAdapterTests.swift
@@ -28,6 +28,7 @@ final class AgentProviderAdapterTests: XCTestCase {
             "cwd": "/tmp",
             "event": "SessionStart",
             "status": "waiting_for_input",
+            "claude_process_id": 12345,
         ])
         let envelope = try JSONDecoder().decode(AgentHookEnvelope.self, from: data)
 
@@ -36,6 +37,7 @@ final class AgentProviderAdapterTests: XCTestCase {
         XCTAssertEqual(event?.provider, .claude)
         XCTAssertEqual(event?.event, .sessionStarted)
         XCTAssertEqual(event?.sessionId, "claude:claude-session")
+        XCTAssertEqual(event?.claudeProcessId, 12345)
     }
 
     func testCodexAdapterNormalizesSupportedEnvelopeIntoHookEvent() throws {

--- a/notchi/Tests/TerminalJumpServiceTests.swift
+++ b/notchi/Tests/TerminalJumpServiceTests.swift
@@ -7,25 +7,176 @@ final class TerminalJumpServiceTests: XCTestCase {
         let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
         session.updateCodexRuntime(processId: 123, origin: .desktop)
         var openedURLs: [URL] = []
-        let service = TerminalJumpService { url in
-            openedURLs.append(url)
-            return true
-        }
+        var activatedProcessIds: [pid_t] = []
+        let service = makeService(
+            openURL: { url in
+                openedURLs.append(url)
+                return true
+            },
+            activateProcess: { processId in
+                activatedProcessIds.append(processId)
+                return true
+            }
+        )
 
         let didJump = service.jump(to: session)
 
         XCTAssertTrue(didJump)
         XCTAssertEqual(openedURLs.map(\.absoluteString), ["codex://threads/thread-123"])
+        XCTAssertTrue(activatedProcessIds.isEmpty)
+    }
+
+    func testCodexCLISessionActivatesHostingTerminalApp() {
+        let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
+        session.updateCodexRuntime(processId: 30, origin: .cli)
+        var openedURLs: [URL] = []
+        var activatedProcessIds: [pid_t] = []
+        let service = makeService(
+            openURL: { url in
+                openedURLs.append(url)
+                return true
+            },
+            processSnapshot: { processId in
+                self.makeSnapshot(parentProcessId: [pid_t(30): pid_t(20), pid_t(20): pid_t(10), pid_t(10): pid_t(1)][processId])
+            },
+            bundleIdentifierForProcess: { processId in
+                [pid_t(10): "com.apple.Terminal"][processId]
+            },
+            activateProcess: { processId in
+                activatedProcessIds.append(processId)
+                return true
+            }
+        )
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertTrue(didJump)
+        XCTAssertTrue(openedURLs.isEmpty)
+        XCTAssertEqual(activatedProcessIds, [10])
+    }
+
+    func testCodexCLISessionDoesNotActivateNonTerminalAncestor() {
+        let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
+        session.updateCodexRuntime(processId: 30, origin: .cli)
+        var activatedProcessIds: [pid_t] = []
+        let service = makeService(
+            processSnapshot: { processId in
+                self.makeSnapshot(parentProcessId: [pid_t(30): pid_t(20), pid_t(20): pid_t(10), pid_t(10): pid_t(1)][processId])
+            },
+            bundleIdentifierForProcess: { processId in
+                [pid_t(10): "com.apple.finder"][processId]
+            },
+            activateProcess: { processId in
+                activatedProcessIds.append(processId)
+                return true
+            }
+        )
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertFalse(didJump)
+        XCTAssertTrue(activatedProcessIds.isEmpty)
+    }
+
+    func testCodexCLISessionWithoutProcessIdDoesNotJump() {
+        let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
+        session.updateCodexRuntime(processId: nil, origin: .cli)
+        var activatedProcessIds: [pid_t] = []
+        let service = makeService { processId in
+            activatedProcessIds.append(processId)
+            return true
+        }
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertFalse(didJump)
+        XCTAssertTrue(activatedProcessIds.isEmpty)
+    }
+
+    func testCodexCLISessionWithStaleProcessIdDoesNotJump() {
+        let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
+        session.updateCodexRuntime(processId: 30, origin: .cli)
+        var activatedProcessIds: [pid_t] = []
+        let service = makeService(
+            processSnapshot: { _ in nil },
+            activateProcess: { processId in
+                activatedProcessIds.append(processId)
+                return true
+            }
+        )
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertFalse(didJump)
+        XCTAssertTrue(activatedProcessIds.isEmpty)
+    }
+
+    func testCodexCLISessionStopsOnAncestorCycle() {
+        let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
+        session.updateCodexRuntime(processId: 30, origin: .cli)
+        var activatedProcessIds: [pid_t] = []
+        let service = makeService(
+            processSnapshot: { processId in
+                self.makeSnapshot(parentProcessId: [pid_t(30): pid_t(20), pid_t(20): pid_t(30)][processId])
+            },
+            bundleIdentifierForProcess: { _ in nil },
+            activateProcess: { processId in
+                activatedProcessIds.append(processId)
+                return true
+            }
+        )
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertFalse(didJump)
+        XCTAssertTrue(activatedProcessIds.isEmpty)
+    }
+
+    func testCodexCLISessionStopsAfterAncestryDepthLimit() {
+        let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
+        session.updateCodexRuntime(processId: 30, origin: .cli)
+        var activatedProcessIds: [pid_t] = []
+        let service = makeService(
+            processSnapshot: { processId in
+                self.makeSnapshot(parentProcessId: processId + 1)
+            },
+            bundleIdentifierForProcess: { processId in
+                processId == 60 ? "com.apple.Terminal" : nil
+            },
+            activateProcess: { processId in
+                activatedProcessIds.append(processId)
+                return true
+            }
+        )
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertFalse(didJump)
+        XCTAssertTrue(activatedProcessIds.isEmpty)
     }
 
     func testNonDesktopCodexSessionDoesNotOpenURL() {
         let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
         session.updateCodexRuntime(processId: 123, origin: .cli)
         var openedURLs: [URL] = []
-        let service = TerminalJumpService { url in
+        let service = makeService(openURL: { url in
             openedURLs.append(url)
             return true
-        }
+        })
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertFalse(didJump)
+        XCTAssertTrue(openedURLs.isEmpty)
+    }
+
+    func testCodexSessionWithoutOriginDoesNotJump() {
+        let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
+        var openedURLs: [URL] = []
+        let service = makeService(openURL: { url in
+            openedURLs.append(url)
+            return true
+        })
 
         let didJump = service.jump(to: session)
 
@@ -36,10 +187,10 @@ final class TerminalJumpServiceTests: XCTestCase {
     func testClaudeSessionDoesNotOpenURL() {
         let session = SessionData(sessionId: "thread-123", provider: .claude, cwd: "/tmp/project")
         var openedURLs: [URL] = []
-        let service = TerminalJumpService { url in
+        let service = makeService(openURL: { url in
             openedURLs.append(url)
             return true
-        }
+        })
 
         let didJump = service.jump(to: session)
 
@@ -56,5 +207,34 @@ final class TerminalJumpServiceTests: XCTestCase {
     func testThreadURLReturnsNilForBlankThreadId() {
         XCTAssertNil(TerminalJumpService.codexDesktopThreadURL(threadId: ""))
         XCTAssertNil(TerminalJumpService.codexDesktopThreadURL(threadId: "   "))
+    }
+
+    private func makeService(
+        openURL: @escaping (URL) -> Bool = { _ in true },
+        processSnapshot: @escaping @MainActor (pid_t) -> TerminalJumpService.ProcessSnapshot? = { _ in nil },
+        bundleIdentifierForProcess: @escaping @MainActor (pid_t) -> String? = { _ in nil },
+        activateProcess: @escaping @MainActor (pid_t) -> Bool = { _ in true }
+    ) -> TerminalJumpService {
+        TerminalJumpService(
+            openURL: openURL,
+            processSnapshot: processSnapshot,
+            bundleIdentifierForProcess: bundleIdentifierForProcess,
+            activateProcess: activateProcess
+        )
+    }
+
+    private func makeService(activateProcess: @escaping @MainActor (pid_t) -> Bool) -> TerminalJumpService {
+        makeService(
+            openURL: { _ in true },
+            processSnapshot: { _ in nil },
+            bundleIdentifierForProcess: { _ in nil },
+            activateProcess: activateProcess
+        )
+    }
+
+    private func makeSnapshot(parentProcessId: pid_t?) -> TerminalJumpService.ProcessSnapshot? {
+        guard let parentProcessId else { return nil }
+
+        return TerminalJumpService.ProcessSnapshot(parentProcessId: parentProcessId)
     }
 }

--- a/notchi/Tests/TerminalJumpServiceTests.swift
+++ b/notchi/Tests/TerminalJumpServiceTests.swift
@@ -36,12 +36,33 @@ final class TerminalJumpServiceTests: XCTestCase {
                 openedURLs.append(url)
                 return true
             },
-            processSnapshot: { processId in
-                self.makeSnapshot(parentProcessId: [pid_t(30): pid_t(20), pid_t(20): pid_t(10), pid_t(10): pid_t(1)][processId])
+            processSnapshot: { self.makeSnapshot(parentProcessId: Self.terminalAncestry[$0]) },
+            bundleIdentifierForProcess: { Self.terminalBundles[$0] },
+            activateProcess: { processId in
+                activatedProcessIds.append(processId)
+                return true
+            }
+        )
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertTrue(didJump)
+        XCTAssertTrue(openedURLs.isEmpty)
+        XCTAssertEqual(activatedProcessIds, [10])
+    }
+
+    func testClaudeCLISessionActivatesHostingTerminalApp() {
+        let session = SessionData(sessionId: "claude-session", provider: .claude, cwd: "/tmp/project")
+        session.updateClaudeRuntime(processId: 30)
+        var openedURLs: [URL] = []
+        var activatedProcessIds: [pid_t] = []
+        let service = makeService(
+            openURL: { url in
+                openedURLs.append(url)
+                return true
             },
-            bundleIdentifierForProcess: { processId in
-                [pid_t(10): "com.apple.Terminal"][processId]
-            },
+            processSnapshot: { self.makeSnapshot(parentProcessId: Self.terminalAncestry[$0]) },
+            bundleIdentifierForProcess: { Self.terminalBundles[$0] },
             activateProcess: { processId in
                 activatedProcessIds.append(processId)
                 return true
@@ -60,9 +81,7 @@ final class TerminalJumpServiceTests: XCTestCase {
         session.updateCodexRuntime(processId: 30, origin: .cli)
         var activatedProcessIds: [pid_t] = []
         let service = makeService(
-            processSnapshot: { processId in
-                self.makeSnapshot(parentProcessId: [pid_t(30): pid_t(20), pid_t(20): pid_t(10), pid_t(10): pid_t(1)][processId])
-            },
+            processSnapshot: { self.makeSnapshot(parentProcessId: Self.terminalAncestry[$0]) },
             bundleIdentifierForProcess: { processId in
                 [pid_t(10): "com.apple.finder"][processId]
             },
@@ -237,4 +256,7 @@ final class TerminalJumpServiceTests: XCTestCase {
 
         return TerminalJumpService.ProcessSnapshot(parentProcessId: parentProcessId)
     }
+
+    private static let terminalAncestry: [pid_t: pid_t] = [30: 20, 20: 10, 10: 1]
+    private static let terminalBundles: [pid_t: String] = [10: "com.apple.Terminal"]
 }

--- a/notchi/Tests/TerminalJumpServiceTests.swift
+++ b/notchi/Tests/TerminalJumpServiceTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import notchi
+
+@MainActor
+final class TerminalJumpServiceTests: XCTestCase {
+    func testCodexDesktopSessionOpensThreadURL() {
+        let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
+        session.updateCodexRuntime(processId: 123, origin: .desktop)
+        var openedURLs: [URL] = []
+        let service = TerminalJumpService { url in
+            openedURLs.append(url)
+            return true
+        }
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertTrue(didJump)
+        XCTAssertEqual(openedURLs.map(\.absoluteString), ["codex://threads/thread-123"])
+    }
+
+    func testNonDesktopCodexSessionDoesNotOpenURL() {
+        let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
+        session.updateCodexRuntime(processId: 123, origin: .cli)
+        var openedURLs: [URL] = []
+        let service = TerminalJumpService { url in
+            openedURLs.append(url)
+            return true
+        }
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertFalse(didJump)
+        XCTAssertTrue(openedURLs.isEmpty)
+    }
+
+    func testClaudeSessionDoesNotOpenURL() {
+        let session = SessionData(sessionId: "thread-123", provider: .claude, cwd: "/tmp/project")
+        var openedURLs: [URL] = []
+        let service = TerminalJumpService { url in
+            openedURLs.append(url)
+            return true
+        }
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertFalse(didJump)
+        XCTAssertTrue(openedURLs.isEmpty)
+    }
+
+    func testThreadURLPercentEncodesPathUnsafeCharacters() {
+        let url = TerminalJumpService.codexDesktopThreadURL(threadId: " thread/with space ")
+
+        XCTAssertEqual(url?.absoluteString, "codex://threads/thread%2Fwith%20space")
+    }
+
+    func testThreadURLReturnsNilForBlankThreadId() {
+        XCTAssertNil(TerminalJumpService.codexDesktopThreadURL(threadId: ""))
+        XCTAssertNil(TerminalJumpService.codexDesktopThreadURL(threadId: "   "))
+    }
+}

--- a/notchi/notchi/Models/HookEvent.swift
+++ b/notchi/notchi/Models/HookEvent.swift
@@ -47,6 +47,7 @@ struct AgentHookEnvelope: Decodable, Sendable {
     let userPrompt: String?
     let permissionMode: String?
     let interactive: Bool?
+    let claudeProcessId: Int?
     let codexProcessId: Int?
     let codexOrigin: CodexOrigin?
     let hasAttachments: Bool?
@@ -61,6 +62,7 @@ struct AgentHookEnvelope: Decodable, Sendable {
         case userPrompt = "user_prompt"
         case permissionMode = "permission_mode"
         case interactive
+        case claudeProcessId = "claude_process_id"
         case codexProcessId = "codex_process_id"
         case codexOrigin = "codex_origin"
         case hasAttachments = "has_attachments"
@@ -81,6 +83,7 @@ struct AgentHookEnvelope: Decodable, Sendable {
         userPrompt = try container.decodeIfPresent(String.self, forKey: .userPrompt)
         permissionMode = try container.decodeIfPresent(String.self, forKey: .permissionMode)
         interactive = try container.decodeIfPresent(Bool.self, forKey: .interactive)
+        claudeProcessId = try container.decodeIfPresent(Int.self, forKey: .claudeProcessId)
         codexProcessId = try container.decodeIfPresent(Int.self, forKey: .codexProcessId)
         codexOrigin = try container.decodeIfPresent(CodexOrigin.self, forKey: .codexOrigin)
         hasAttachments = try container.decodeIfPresent(Bool.self, forKey: .hasAttachments)
@@ -101,6 +104,7 @@ struct HookEvent: Sendable {
     let userPromptHasAttachments: Bool
     let permissionMode: String?
     let interactive: Bool?
+    let claudeProcessId: Int?
     let codexProcessId: Int?
     let codexOrigin: CodexOrigin?
 
@@ -126,6 +130,7 @@ struct HookEvent: Sendable {
         userPromptHasAttachments: Bool = false,
         permissionMode: String? = nil,
         interactive: Bool? = nil,
+        claudeProcessId: Int? = nil,
         codexProcessId: Int? = nil,
         codexOrigin: CodexOrigin? = nil
     ) {
@@ -142,6 +147,7 @@ struct HookEvent: Sendable {
         self.userPromptHasAttachments = userPromptHasAttachments
         self.permissionMode = permissionMode
         self.interactive = interactive
+        self.claudeProcessId = claudeProcessId
         self.codexProcessId = codexProcessId
         self.codexOrigin = codexOrigin
     }

--- a/notchi/notchi/Models/SessionData.swift
+++ b/notchi/notchi/Models/SessionData.swift
@@ -33,6 +33,7 @@ final class SessionData: Identifiable {
     private(set) var permissionMode: String = "default"
     private(set) var pendingQuestions: [PendingQuestion] = []
     private(set) var currentSpinnerVerb: String
+    private(set) var claudeProcessId: Int?
     private(set) var codexProcessId: Int?
     private(set) var codexOrigin: CodexOrigin?
     private(set) var codexTitle: String?
@@ -74,6 +75,10 @@ final class SessionData: Identifiable {
 
     var isCodexCLIProcessBacked: Bool {
         provider == .codex && codexOrigin == .cli && codexProcessId != nil
+    }
+
+    var isClaudeProcessBacked: Bool {
+        provider == .claude && claudeProcessId != nil
     }
 
     var isCodexThreadBacked: Bool {
@@ -226,6 +231,14 @@ final class SessionData: Identifiable {
 
     func updatePermissionMode(_ mode: String) {
         permissionMode = mode
+    }
+
+    func updateClaudeRuntime(processId: Int?) {
+        guard provider == .claude,
+              let processId,
+              processId > 0 else { return }
+
+        claudeProcessId = processId
     }
 
     func updateCodexRuntime(processId: Int?, origin: CodexOrigin?) {

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -486,7 +486,9 @@ struct NotchContentView: View {
             haptics.playSessionSelection()
         }
 
-        sessionStore.selectSession(matchingStableId: sessionId)
+        if let session = sessionStore.selectSession(matchingStableId: sessionId) {
+            TerminalJumpService.shared.jump(to: session)
+        }
         showingSessionActivity = true
     }
 

--- a/notchi/notchi/Resources/notchi-hook.sh
+++ b/notchi/notchi/Resources/notchi-hook.sh
@@ -21,6 +21,7 @@ export NOTCHI_INTERACTIVE=$IS_INTERACTIVE
 import json
 import os
 import socket
+import subprocess
 import sys
 
 try:
@@ -54,6 +55,61 @@ output = {
     'interactive': os.environ.get('NOTCHI_INTERACTIVE', 'true') == 'true',
     'permission_mode': input_data.get('permission_mode', 'default')
 }
+
+def process_table():
+    try:
+        ps_output = subprocess.check_output(
+            ['/bin/ps', '-axo', 'pid=,ppid=,command='],
+            text=True,
+            timeout=0.5,
+        )
+    except Exception:
+        return {}
+
+    table = {}
+    for line in ps_output.splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3 or not parts[0].isdigit() or not parts[1].isdigit():
+            continue
+
+        tokens = parts[2].split()
+        argv0 = os.path.basename(tokens[0]).lower() if tokens else ''
+        table[int(parts[0])] = {
+            'ppid': int(parts[1]),
+            'argv0': argv0,
+        }
+
+    return table
+
+def claude_process_id():
+    processes = process_table()
+    pid = os.getppid()
+    visited = set()
+
+    for _ in range(8):
+        if pid in visited:
+            break
+
+        visited.add(pid)
+        info = processes.get(pid)
+        if info is None:
+            break
+
+        argv0 = info['argv0']
+        if argv0 == 'claude' or argv0.startswith('claude-'):
+            return pid
+
+        if info['ppid'] <= 1 or info['ppid'] == pid:
+            break
+
+        pid = info['ppid']
+
+    return None
+
+if hook_event in ('SessionStart', 'UserPromptSubmit'):
+    process_id = claude_process_id()
+    if process_id:
+        output['claude_process_id'] = process_id
 
 # Pass user prompt directly for UserPromptSubmit
 if hook_event == 'UserPromptSubmit':

--- a/notchi/notchi/Resources/notchi-hook.sh
+++ b/notchi/notchi/Resources/notchi-hook.sh
@@ -96,7 +96,7 @@ def claude_process_id():
             break
 
         argv0 = info['argv0']
-        if argv0 == 'claude' or argv0.startswith('claude-'):
+        if argv0 in ('claude', 'claude-code'):
             return pid
 
         if info['ppid'] <= 1 or info['ppid'] == pid:

--- a/notchi/notchi/Services/ClaudeProviderAdapter.swift
+++ b/notchi/notchi/Services/ClaudeProviderAdapter.swift
@@ -39,7 +39,8 @@ struct ClaudeProviderAdapter: AgentProviderAdapter {
             toolUseId: envelope.toolUseId,
             userPrompt: envelope.userPrompt,
             permissionMode: envelope.permissionMode,
-            interactive: envelope.interactive
+            interactive: envelope.interactive,
+            claudeProcessId: envelope.claudeProcessId
         )
     }
 }

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -58,9 +58,11 @@ final class SessionStore {
         selectedSessionKey = sessionKey
     }
 
-    func selectSession(matchingStableId stableId: String) {
-        guard let sessionKey = ProviderSessionKey(stableId: stableId) else { return }
+    @discardableResult
+    func selectSession(matchingStableId stableId: String) -> SessionData? {
+        guard let sessionKey = ProviderSessionKey(stableId: stableId) else { return nil }
         selectSession(sessionKey)
+        return sessions[sessionKey]
     }
 
     func clearSelectedSession() {

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -88,6 +88,7 @@ final class SessionStore {
             session.updatePermissionMode(mode)
         }
 
+        session.updateClaudeRuntime(processId: event.claudeProcessId)
         session.updateCodexRuntime(processId: event.codexProcessId, origin: event.codexOrigin)
         if event.provider == .codex, let transcriptPath = event.transcriptPath {
             session.updateCodexThreadMetadata(

--- a/notchi/notchi/Services/TerminalFocusDetector.swift
+++ b/notchi/notchi/Services/TerminalFocusDetector.swift
@@ -1,7 +1,8 @@
 import AppKit
 
 struct TerminalFocusDetector {
-    private static let terminalBundleIds: Set<String> = [
+    // Keep focus detection and terminal jump targeting on the same supported app list.
+    static let terminalBundleIds: Set<String> = [
         "com.apple.Terminal",
         "com.googlecode.iterm2",
         "dev.warp.Warp-Stable",

--- a/notchi/notchi/Services/TerminalJumpService.swift
+++ b/notchi/notchi/Services/TerminalJumpService.swift
@@ -1,0 +1,45 @@
+import AppKit
+
+@MainActor
+struct TerminalJumpService {
+    static let shared = TerminalJumpService()
+
+    private let openURL: (URL) -> Bool
+
+    init(openURL: @escaping (URL) -> Bool = { NSWorkspace.shared.open($0) }) {
+        self.openURL = openURL
+    }
+
+    @discardableResult
+    func jump(to session: SessionData) -> Bool {
+        guard let url = Self.codexDesktopThreadURL(for: session) else {
+            return false
+        }
+
+        return openURL(url)
+    }
+
+    static func codexDesktopThreadURL(for session: SessionData) -> URL? {
+        guard session.provider == .codex, session.codexOrigin == .desktop else {
+            return nil
+        }
+
+        return codexDesktopThreadURL(threadId: session.rawSessionId)
+    }
+
+    nonisolated static func codexDesktopThreadURL(threadId: String) -> URL? {
+        let trimmedThreadId = threadId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedThreadId.isEmpty,
+              let encodedThreadId = trimmedThreadId.addingPercentEncoding(withAllowedCharacters: threadIDAllowedCharacters) else {
+            return nil
+        }
+
+        return URL(string: "codex://threads/\(encodedThreadId)")
+    }
+
+    private nonisolated static let threadIDAllowedCharacters: CharacterSet = {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/?#[]@!$&'()*+,;=")
+        return allowed
+    }()
+}

--- a/notchi/notchi/Services/TerminalJumpService.swift
+++ b/notchi/notchi/Services/TerminalJumpService.swift
@@ -1,22 +1,43 @@
 import AppKit
+import Darwin
 
 @MainActor
 struct TerminalJumpService {
+    struct ProcessSnapshot {
+        let parentProcessId: pid_t
+    }
+
     static let shared = TerminalJumpService()
 
     private let openURL: (URL) -> Bool
+    private let processSnapshot: @MainActor (pid_t) -> ProcessSnapshot?
+    private let bundleIdentifierForProcess: @MainActor (pid_t) -> String?
+    private let activateProcess: @MainActor (pid_t) -> Bool
 
-    init(openURL: @escaping (URL) -> Bool = { NSWorkspace.shared.open($0) }) {
+    init(
+        openURL: @escaping (URL) -> Bool = { NSWorkspace.shared.open($0) },
+        processSnapshot: @escaping @MainActor (pid_t) -> ProcessSnapshot? = Self.defaultProcessSnapshot,
+        bundleIdentifierForProcess: @escaping @MainActor (pid_t) -> String? = Self.defaultBundleIdentifier,
+        activateProcess: @escaping @MainActor (pid_t) -> Bool = Self.defaultActivateProcess
+    ) {
         self.openURL = openURL
+        self.processSnapshot = processSnapshot
+        self.bundleIdentifierForProcess = bundleIdentifierForProcess
+        self.activateProcess = activateProcess
     }
 
     @discardableResult
     func jump(to session: SessionData) -> Bool {
-        guard let url = Self.codexDesktopThreadURL(for: session) else {
-            return false
+        if let url = Self.codexDesktopThreadURL(for: session) {
+            return openURL(url)
         }
 
-        return openURL(url)
+        if let processId = Self.codexCLIProcessId(for: session),
+           let terminalProcessId = terminalProcessID(hosting: processId) {
+            return activateProcess(terminalProcessId)
+        }
+
+        return false
     }
 
     static func codexDesktopThreadURL(for session: SessionData) -> URL? {
@@ -25,6 +46,17 @@ struct TerminalJumpService {
         }
 
         return codexDesktopThreadURL(threadId: session.rawSessionId)
+    }
+
+    static func codexCLIProcessId(for session: SessionData) -> pid_t? {
+        guard session.provider == .codex,
+              session.codexOrigin == .cli,
+              let processId = session.codexProcessId,
+              processId > 0 else {
+            return nil
+        }
+
+        return pid_t(processId)
     }
 
     nonisolated static func codexDesktopThreadURL(threadId: String) -> URL? {
@@ -37,9 +69,66 @@ struct TerminalJumpService {
         return URL(string: "codex://threads/\(encodedThreadId)")
     }
 
+    private func terminalProcessID(hosting processId: pid_t) -> pid_t? {
+        var currentProcessId = processId
+        var visitedProcessIds = Set<pid_t>()
+
+        for _ in 0..<Self.maxProcessAncestryDepth {
+            guard currentProcessId > 1, !visitedProcessIds.contains(currentProcessId) else {
+                return nil
+            }
+
+            visitedProcessIds.insert(currentProcessId)
+
+            guard let snapshot = processSnapshot(currentProcessId) else {
+                return nil
+            }
+
+            if let bundleIdentifier = bundleIdentifierForProcess(currentProcessId),
+               TerminalFocusDetector.terminalBundleIds.contains(bundleIdentifier) {
+                return currentProcessId
+            }
+
+            guard snapshot.parentProcessId > 0 else {
+                return nil
+            }
+
+            currentProcessId = snapshot.parentProcessId
+        }
+
+        return nil
+    }
+
     private nonisolated static let threadIDAllowedCharacters: CharacterSet = {
         var allowed = CharacterSet.urlPathAllowed
         allowed.remove(charactersIn: "/?#[]@!$&'()*+,;=")
         return allowed
     }()
+
+    private nonisolated static let maxProcessAncestryDepth = 12
+
+    private nonisolated static func defaultProcessSnapshot(for processId: pid_t) -> ProcessSnapshot? {
+        guard processId > 1 else { return nil }
+
+        var info = proc_bsdshortinfo()
+        let size = MemoryLayout<proc_bsdshortinfo>.size
+        let result = proc_pidinfo(Int32(processId), Int32(PROC_PIDT_SHORTBSDINFO), 0, &info, Int32(size))
+        guard result == Int32(size), info.pbsi_ppid > 0 else {
+            return nil
+        }
+
+        return ProcessSnapshot(parentProcessId: pid_t(info.pbsi_ppid))
+    }
+
+    private static func defaultBundleIdentifier(for processId: pid_t) -> String? {
+        NSRunningApplication(processIdentifier: processId)?.bundleIdentifier
+    }
+
+    private static func defaultActivateProcess(_ processId: pid_t) -> Bool {
+        guard let app = NSRunningApplication(processIdentifier: processId) else {
+            return false
+        }
+
+        return app.activate()
+    }
 }

--- a/notchi/notchi/Services/TerminalJumpService.swift
+++ b/notchi/notchi/Services/TerminalJumpService.swift
@@ -32,7 +32,7 @@ struct TerminalJumpService {
             return openURL(url)
         }
 
-        if let processId = Self.codexCLIProcessId(for: session),
+        if let processId = Self.terminalBackedProcessId(for: session),
            let terminalProcessId = terminalProcessID(hosting: processId) {
             return activateProcess(terminalProcessId)
         }
@@ -52,6 +52,16 @@ struct TerminalJumpService {
         guard session.provider == .codex,
               session.codexOrigin == .cli,
               let processId = session.codexProcessId,
+              processId > 0 else {
+            return nil
+        }
+
+        return pid_t(processId)
+    }
+
+    static func claudeCodeProcessId(for session: SessionData) -> pid_t? {
+        guard session.provider == .claude,
+              let processId = session.claudeProcessId,
               processId > 0 else {
             return nil
         }
@@ -97,6 +107,10 @@ struct TerminalJumpService {
         }
 
         return nil
+    }
+
+    private static func terminalBackedProcessId(for session: SessionData) -> pid_t? {
+        codexCLIProcessId(for: session) ?? claudeCodeProcessId(for: session)
     }
 
     private nonisolated static let threadIDAllowedCharacters: CharacterSet = {

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -380,7 +380,9 @@ struct ExpandedPanelView: View {
                         selectedSessionId: sessionStore.selectedSessionId,
                         hoveredSessionId: $hoveredSessionId,
                         onSelectSession: { sessionId in
-                            sessionStore.selectSession(matchingStableId: sessionId)
+                            if let session = sessionStore.selectSession(matchingStableId: sessionId) {
+                                TerminalJumpService.shared.jump(to: session)
+                            }
                             showingSessionActivity = true
                         },
                         onDeleteSession: { sessionId in


### PR DESCRIPTION
## Summary

Adds click-to-jump behavior for tracked agent sessions:

- Codex Desktop sessions open the exact Codex thread via `codex://threads/<id>`.
- Codex CLI sessions activate the hosting terminal app by walking the tracked Codex process ancestry.
- Claude Code sessions now capture the live Claude process PID from the hook and activate the hosting terminal app by process ancestry.

This intentionally keeps CLI behavior at app-level activation for now. Exact terminal window/tab targeting is terminal-specific; Ghostty exact targeting is tracked separately in RSK-153 and depends on Ghostty PID/TTY AppleScript support in the 1.4/tip line.

Closes #39.

## Notes

- The implementation avoids shelling out from the sandboxed app for process ancestry; it uses `proc_pidinfo`.
- The Claude hook only resolves the Claude PID on `SessionStart` and `UserPromptSubmit` to avoid extra work on frequent tool hooks.
- The row/sprite click path reuses the selected `SessionData` returned by `SessionStore.selectSession(matchingStableId:)`.

## Validation

- `bash -n notchi/notchi/Resources/notchi-hook.sh`
- `xcodebuild test -project notchi/notchi.xcodeproj -scheme notchi -derivedDataPath build/test-claude-jump -only-testing:Tests/TerminalJumpServiceTests`
- `xcodebuild test -project notchi/notchi.xcodeproj -scheme notchi -derivedDataPath build/test-claude-jump-adapter -only-testing:Tests/AgentProviderAdapterTests`
- `./scripts/test.sh focused`