### PR TITLE
Add two-way Claude interaction prompts

### DIFF
--- a/notchi/Tests/HookInstallerTests.swift
+++ b/notchi/Tests/HookInstallerTests.swift
@@ -66,4 +66,16 @@ final class HookInstallerTests: XCTestCase {
         XCTAssertEqual(sessionStartHooks.count, 1)
         XCTAssertEqual(sessionStartHooks.first?["command"] as? String, HookInstaller.hookCommand)
     }
+
+    func testBundledHookDoesNotWaitForHeadlessPermissionRequests() throws {
+        let testDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let hookScript = testDirectory
+            .deletingLastPathComponent()
+            .appendingPathComponent("notchi/Resources/notchi-hook.sh")
+        let script = try String(contentsOf: hookScript)
+
+        XCTAssertTrue(script.contains("def should_wait_for_response():"))
+        XCTAssertTrue(script.contains("os.environ.get('NOTCHI_INTERACTIVE', 'true') != 'true'"))
+        XCTAssertTrue(script.contains("return hook_event == 'PermissionRequest'"))
+    }
 }

--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -409,6 +409,224 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(session.task, .idle)
     }
 
+    func testAnswerPermissionRequestSubmitsAllowResponse() async throws {
+        let store = SessionStore.shared
+        let sessionId = "permission-request-allow-\(UUID().uuidString)"
+        let requestId = HookInteractionRequest.id(
+            provider: .claude,
+            rawSessionId: sessionId,
+            hookEventName: NormalizedAgentEvent.permissionRequest.rawValue,
+            toolUseId: "permission-\(UUID().uuidString)"
+        )
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            event: .permissionRequest,
+            status: "waiting_for_input",
+            tool: "Bash",
+            toolInput: [
+                "command": AnyCodable("npm test"),
+                "description": AnyCodable("Run tests"),
+            ],
+            interactionRequestId: requestId
+        ))
+        XCTAssertEqual(session.pendingQuestions.first?.options.map(\.label), ["Yes", "No"])
+
+        let responseTask = Task.detached {
+            HookInteractionResponseBroker.shared.waitForResponse(
+                requestId: requestId,
+                timeout: 1
+            )
+        }
+        let responseWaiterRegistered = await waitUntil(timeout: 1) {
+            HookInteractionResponseBroker.shared.isWaitingForResponse(requestId: requestId)
+        }
+        XCTAssertTrue(responseWaiterRegistered)
+
+        XCTAssertTrue(store.answerPendingQuestions(
+            in: session.sessionKey,
+            selectedOptionIndexesByQuestion: [0: 0]
+        ))
+
+        let awaitedResponseData = await responseTask.value
+        let responseData = try XCTUnwrap(awaitedResponseData)
+        let response = try XCTUnwrap(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+        let hookOutput = try XCTUnwrap(response["hookSpecificOutput"] as? [String: Any])
+        let decision = try XCTUnwrap(hookOutput["decision"] as? [String: Any])
+        let updatedInput = try XCTUnwrap(decision["updatedInput"] as? [String: Any])
+
+        XCTAssertEqual(hookOutput["hookEventName"] as? String, "PermissionRequest")
+        XCTAssertEqual(decision["behavior"] as? String, "allow")
+        XCTAssertEqual(updatedInput["command"] as? String, "npm test")
+        XCTAssertNil(decision["updatedPermissions"])
+        XCTAssertTrue(session.pendingQuestions.isEmpty)
+        XCTAssertEqual(session.task, .working)
+    }
+
+    func testAnswerPermissionRequestCanSubmitRememberedAllowResponse() async throws {
+        let store = SessionStore.shared
+        let sessionId = "permission-request-remember-\(UUID().uuidString)"
+        let requestId = HookInteractionRequest.id(
+            provider: .claude,
+            rawSessionId: sessionId,
+            hookEventName: NormalizedAgentEvent.permissionRequest.rawValue,
+            toolUseId: "permission-\(UUID().uuidString)"
+        )
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            event: .permissionRequest,
+            status: "waiting_for_input",
+            tool: "Bash",
+            toolInput: [
+                "command": AnyCodable("npm test"),
+            ],
+            permissionSuggestions: [
+                AnyCodable([
+                    "type": "addRules",
+                    "rules": [["toolName": "Bash", "ruleContent": "npm test"]],
+                    "behavior": "allow",
+                    "destination": "localSettings",
+                ]),
+            ],
+            interactionRequestId: requestId
+        ))
+        XCTAssertEqual(
+            session.pendingQuestions.first?.options.map(\.label),
+            ["Yes", "Yes, and don't ask again", "No"]
+        )
+
+        let responseTask = Task.detached {
+            HookInteractionResponseBroker.shared.waitForResponse(
+                requestId: requestId,
+                timeout: 1
+            )
+        }
+        let responseWaiterRegistered = await waitUntil(timeout: 1) {
+            HookInteractionResponseBroker.shared.isWaitingForResponse(requestId: requestId)
+        }
+        XCTAssertTrue(responseWaiterRegistered)
+
+        XCTAssertTrue(store.answerPendingQuestions(
+            in: session.sessionKey,
+            selectedOptionIndexesByQuestion: [0: 1]
+        ))
+
+        let awaitedResponseData = await responseTask.value
+        let responseData = try XCTUnwrap(awaitedResponseData)
+        let response = try XCTUnwrap(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+        let hookOutput = try XCTUnwrap(response["hookSpecificOutput"] as? [String: Any])
+        let decision = try XCTUnwrap(hookOutput["decision"] as? [String: Any])
+        let updatedPermissions = try XCTUnwrap(decision["updatedPermissions"] as? [[String: Any]])
+        let permissionUpdate = try XCTUnwrap(updatedPermissions.first)
+        let rules = try XCTUnwrap(permissionUpdate["rules"] as? [[String: Any]])
+
+        XCTAssertEqual(decision["behavior"] as? String, "allow")
+        XCTAssertEqual(permissionUpdate["destination"] as? String, "localSettings")
+        XCTAssertEqual(rules.first?["toolName"] as? String, "Bash")
+        XCTAssertEqual(rules.first?["ruleContent"] as? String, "npm test")
+        XCTAssertTrue(session.pendingQuestions.isEmpty)
+    }
+
+    func testAnswerPermissionRequestSubmitsDenyResponse() async throws {
+        let store = SessionStore.shared
+        let sessionId = "permission-request-deny-\(UUID().uuidString)"
+        let requestId = HookInteractionRequest.id(
+            provider: .claude,
+            rawSessionId: sessionId,
+            hookEventName: NormalizedAgentEvent.permissionRequest.rawValue,
+            toolUseId: "permission-\(UUID().uuidString)"
+        )
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            event: .permissionRequest,
+            status: "waiting_for_input",
+            tool: "Bash",
+            toolInput: [
+                "command": AnyCodable("rm -rf node_modules"),
+            ],
+            interactionRequestId: requestId
+        ))
+        let responseTask = Task.detached {
+            HookInteractionResponseBroker.shared.waitForResponse(
+                requestId: requestId,
+                timeout: 1
+            )
+        }
+        let responseWaiterRegistered = await waitUntil(timeout: 1) {
+            HookInteractionResponseBroker.shared.isWaitingForResponse(requestId: requestId)
+        }
+        XCTAssertTrue(responseWaiterRegistered)
+
+        XCTAssertTrue(store.answerPendingQuestions(
+            in: session.sessionKey,
+            selectedOptionIndexesByQuestion: [0: 1]
+        ))
+
+        let awaitedResponseData = await responseTask.value
+        let responseData = try XCTUnwrap(awaitedResponseData)
+        let response = try XCTUnwrap(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+        let hookOutput = try XCTUnwrap(response["hookSpecificOutput"] as? [String: Any])
+        let decision = try XCTUnwrap(hookOutput["decision"] as? [String: Any])
+
+        XCTAssertEqual(decision["behavior"] as? String, "deny")
+        XCTAssertEqual(decision["message"] as? String, "User denied this action.")
+        XCTAssertEqual(decision["interrupt"] as? Bool, false)
+        XCTAssertTrue(session.pendingQuestions.isEmpty)
+    }
+
+    func testCancelPendingPermissionRequestSubmitsDenyResponse() async throws {
+        let store = SessionStore.shared
+        let sessionId = "permission-request-cancel-\(UUID().uuidString)"
+        let requestId = HookInteractionRequest.id(
+            provider: .claude,
+            rawSessionId: sessionId,
+            hookEventName: NormalizedAgentEvent.permissionRequest.rawValue,
+            toolUseId: "permission-\(UUID().uuidString)"
+        )
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            event: .permissionRequest,
+            status: "waiting_for_input",
+            tool: "Bash",
+            toolInput: [
+                "command": AnyCodable("npm test"),
+            ],
+            interactionRequestId: requestId
+        ))
+        let responseTask = Task.detached {
+            HookInteractionResponseBroker.shared.waitForResponse(
+                requestId: requestId,
+                timeout: 1
+            )
+        }
+        let responseWaiterRegistered = await waitUntil(timeout: 1) {
+            HookInteractionResponseBroker.shared.isWaitingForResponse(requestId: requestId)
+        }
+        XCTAssertTrue(responseWaiterRegistered)
+
+        XCTAssertTrue(store.cancelPendingQuestion(in: session.sessionKey))
+
+        let awaitedResponseData = await responseTask.value
+        let responseData = try XCTUnwrap(awaitedResponseData)
+        let response = try XCTUnwrap(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+        let hookOutput = try XCTUnwrap(response["hookSpecificOutput"] as? [String: Any])
+        let decision = try XCTUnwrap(hookOutput["decision"] as? [String: Any])
+
+        XCTAssertEqual(decision["behavior"] as? String, "deny")
+        XCTAssertEqual(decision["message"] as? String, "User denied this action.")
+        XCTAssertEqual(decision["interrupt"] as? Bool, false)
+        XCTAssertTrue(session.pendingQuestions.isEmpty)
+        XCTAssertEqual(session.task, .working)
+    }
+
+    func testRememberedPermissionResponseRequiresPermissionSuggestion() {
+        XCTAssertNil(HookInteractionResponse.makePermissionRequestResponse(
+            decision: .allowAndRemember,
+            hookEventName: NormalizedAgentEvent.permissionRequest.rawValue,
+            toolInput: nil,
+            permissionSuggestions: nil
+        ))
+    }
+
     func testAskUserQuestionPermissionRequestResponseUsesDecisionShapeAndPreservesNulls() throws {
         let responseData = try XCTUnwrap(HookInteractionResponse.makeAskUserQuestionResponse(
             hookEventName: NormalizedAgentEvent.permissionRequest.rawValue,
@@ -543,6 +761,26 @@ final class SessionStoreTests: XCTestCase {
         let envelope = try JSONDecoder().decode(AgentHookEnvelope.self, from: data)
 
         XCTAssertNil(HookInteractionRequest.id(for: envelope))
+    }
+
+    func testPermissionRequestInteractionIdDoesNotRequireToolUseId() throws {
+        let payload: [String: Any] = [
+            "provider": "claude",
+            "session_id": "permission-request-id",
+            "cwd": "/tmp",
+            "event": "PermissionRequest",
+            "status": "waiting_for_input",
+            "tool": "Bash",
+            "tool_input": [
+                "command": "npm test",
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let envelope = try JSONDecoder().decode(AgentHookEnvelope.self, from: data)
+
+        let requestId = try XCTUnwrap(HookInteractionRequest.id(for: envelope))
+
+        XCTAssertTrue(requestId.hasPrefix("claude:permission-request-id:PermissionRequest:"))
     }
 
     func testDisplaySessionNumbersRenumberAfterDismissal() {
@@ -938,6 +1176,7 @@ final class SessionStoreTests: XCTestCase {
         tool: String? = nil,
         toolUseId: String? = nil,
         toolInput: [String: AnyCodable]? = nil,
+        permissionSuggestions: [AnyCodable]? = nil,
         interactionRequestId: String? = nil
     ) -> HookEvent {
         HookEvent(
@@ -953,6 +1192,7 @@ final class SessionStoreTests: XCTestCase {
             userPrompt: userPrompt,
             userPromptHasAttachments: userPromptHasAttachments,
             permissionMode: nil,
+            permissionSuggestions: permissionSuggestions,
             interactive: true,
             interactionRequestId: interactionRequestId
         )

--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -91,6 +91,118 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertNotNil(session.promptSubmitTime)
     }
 
+    func testPermissionRequestForAskUserQuestionUsesProvidedOptions() {
+        let store = SessionStore.shared
+        let session = store.process(makeEvent(
+            sessionId: "ask-user-question-permission-\(UUID().uuidString)",
+            event: .permissionRequest,
+            status: "waiting_for_input",
+            tool: "AskUserQuestion",
+            toolInput: [
+                "questions": AnyCodable([
+                    [
+                        "question": "What do you mean by \"toll permissions prompt\"?",
+                        "header": "Intent",
+                        "options": [
+                            [
+                                "label": "Trigger a tool permission prompt",
+                                "description": "Run a command that requires your approval",
+                            ],
+                            [
+                                "label": "Configure tool permissions",
+                                "description": "Edit Claude settings",
+                            ],
+                            [
+                                "label": "Chat about this",
+                            ],
+                        ],
+                    ],
+                ]),
+            ]
+        ))
+
+        XCTAssertEqual(session.task, .waiting)
+        XCTAssertEqual(session.pendingQuestions.count, 1)
+        XCTAssertEqual(session.pendingQuestions[0].header, "Intent")
+        XCTAssertEqual(
+            session.pendingQuestions[0].question,
+            "What do you mean by \"toll permissions prompt\"?"
+        )
+        XCTAssertEqual(
+            session.pendingQuestions[0].options.map(\.label),
+            [
+                "Trigger a tool permission prompt",
+                "Configure tool permissions",
+                "Chat about this",
+                "Type something.",
+            ]
+        )
+        XCTAssertEqual(
+            session.pendingQuestions[0].options.map(\.description),
+            [
+                "Run a command that requires your approval",
+                "Edit Claude settings",
+                nil,
+                nil,
+            ]
+        )
+    }
+
+    func testPreToolUseForAskUserQuestionUsesProvidedOptionsAndFreeTextChoice() {
+        let store = SessionStore.shared
+        let session = store.process(makeEvent(
+            sessionId: "ask-user-question-pretool-\(UUID().uuidString)",
+            event: .preToolUse,
+            status: "running_tool",
+            tool: "AskUserQuestion",
+            toolInput: [
+                "questions": AnyCodable([
+                    [
+                        "question": "Which path?",
+                        "header": "Path",
+                        "options": [
+                            ["label": "Fast"],
+                            ["label": "Careful"],
+                        ],
+                    ],
+                ]),
+            ]
+        ))
+
+        XCTAssertEqual(session.task, .waiting)
+        XCTAssertEqual(session.pendingQuestions.count, 1)
+        XCTAssertEqual(
+            session.pendingQuestions[0].options.map(\.label),
+            ["Fast", "Careful", PendingQuestion.freeTextOptionLabel]
+        )
+    }
+
+    func testAskUserQuestionDoesNotDuplicateProvidedFreeTextOption() {
+        let store = SessionStore.shared
+        let session = store.process(makeEvent(
+            sessionId: "ask-user-question-free-text-dedupe-\(UUID().uuidString)",
+            event: .preToolUse,
+            status: "running_tool",
+            tool: "AskUserQuestion",
+            toolInput: [
+                "questions": AnyCodable([
+                    [
+                        "question": "Which path?",
+                        "options": [
+                            ["label": "Fast"],
+                            ["label": "Type something"],
+                        ],
+                    ],
+                ]),
+            ]
+        ))
+
+        XCTAssertEqual(
+            session.pendingQuestions[0].options.map(\.label),
+            ["Fast", "Type something"]
+        )
+    }
+
     func testDisplaySessionNumbersRenumberAfterDismissal() {
         let store = SessionStore.shared
         let cwd = "/tmp/notchi"
@@ -482,7 +594,8 @@ final class SessionStoreTests: XCTestCase {
         userPrompt: String? = nil,
         userPromptHasAttachments: Bool = false,
         tool: String? = nil,
-        toolUseId: String? = nil
+        toolUseId: String? = nil,
+        toolInput: [String: AnyCodable]? = nil
     ) -> HookEvent {
         HookEvent(
             provider: provider,
@@ -492,7 +605,7 @@ final class SessionStoreTests: XCTestCase {
             event: event,
             status: status,
             tool: tool,
-            toolInput: nil,
+            toolInput: toolInput,
             toolUseId: toolUseId,
             userPrompt: userPrompt,
             userPromptHasAttachments: userPromptHasAttachments,

--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -203,6 +203,191 @@ final class SessionStoreTests: XCTestCase {
         )
     }
 
+    func testAnswerPendingQuestionSubmitsClaudePreToolUseResponse() async throws {
+        let store = SessionStore.shared
+        let sessionId = "ask-user-question-answer-\(UUID().uuidString)"
+        let requestId = HookInteractionRequest.id(
+            provider: .claude,
+            rawSessionId: sessionId,
+            hookEventName: NormalizedAgentEvent.preToolUse.rawValue,
+            toolUseId: "tool-ask"
+        )
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            event: .preToolUse,
+            status: "running_tool",
+            tool: "AskUserQuestion",
+            toolUseId: "tool-ask",
+            toolInput: [
+                "questions": AnyCodable([
+                    [
+                        "question": "Which path?",
+                        "options": [
+                            ["label": "Fast"],
+                            ["label": "Careful"],
+                        ],
+                    ],
+                ]),
+            ],
+            interactionRequestId: requestId
+        ))
+        let responseTask = Task.detached {
+            HookInteractionResponseBroker.shared.waitForResponse(
+                requestId: requestId,
+                timeout: 1
+            )
+        }
+        let responseWaiterRegistered = await waitUntil(timeout: 1) {
+            HookInteractionResponseBroker.shared.isWaitingForResponse(requestId: requestId)
+        }
+        XCTAssertTrue(responseWaiterRegistered)
+
+        XCTAssertTrue(store.answerPendingQuestion(
+            in: session.sessionKey,
+            questionIndex: 0,
+            optionIndex: 1
+        ))
+
+        let maybeResponseData = await responseTask.value
+        let responseData = try XCTUnwrap(maybeResponseData)
+        let response = try XCTUnwrap(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+        let hookOutput = try XCTUnwrap(response["hookSpecificOutput"] as? [String: Any])
+        let updatedInput = try XCTUnwrap(hookOutput["updatedInput"] as? [String: Any])
+        let answers = try XCTUnwrap(updatedInput["answers"] as? [String: String])
+        let questions = try XCTUnwrap(updatedInput["questions"] as? [[String: Any]])
+
+        XCTAssertEqual(hookOutput["hookEventName"] as? String, "PreToolUse")
+        XCTAssertEqual(hookOutput["permissionDecision"] as? String, "allow")
+        XCTAssertEqual(answers, ["Which path?": "Careful"])
+        XCTAssertEqual(questions.first?["question"] as? String, "Which path?")
+        XCTAssertEqual((questions.first?["options"] as? [[String: Any]])?.count, 2)
+        XCTAssertTrue(session.pendingQuestions.isEmpty)
+    }
+
+    func testAskUserQuestionPermissionRequestResponseUsesDecisionShapeAndPreservesNulls() throws {
+        let responseData = try XCTUnwrap(HookInteractionResponse.makeAskUserQuestionResponse(
+            hookEventName: NormalizedAgentEvent.permissionRequest.rawValue,
+            toolInput: [
+                "metadata": AnyCodable([
+                    "nullValue": NSNull(),
+                    "list": [NSNull(), "kept"],
+                ]),
+            ],
+            question: "Which path?",
+            answer: "Careful"
+        ))
+        let response = try XCTUnwrap(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+        let hookOutput = try XCTUnwrap(response["hookSpecificOutput"] as? [String: Any])
+        let decision = try XCTUnwrap(hookOutput["decision"] as? [String: Any])
+        let updatedInput = try XCTUnwrap(decision["updatedInput"] as? [String: Any])
+        let answers = try XCTUnwrap(updatedInput["answers"] as? [String: String])
+        let metadata = try XCTUnwrap(updatedInput["metadata"] as? [String: Any])
+        let list = try XCTUnwrap(metadata["list"] as? [Any])
+
+        XCTAssertEqual(hookOutput["hookEventName"] as? String, "PermissionRequest")
+        XCTAssertNil(hookOutput["permissionDecision"])
+        XCTAssertEqual(decision["behavior"] as? String, "allow")
+        XCTAssertEqual(answers, ["Which path?": "Careful"])
+        XCTAssertTrue(metadata["nullValue"] is NSNull)
+        XCTAssertTrue(list.first is NSNull)
+        XCTAssertEqual(list.last as? String, "kept")
+    }
+
+    func testAnswerPendingQuestionClearsStaleQuestionWhenBrokerAlreadyTimedOut() {
+        let store = SessionStore.shared
+        let sessionId = "ask-user-question-stale-\(UUID().uuidString)"
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            event: .preToolUse,
+            status: "running_tool",
+            tool: "AskUserQuestion",
+            toolUseId: "tool-ask",
+            toolInput: [
+                "questions": AnyCodable([
+                    [
+                        "question": "Which path?",
+                        "options": [
+                            ["label": "Fast"],
+                        ],
+                    ],
+                ]),
+            ],
+            interactionRequestId: HookInteractionRequest.id(
+                provider: .claude,
+                rawSessionId: sessionId,
+                hookEventName: NormalizedAgentEvent.preToolUse.rawValue,
+                toolUseId: "tool-ask"
+            )
+        ))
+
+        XCTAssertFalse(store.answerPendingQuestion(
+            in: session.sessionKey,
+            questionIndex: 0,
+            optionIndex: 0
+        ))
+        XCTAssertTrue(session.pendingQuestions.isEmpty)
+        XCTAssertEqual(session.task, .idle)
+    }
+
+    func testFreeTextPendingQuestionOptionDoesNotSubmitResponse() {
+        let store = SessionStore.shared
+        let sessionId = "ask-user-question-free-text-no-submit-\(UUID().uuidString)"
+        let requestId = HookInteractionRequest.id(
+            provider: .claude,
+            rawSessionId: sessionId,
+            hookEventName: NormalizedAgentEvent.preToolUse.rawValue,
+            toolUseId: "tool-ask"
+        )
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            event: .preToolUse,
+            status: "running_tool",
+            tool: "AskUserQuestion",
+            toolUseId: "tool-ask",
+            toolInput: [
+                "questions": AnyCodable([
+                    [
+                        "question": "Which path?",
+                        "options": [
+                            ["label": "Fast"],
+                        ],
+                    ],
+                ]),
+            ],
+            interactionRequestId: requestId
+        ))
+
+        XCTAssertFalse(store.answerPendingQuestion(
+            in: session.sessionKey,
+            questionIndex: 0,
+            optionIndex: 1
+        ))
+        XCTAssertFalse(session.pendingQuestions.isEmpty)
+    }
+
+    func testAskUserQuestionInteractionIdRequiresToolUseIdForPreToolUse() throws {
+        let payload: [String: Any] = [
+            "provider": "claude",
+            "session_id": "missing-tool-use-id",
+            "cwd": "/tmp",
+            "event": "PreToolUse",
+            "status": "running_tool",
+            "tool": "AskUserQuestion",
+            "tool_input": [
+                "questions": [
+                    [
+                        "question": "Which path?",
+                        "options": [["label": "Fast"]],
+                    ],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let envelope = try JSONDecoder().decode(AgentHookEnvelope.self, from: data)
+
+        XCTAssertNil(HookInteractionRequest.id(for: envelope))
+    }
+
     func testDisplaySessionNumbersRenumberAfterDismissal() {
         let store = SessionStore.shared
         let cwd = "/tmp/notchi"
@@ -595,7 +780,8 @@ final class SessionStoreTests: XCTestCase {
         userPromptHasAttachments: Bool = false,
         tool: String? = nil,
         toolUseId: String? = nil,
-        toolInput: [String: AnyCodable]? = nil
+        toolInput: [String: AnyCodable]? = nil,
+        interactionRequestId: String? = nil
     ) -> HookEvent {
         HookEvent(
             provider: provider,
@@ -610,7 +796,26 @@ final class SessionStoreTests: XCTestCase {
             userPrompt: userPrompt,
             userPromptHasAttachments: userPromptHasAttachments,
             permissionMode: nil,
-            interactive: true
+            interactive: true,
+            interactionRequestId: interactionRequestId
         )
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval,
+        pollIntervalNanoseconds: UInt64 = 10_000_000,
+        condition: @escaping () -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            if condition() {
+                return true
+            }
+
+            try? await Task.sleep(nanoseconds: pollIntervalNanoseconds)
+        }
+
+        return condition()
     }
 }

--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -134,7 +134,7 @@ final class SessionStoreTests: XCTestCase {
                 "Trigger a tool permission prompt",
                 "Configure tool permissions",
                 "Chat about this",
-                "Type something.",
+                "Type something",
             ]
         )
         XCTAssertEqual(
@@ -242,10 +242,9 @@ final class SessionStoreTests: XCTestCase {
         }
         XCTAssertTrue(responseWaiterRegistered)
 
-        XCTAssertTrue(store.answerPendingQuestion(
+        XCTAssertTrue(store.answerPendingQuestions(
             in: session.sessionKey,
-            questionIndex: 0,
-            optionIndex: 1
+            selectedOptionIndexesByQuestion: [0: 1]
         ))
 
         let maybeResponseData = await responseTask.value
@@ -261,6 +260,81 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(answers, ["Which path?": "Careful"])
         XCTAssertEqual(questions.first?["question"] as? String, "Which path?")
         XCTAssertEqual((questions.first?["options"] as? [[String: Any]])?.count, 2)
+        XCTAssertTrue(session.pendingQuestions.isEmpty)
+    }
+
+    func testAnswerPendingQuestionsSubmitsAllAnswersTogether() async throws {
+        let store = SessionStore.shared
+        let sessionId = "ask-user-question-multi-answer-\(UUID().uuidString)"
+        let requestId = HookInteractionRequest.id(
+            provider: .claude,
+            rawSessionId: sessionId,
+            hookEventName: NormalizedAgentEvent.preToolUse.rawValue,
+            toolUseId: "tool-ask"
+        )
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            event: .preToolUse,
+            status: "running_tool",
+            tool: "AskUserQuestion",
+            toolUseId: "tool-ask",
+            toolInput: [
+                "questions": AnyCodable([
+                    [
+                        "question": "Which path?",
+                        "options": [
+                            ["label": "Fast"],
+                            ["label": "Careful"],
+                        ],
+                    ],
+                    [
+                        "question": "Which target?",
+                        "options": [
+                            ["label": "Production"],
+                            ["label": "Staging"],
+                        ],
+                    ],
+                ]),
+            ],
+            interactionRequestId: requestId
+        ))
+        let responseTask = Task.detached {
+            HookInteractionResponseBroker.shared.waitForResponse(
+                requestId: requestId,
+                timeout: 1
+            )
+        }
+        let responseWaiterRegistered = await waitUntil(timeout: 1) {
+            HookInteractionResponseBroker.shared.isWaitingForResponse(requestId: requestId)
+        }
+        XCTAssertTrue(responseWaiterRegistered)
+
+        XCTAssertFalse(store.answerPendingQuestions(
+            in: session.sessionKey,
+            selectedOptionIndexesByQuestion: [0: 1]
+        ))
+        XCTAssertFalse(session.pendingQuestions.isEmpty)
+
+        XCTAssertTrue(store.answerPendingQuestions(
+            in: session.sessionKey,
+            selectedOptionIndexesByQuestion: [0: 1, 1: 0]
+        ))
+
+        let maybeResponseData = await responseTask.value
+        let responseData = try XCTUnwrap(maybeResponseData)
+        let response = try XCTUnwrap(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+        let hookOutput = try XCTUnwrap(response["hookSpecificOutput"] as? [String: Any])
+        let updatedInput = try XCTUnwrap(hookOutput["updatedInput"] as? [String: Any])
+        let answers = try XCTUnwrap(updatedInput["answers"] as? [String: String])
+        let questions = try XCTUnwrap(updatedInput["questions"] as? [[String: Any]])
+
+        XCTAssertEqual(hookOutput["hookEventName"] as? String, "PreToolUse")
+        XCTAssertEqual(hookOutput["permissionDecision"] as? String, "allow")
+        XCTAssertEqual(answers, [
+            "Which path?": "Careful",
+            "Which target?": "Production",
+        ])
+        XCTAssertEqual(questions.count, 2)
         XCTAssertTrue(session.pendingQuestions.isEmpty)
     }
 
@@ -344,8 +418,7 @@ final class SessionStoreTests: XCTestCase {
                     "list": [NSNull(), "kept"],
                 ]),
             ],
-            question: "Which path?",
-            answer: "Careful"
+            answers: ["Which path?": "Careful"]
         ))
         let response = try XCTUnwrap(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
         let hookOutput = try XCTUnwrap(response["hookSpecificOutput"] as? [String: Any])
@@ -406,10 +479,9 @@ final class SessionStoreTests: XCTestCase {
             )
         ))
 
-        XCTAssertFalse(store.answerPendingQuestion(
+        XCTAssertFalse(store.answerPendingQuestions(
             in: session.sessionKey,
-            questionIndex: 0,
-            optionIndex: 0
+            selectedOptionIndexesByQuestion: [0: 0]
         ))
         XCTAssertTrue(session.pendingQuestions.isEmpty)
         XCTAssertEqual(session.task, .idle)
@@ -443,10 +515,9 @@ final class SessionStoreTests: XCTestCase {
             interactionRequestId: requestId
         ))
 
-        XCTAssertFalse(store.answerPendingQuestion(
+        XCTAssertFalse(store.answerPendingQuestions(
             in: session.sessionKey,
-            questionIndex: 0,
-            optionIndex: 1
+            selectedOptionIndexesByQuestion: [0: 1]
         ))
         XCTAssertFalse(session.pendingQuestions.isEmpty)
     }

--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -338,6 +338,72 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertTrue(session.pendingQuestions.isEmpty)
     }
 
+    func testAnswerPendingQuestionsSubmitsCustomTextAnswers() async throws {
+        let store = SessionStore.shared
+        let sessionId = "ask-user-question-custom-answer-\(UUID().uuidString)"
+        let requestId = HookInteractionRequest.id(
+            provider: .claude,
+            rawSessionId: sessionId,
+            hookEventName: NormalizedAgentEvent.preToolUse.rawValue,
+            toolUseId: "tool-ask"
+        )
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            event: .preToolUse,
+            status: "running_tool",
+            tool: "AskUserQuestion",
+            toolUseId: "tool-ask",
+            toolInput: [
+                "questions": AnyCodable([
+                    [
+                        "question": "Which path?",
+                        "options": [
+                            ["label": "Fast"],
+                            ["label": "Careful"],
+                        ],
+                    ],
+                    [
+                        "question": "Which target?",
+                        "options": [
+                            ["label": "Production"],
+                            ["label": "Staging"],
+                        ],
+                    ],
+                ]),
+            ],
+            interactionRequestId: requestId
+        ))
+        let responseTask = Task.detached {
+            HookInteractionResponseBroker.shared.waitForResponse(
+                requestId: requestId,
+                timeout: 1
+            )
+        }
+        let responseWaiterRegistered = await waitUntil(timeout: 1) {
+            HookInteractionResponseBroker.shared.isWaitingForResponse(requestId: requestId)
+        }
+        XCTAssertTrue(responseWaiterRegistered)
+
+        XCTAssertTrue(store.answerPendingQuestions(
+            in: session.sessionKey,
+            selectedOptionIndexesByQuestion: [0: 1],
+            customAnswersByQuestion: [1: "  Local sandbox  "]
+        ))
+
+        let maybeResponseData = await responseTask.value
+        let responseData = try XCTUnwrap(maybeResponseData)
+        let response = try XCTUnwrap(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+        let hookOutput = try XCTUnwrap(response["hookSpecificOutput"] as? [String: Any])
+        let updatedInput = try XCTUnwrap(hookOutput["updatedInput"] as? [String: Any])
+        let answers = try XCTUnwrap(updatedInput["answers"] as? [String: String])
+
+        XCTAssertEqual(answers, [
+            "Which path?": "Careful",
+            "Which target?": "Local sandbox",
+        ])
+        XCTAssertTrue(session.pendingQuestions.isEmpty)
+    }
+
     func testCancelPendingQuestionSubmitsClaudePreToolUseDenyResponse() async throws {
         let store = SessionStore.shared
         let sessionId = "ask-user-question-cancel-\(UUID().uuidString)"

--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -264,6 +264,77 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertTrue(session.pendingQuestions.isEmpty)
     }
 
+    func testCancelPendingQuestionSubmitsClaudePreToolUseDenyResponse() async throws {
+        let store = SessionStore.shared
+        let sessionId = "ask-user-question-cancel-\(UUID().uuidString)"
+        let requestId = HookInteractionRequest.id(
+            provider: .claude,
+            rawSessionId: sessionId,
+            hookEventName: NormalizedAgentEvent.preToolUse.rawValue,
+            toolUseId: "tool-ask"
+        )
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            event: .preToolUse,
+            status: "running_tool",
+            tool: "AskUserQuestion",
+            toolUseId: "tool-ask",
+            toolInput: [
+                "questions": AnyCodable([
+                    [
+                        "question": "Which path?",
+                        "options": [
+                            ["label": "Fast"],
+                        ],
+                    ],
+                ]),
+            ],
+            interactionRequestId: requestId
+        ))
+        let responseTask = Task.detached {
+            HookInteractionResponseBroker.shared.waitForResponse(
+                requestId: requestId,
+                timeout: 1
+            )
+        }
+        let responseWaiterRegistered = await waitUntil(timeout: 1) {
+            HookInteractionResponseBroker.shared.isWaitingForResponse(requestId: requestId)
+        }
+        XCTAssertTrue(responseWaiterRegistered)
+
+        XCTAssertTrue(store.cancelPendingQuestion(in: session.sessionKey))
+
+        let maybeResponseData = await responseTask.value
+        let responseData = try XCTUnwrap(maybeResponseData)
+        let response = try XCTUnwrap(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+        let hookOutput = try XCTUnwrap(response["hookSpecificOutput"] as? [String: Any])
+
+        XCTAssertEqual(hookOutput["hookEventName"] as? String, "PreToolUse")
+        XCTAssertEqual(hookOutput["permissionDecision"] as? String, "deny")
+        XCTAssertEqual(hookOutput["permissionDecisionReason"] as? String, "Question canceled by user.")
+        XCTAssertNil(hookOutput["updatedInput"])
+        XCTAssertTrue(session.pendingQuestions.isEmpty)
+    }
+
+    func testCancelPendingQuestionWithoutResponseContextClearsLocalQuestion() {
+        let store = SessionStore.shared
+        let session = store.process(makeEvent(
+            sessionId: "permission-question-cancel-\(UUID().uuidString)",
+            event: .permissionRequest,
+            status: "waiting_for_input",
+            tool: "Bash",
+            toolInput: [
+                "command": AnyCodable("sysctl -n hw.ncpu"),
+                "description": AnyCodable("Print CPU core count"),
+            ]
+        ))
+
+        XCTAssertFalse(session.pendingQuestions.isEmpty)
+        XCTAssertTrue(store.cancelPendingQuestion(in: session.sessionKey))
+        XCTAssertTrue(session.pendingQuestions.isEmpty)
+        XCTAssertEqual(session.task, .idle)
+    }
+
     func testAskUserQuestionPermissionRequestResponseUsesDecisionShapeAndPreservesNulls() throws {
         let responseData = try XCTUnwrap(HookInteractionResponse.makeAskUserQuestionResponse(
             hookEventName: NormalizedAgentEvent.permissionRequest.rawValue,
@@ -291,6 +362,21 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertTrue(metadata["nullValue"] is NSNull)
         XCTAssertTrue(list.first is NSNull)
         XCTAssertEqual(list.last as? String, "kept")
+    }
+
+    func testAskUserQuestionPermissionRequestCancellationUsesDecisionDenyShape() throws {
+        let responseData = try XCTUnwrap(HookInteractionResponse.makeAskUserQuestionCancellationResponse(
+            hookEventName: NormalizedAgentEvent.permissionRequest.rawValue
+        ))
+        let response = try XCTUnwrap(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+        let hookOutput = try XCTUnwrap(response["hookSpecificOutput"] as? [String: Any])
+        let decision = try XCTUnwrap(hookOutput["decision"] as? [String: Any])
+
+        XCTAssertEqual(hookOutput["hookEventName"] as? String, "PermissionRequest")
+        XCTAssertNil(hookOutput["permissionDecision"])
+        XCTAssertEqual(decision["behavior"] as? String, "deny")
+        XCTAssertEqual(decision["message"] as? String, "Question canceled by user.")
+        XCTAssertEqual(decision["interrupt"] as? Bool, false)
     }
 
     func testAnswerPendingQuestionClearsStaleQuestionWhenBrokerAlreadyTimedOut() {

--- a/notchi/Tests/SocketServerTests.swift
+++ b/notchi/Tests/SocketServerTests.swift
@@ -137,6 +137,7 @@ final class SocketServerTests: XCTestCase {
             Task {
                 await secondRecorder.record(event)
             }
+            return nil
         }
 
         try await Task.sleep(nanoseconds: 100_000_000)
@@ -172,6 +173,7 @@ final class SocketServerTests: XCTestCase {
             Task {
                 await secondRecorder.record(event)
             }
+            return nil
         }
 
         firstServer.stop()
@@ -259,6 +261,28 @@ final class SocketServerTests: XCTestCase {
         XCTAssertTrue(delivered)
     }
 
+    func testServerWritesHandlerResponseToHalfClosedClient() async throws {
+        let response = Data("{\"ok\":true}".utf8)
+        let path = uniqueSocketPath()
+        let server = SocketServer(socketPath: path, clientReadTimeout: 0.5)
+        activeServers.append((server, path))
+
+        server.start { _ in response }
+
+        let didStart = await waitUntil(timeout: 1) {
+            FileManager.default.fileExists(atPath: path)
+        }
+        XCTAssertTrue(didStart)
+
+        let client = try connectClient(to: path)
+        try client.send(makeEventPayload(sessionId: "response-test"))
+        client.shutdownWriting()
+
+        let received = try client.readUntilClose()
+
+        XCTAssertEqual(received, response)
+    }
+
     private func makeServer(
         at path: String? = nil,
         clientReadTimeout: TimeInterval,
@@ -272,6 +296,7 @@ final class SocketServerTests: XCTestCase {
             Task {
                 await recorder.record(event)
             }
+            return nil
         }
 
         let didStart = await waitUntil(timeout: 1) {
@@ -419,6 +444,34 @@ private final class UnixSocketClient {
 
                 throw posixError(code: errno, message: "Failed to send test payload")
             }
+        }
+    }
+
+    func shutdownWriting() {
+        guard fileDescriptor >= 0 else { return }
+        shutdown(fileDescriptor, SHUT_WR)
+    }
+
+    func readUntilClose() throws -> Data {
+        var allData = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+
+        while true {
+            let bytesRead = read(fileDescriptor, &buffer, buffer.count)
+            if bytesRead > 0 {
+                allData.append(contentsOf: buffer[0..<bytesRead])
+                continue
+            }
+
+            if bytesRead == 0 {
+                return allData
+            }
+
+            if errno == EINTR {
+                continue
+            }
+
+            throw posixError(code: errno, message: "Failed to read test response")
         }
     }
 

--- a/notchi/notchi/Models/HookEvent.swift
+++ b/notchi/notchi/Models/HookEvent.swift
@@ -46,6 +46,7 @@ struct AgentHookEnvelope: Decodable, Sendable {
     let toolUseId: String?
     let userPrompt: String?
     let permissionMode: String?
+    let permissionSuggestions: [AnyCodable]?
     let interactive: Bool?
     let claudeProcessId: Int?
     let codexProcessId: Int?
@@ -61,6 +62,7 @@ struct AgentHookEnvelope: Decodable, Sendable {
         case toolUseId = "tool_use_id"
         case userPrompt = "user_prompt"
         case permissionMode = "permission_mode"
+        case permissionSuggestions = "permission_suggestions"
         case interactive
         case claudeProcessId = "claude_process_id"
         case codexProcessId = "codex_process_id"
@@ -82,6 +84,7 @@ struct AgentHookEnvelope: Decodable, Sendable {
         toolUseId = try container.decodeIfPresent(String.self, forKey: .toolUseId)
         userPrompt = try container.decodeIfPresent(String.self, forKey: .userPrompt)
         permissionMode = try container.decodeIfPresent(String.self, forKey: .permissionMode)
+        permissionSuggestions = try container.decodeIfPresent([AnyCodable].self, forKey: .permissionSuggestions)
         interactive = try container.decodeIfPresent(Bool.self, forKey: .interactive)
         claudeProcessId = try container.decodeIfPresent(Int.self, forKey: .claudeProcessId)
         codexProcessId = try container.decodeIfPresent(Int.self, forKey: .codexProcessId)
@@ -103,6 +106,7 @@ struct HookEvent: Sendable {
     let userPrompt: String?
     let userPromptHasAttachments: Bool
     let permissionMode: String?
+    let permissionSuggestions: [AnyCodable]?
     let interactive: Bool?
     let claudeProcessId: Int?
     let codexProcessId: Int?
@@ -130,6 +134,7 @@ struct HookEvent: Sendable {
         userPrompt: String? = nil,
         userPromptHasAttachments: Bool = false,
         permissionMode: String? = nil,
+        permissionSuggestions: [AnyCodable]? = nil,
         interactive: Bool? = nil,
         claudeProcessId: Int? = nil,
         codexProcessId: Int? = nil,
@@ -148,6 +153,7 @@ struct HookEvent: Sendable {
         self.userPrompt = userPrompt
         self.userPromptHasAttachments = userPromptHasAttachments
         self.permissionMode = permissionMode
+        self.permissionSuggestions = permissionSuggestions
         self.interactive = interactive
         self.claudeProcessId = claudeProcessId
         self.codexProcessId = codexProcessId

--- a/notchi/notchi/Models/HookEvent.swift
+++ b/notchi/notchi/Models/HookEvent.swift
@@ -107,6 +107,7 @@ struct HookEvent: Sendable {
     let claudeProcessId: Int?
     let codexProcessId: Int?
     let codexOrigin: CodexOrigin?
+    let interactionRequestId: String?
 
     nonisolated var sessionId: String {
         sessionKey.stableId
@@ -132,7 +133,8 @@ struct HookEvent: Sendable {
         interactive: Bool? = nil,
         claudeProcessId: Int? = nil,
         codexProcessId: Int? = nil,
-        codexOrigin: CodexOrigin? = nil
+        codexOrigin: CodexOrigin? = nil,
+        interactionRequestId: String? = nil
     ) {
         self.provider = provider
         self.sessionKey = ProviderSessionKey(provider: provider, rawSessionId: rawSessionId)
@@ -150,6 +152,7 @@ struct HookEvent: Sendable {
         self.claudeProcessId = claudeProcessId
         self.codexProcessId = codexProcessId
         self.codexOrigin = codexOrigin
+        self.interactionRequestId = interactionRequestId
     }
 }
 

--- a/notchi/notchi/Models/SessionData.swift
+++ b/notchi/notchi/Models/SessionData.swift
@@ -418,7 +418,14 @@ final class SessionData: Identifiable {
 }
 
 nonisolated struct PendingQuestionResponseContext: Sendable {
+    enum Kind: Sendable {
+        case askUserQuestion
+        case permissionRequest
+    }
+
     let requestId: String
     let hookEventName: String
     let toolInput: [String: AnyCodable]?
+    let permissionSuggestions: [AnyCodable]?
+    let kind: Kind
 }

--- a/notchi/notchi/Models/SessionData.swift
+++ b/notchi/notchi/Models/SessionData.swift
@@ -1,5 +1,7 @@
 import Foundation
 struct PendingQuestion {
+    static let freeTextOptionLabel = "Type something."
+
     let question: String
     let header: String?
     let options: [(label: String, description: String?)]

--- a/notchi/notchi/Models/SessionData.swift
+++ b/notchi/notchi/Models/SessionData.swift
@@ -5,6 +5,15 @@ struct PendingQuestion {
     let question: String
     let header: String?
     let options: [(label: String, description: String?)]
+
+    static func isFreeTextOptionLabel(_ label: String) -> Bool {
+        normalizedFreeTextLabel(label)
+            .caseInsensitiveCompare(normalizedFreeTextLabel(freeTextOptionLabel)) == .orderedSame
+    }
+
+    private static func normalizedFreeTextLabel(_ label: String) -> String {
+        label.trimmingCharacters(in: CharacterSet(charactersIn: ". "))
+    }
 }
 
 @MainActor
@@ -34,6 +43,7 @@ final class SessionData: Identifiable {
     private(set) var promptSubmitTime: Date?
     private(set) var permissionMode: String = "default"
     private(set) var pendingQuestions: [PendingQuestion] = []
+    private(set) var pendingQuestionResponseContext: PendingQuestionResponseContext?
     private(set) var currentSpinnerVerb: String
     private(set) var claudeProcessId: Int?
     private(set) var codexProcessId: Int?
@@ -301,13 +311,18 @@ final class SessionData: Identifiable {
         }
     }
 
-    func setPendingQuestions(_ questions: [PendingQuestion]) {
+    func setPendingQuestions(
+        _ questions: [PendingQuestion],
+        responseContext: PendingQuestionResponseContext? = nil
+    ) {
         pendingQuestions = questions
+        pendingQuestionResponseContext = responseContext
         lastActivity = Date()
     }
 
     func clearPendingQuestions() {
         pendingQuestions = []
+        pendingQuestionResponseContext = nil
     }
 
     func recordPreToolUse(tool: String?, toolInput: [String: Any]?, toolUseId: String?) {
@@ -400,4 +415,10 @@ final class SessionData: Identifiable {
         let seconds = total % 60
         formattedDuration = String(format: "%dm %02ds", minutes, seconds)
     }
+}
+
+nonisolated struct PendingQuestionResponseContext: Sendable {
+    let requestId: String
+    let hookEventName: String
+    let toolInput: [String: AnyCodable]?
 }

--- a/notchi/notchi/Models/SessionData.swift
+++ b/notchi/notchi/Models/SessionData.swift
@@ -1,6 +1,6 @@
 import Foundation
 struct PendingQuestion {
-    static let freeTextOptionLabel = "Type something."
+    static let freeTextOptionLabel = "Type something"
 
     let question: String
     let header: String?

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -7,6 +7,7 @@ enum NotchConstants {
 
 extension Notification.Name {
     static let notchiShouldCollapse = Notification.Name("notchiShouldCollapse")
+    static let notchiQuestionOptionShortcut = Notification.Name("notchiQuestionOptionShortcut")
 }
 
 private let cornerRadiusInsets = (
@@ -372,6 +373,7 @@ struct NotchContentView: View {
         }
         .onChange(of: isExpanded) { _, expanded in
             startSpriteHandoff(for: expanded)
+            updateKeyboardFocus(for: expanded)
             if !expanded {
                 showingPanelSettings = false
                 showingPanelSettingsDetail = false
@@ -567,6 +569,12 @@ struct NotchContentView: View {
             spriteHandoff = nil
             spriteHandoffProgress = 0
         }
+    }
+
+    private func updateKeyboardFocus(for expanded: Bool) {
+        guard expanded,
+              let panel = NSApp.windows.first(where: { $0 is NotchPanel }) else { return }
+        panel.makeKey()
     }
 
     private func startLaunchGlow() {

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -369,6 +369,10 @@ struct NotchContentView: View {
             await startLaunchWave()
         }
         .onReceive(NotificationCenter.default.publisher(for: .notchiShouldCollapse)) { _ in
+            if let activeSession, !activeSession.pendingQuestions.isEmpty {
+                sessionStore.cancelPendingQuestion(in: activeSession.sessionKey)
+                return
+            }
             panelManager.collapse()
         }
         .onChange(of: isExpanded) { _, expanded in

--- a/notchi/notchi/NotchPanel.swift
+++ b/notchi/notchi/NotchPanel.swift
@@ -33,9 +33,31 @@ final class NotchPanel: NSPanel {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
 
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .leftMouseDown, !isKeyWindow {
+            makeKey()
+        }
+        super.sendEvent(event)
+    }
+
     override func keyDown(with event: NSEvent) {
         if event.keyCode == 53 {
             NotificationCenter.default.post(name: .notchiShouldCollapse, object: nil)
+            return
         }
+
+        let modifiers = event.modifierFlags.intersection([.command, .control, .option, .shift])
+        if modifiers.isEmpty,
+           let character = event.charactersIgnoringModifiers?.first,
+           let optionNumber = Int(String(character)),
+           optionNumber > 0 {
+            NotificationCenter.default.post(
+                name: .notchiQuestionOptionShortcut,
+                object: optionNumber
+            )
+            return
+        }
+
+        super.keyDown(with: event)
     }
 }

--- a/notchi/notchi/Resources/notchi-hook.sh
+++ b/notchi/notchi/Resources/notchi-hook.sh
@@ -131,10 +131,17 @@ tool_input = input_data.get('tool_input', {})
 if tool_input:
     output['tool_input'] = tool_input
 
+permission_suggestions = input_data.get('permission_suggestions', [])
+if permission_suggestions:
+    output['permission_suggestions'] = permission_suggestions
+
 def should_wait_for_response():
-    # PreToolUse is the normal Claude AskUserQuestion path. Keep
-    # PermissionRequest for Claude versions/events that surface it there.
-    return hook_event in ('PreToolUse', 'PermissionRequest') and tool == 'AskUserQuestion'
+    if os.environ.get('NOTCHI_INTERACTIVE', 'true') != 'true':
+        return False
+
+    return hook_event == 'PermissionRequest' or (
+        hook_event == 'PreToolUse' and tool == 'AskUserQuestion'
+    )
 
 try:
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/notchi/notchi/Resources/notchi-hook.sh
+++ b/notchi/notchi/Resources/notchi-hook.sh
@@ -38,6 +38,8 @@ status_map = {
     'SessionEnd': 'ended',
     'PreToolUse': 'running_tool',
     'PostToolUse': 'processing',
+    # Claude Code normally asks custom questions through PreToolUse; keep
+    # PermissionRequest for compatibility with observed/beta event shapes.
     'PermissionRequest': 'waiting_for_input',
     'Stop': 'waiting_for_input',
     'SubagentStop': 'waiting_for_input'
@@ -129,10 +131,27 @@ tool_input = input_data.get('tool_input', {})
 if tool_input:
     output['tool_input'] = tool_input
 
+def should_wait_for_response():
+    # PreToolUse is the normal Claude AskUserQuestion path. Keep
+    # PermissionRequest for Claude versions/events that surface it there.
+    return hook_event in ('PreToolUse', 'PermissionRequest') and tool == 'AskUserQuestion'
+
 try:
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.connect('$SOCKET_PATH')
     sock.sendall(json.dumps(output).encode())
+    if should_wait_for_response():
+        sock.shutdown(socket.SHUT_WR)
+        sock.settimeout(290)
+        response_chunks = []
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            response_chunks.append(chunk)
+        if response_chunks:
+            sys.stdout.write(b''.join(response_chunks).decode())
+            sys.stdout.flush()
     sock.close()
 except:
     pass

--- a/notchi/notchi/Services/ClaudeProviderAdapter.swift
+++ b/notchi/notchi/Services/ClaudeProviderAdapter.swift
@@ -39,6 +39,7 @@ struct ClaudeProviderAdapter: AgentProviderAdapter {
             toolUseId: envelope.toolUseId,
             userPrompt: envelope.userPrompt,
             permissionMode: envelope.permissionMode,
+            permissionSuggestions: envelope.permissionSuggestions,
             interactive: envelope.interactive,
             claudeProcessId: envelope.claudeProcessId,
             interactionRequestId: HookInteractionRequest.id(for: envelope)

--- a/notchi/notchi/Services/ClaudeProviderAdapter.swift
+++ b/notchi/notchi/Services/ClaudeProviderAdapter.swift
@@ -40,7 +40,8 @@ struct ClaudeProviderAdapter: AgentProviderAdapter {
             userPrompt: envelope.userPrompt,
             permissionMode: envelope.permissionMode,
             interactive: envelope.interactive,
-            claudeProcessId: envelope.claudeProcessId
+            claudeProcessId: envelope.claudeProcessId,
+            interactionRequestId: HookInteractionRequest.id(for: envelope)
         )
     }
 }

--- a/notchi/notchi/Services/IntegrationCoordinator.swift
+++ b/notchi/notchi/Services/IntegrationCoordinator.swift
@@ -61,15 +61,20 @@ nonisolated final class IntegrationCoordinator: @unchecked Sendable {
         startEventDeliveryIfNeeded(onEvent: onEvent)
 
         socketServer.start { [weak self] envelope in
-            guard let self else { return }
+            guard let self else { return nil }
             guard let event = self.normalize(envelope) else {
                 integrationLogger.warning(
                     "Dropped unsupported \(envelope.provider.rawValue, privacy: .public) hook event: \(envelope.event, privacy: .public)"
                 )
-                return
+                return nil
             }
 
             self.enqueue(event)
+            guard let requestId = event.interactionRequestId else { return nil }
+            return HookInteractionResponseBroker.shared.waitForResponse(
+                requestId: requestId,
+                timeout: HookInteractionRequest.responseWaitTimeout
+            )
         }
     }
 

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -132,9 +132,13 @@ final class SessionStore {
             }
 
         case .permissionRequest:
-            let question = Self.buildPermissionQuestion(tool: event.tool, toolInput: event.toolInput)
             session.updateTask(.waiting)
-            session.setPendingQuestions([question])
+            if event.tool == "AskUserQuestion" {
+                session.setPendingQuestions(Self.parseQuestions(from: event.toolInput))
+            } else {
+                let question = Self.buildPermissionQuestion(tool: event.tool, toolInput: event.toolInput)
+                session.setPendingQuestions([question])
+            }
 
         case .postToolUse:
             let success = event.status != "error"
@@ -389,8 +393,28 @@ final class SessionStore {
                 guard let label = opt["label"] as? String else { return nil }
                 return (label: label, description: opt["description"] as? String)
             }
-            return PendingQuestion(question: questionText, header: header, options: options)
+            return PendingQuestion(
+                question: questionText,
+                header: header,
+                options: Self.optionsWithFreeTextChoice(options)
+            )
         }
+    }
+
+    private static func optionsWithFreeTextChoice(
+        _ options: [(label: String, description: String?)]
+    ) -> [(label: String, description: String?)] {
+        let trimmed = Self.freeTextLabelNormalized(PendingQuestion.freeTextOptionLabel)
+        let alreadyIncludesFreeText = options.contains { option in
+            Self.freeTextLabelNormalized(option.label).caseInsensitiveCompare(trimmed) == .orderedSame
+        }
+
+        guard !alreadyIncludesFreeText else { return options }
+        return options + [(label: PendingQuestion.freeTextOptionLabel, description: nil)]
+    }
+
+    private static func freeTextLabelNormalized(_ label: String) -> String {
+        label.trimmingCharacters(in: CharacterSet(charactersIn: ". "))
     }
 
     private static let localSlashCommands: Set<String> = [

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -127,7 +127,7 @@ final class SessionStore {
                 session.updateTask(.waiting)
                 session.setPendingQuestions(
                     Self.parseQuestions(from: event.toolInput),
-                    responseContext: Self.buildQuestionResponseContext(for: event)
+                    responseContext: Self.buildQuestionResponseContext(for: event, kind: .askUserQuestion)
                 )
             } else {
                 session.clearPendingQuestions()
@@ -139,11 +139,18 @@ final class SessionStore {
             if event.tool == "AskUserQuestion" {
                 session.setPendingQuestions(
                     Self.parseQuestions(from: event.toolInput),
-                    responseContext: Self.buildQuestionResponseContext(for: event)
+                    responseContext: Self.buildQuestionResponseContext(for: event, kind: .askUserQuestion)
                 )
             } else {
-                let question = Self.buildPermissionQuestion(tool: event.tool, toolInput: event.toolInput)
-                session.setPendingQuestions([question])
+                let question = Self.buildPermissionQuestion(
+                    tool: event.tool,
+                    toolInput: event.toolInput,
+                    permissionSuggestions: event.permissionSuggestions
+                )
+                session.setPendingQuestions(
+                    [question],
+                    responseContext: Self.buildQuestionResponseContext(for: event, kind: .permissionRequest)
+                )
             }
 
         case .postToolUse:
@@ -329,6 +336,14 @@ final class SessionStore {
             return false
         }
 
+        if context.kind == .permissionRequest {
+            return answerPermissionRequest(
+                session: session,
+                context: context,
+                selectedOptionIndexesByQuestion: selectedOptionIndexesByQuestion
+            )
+        }
+
         var answers: [String: String] = [:]
         for questionIndex in session.pendingQuestions.indices {
             guard let optionIndex = selectedOptionIndexesByQuestion[questionIndex] else {
@@ -368,6 +383,39 @@ final class SessionStore {
         return true
     }
 
+    private func answerPermissionRequest(
+        session: SessionData,
+        context: PendingQuestionResponseContext,
+        selectedOptionIndexesByQuestion: [Int: Int]
+    ) -> Bool {
+        guard selectedOptionIndexesByQuestion.count == 1,
+              let optionIndex = selectedOptionIndexesByQuestion[0],
+              let question = session.pendingQuestions.first,
+              question.options.indices.contains(optionIndex),
+              let decision = PermissionRequestDecision(optionLabel: question.options[optionIndex].label),
+              let responseData = HookInteractionResponse.makePermissionRequestResponse(
+                decision: decision,
+                hookEventName: context.hookEventName,
+                toolInput: context.toolInput,
+                permissionSuggestions: context.permissionSuggestions
+              ) else {
+            return false
+        }
+
+        guard HookInteractionResponseBroker.shared.submitResponse(
+            responseData,
+            for: context.requestId
+        ) else {
+            session.clearPendingQuestions()
+            session.updateTask(.idle)
+            return false
+        }
+
+        session.clearPendingQuestions()
+        session.updateTask(.working)
+        return true
+    }
+
     @discardableResult
     func cancelPendingQuestion(in sessionKey: ProviderSessionKey) -> Bool {
         guard let session = sessions[sessionKey],
@@ -379,9 +427,7 @@ final class SessionStore {
         // otherwise Claude isn't waiting on us, so drop to .idle.
         let denySubmitted: Bool
         if let context = session.pendingQuestionResponseContext,
-           let responseData = HookInteractionResponse.makeAskUserQuestionCancellationResponse(
-               hookEventName: context.hookEventName
-           ) {
+           let responseData = Self.cancellationResponse(for: context) {
             denySubmitted = HookInteractionResponseBroker.shared.submitResponse(
                 responseData,
                 for: context.requestId
@@ -393,6 +439,22 @@ final class SessionStore {
         session.clearPendingQuestions()
         session.updateTask(denySubmitted ? .working : .idle)
         return true
+    }
+
+    private static func cancellationResponse(for context: PendingQuestionResponseContext) -> Data? {
+        switch context.kind {
+        case .askUserQuestion:
+            HookInteractionResponse.makeAskUserQuestionCancellationResponse(
+                hookEventName: context.hookEventName
+            )
+        case .permissionRequest:
+            HookInteractionResponse.makePermissionRequestResponse(
+                decision: .deny,
+                hookEventName: context.hookEventName,
+                toolInput: context.toolInput,
+                permissionSuggestions: context.permissionSuggestions
+            )
+        }
     }
 
 #if DEBUG
@@ -495,7 +557,10 @@ final class SessionStore {
         return options + [(label: PendingQuestion.freeTextOptionLabel, description: nil)]
     }
 
-    private static func buildQuestionResponseContext(for event: HookEvent) -> PendingQuestionResponseContext? {
+    private static func buildQuestionResponseContext(
+        for event: HookEvent,
+        kind: PendingQuestionResponseContext.Kind
+    ) -> PendingQuestionResponseContext? {
         guard event.provider == .claude,
               let requestId = event.interactionRequestId else {
             return nil
@@ -504,7 +569,9 @@ final class SessionStore {
         return PendingQuestionResponseContext(
             requestId: requestId,
             hookEventName: event.event.rawValue,
-            toolInput: event.toolInput
+            toolInput: event.toolInput,
+            permissionSuggestions: event.permissionSuggestions,
+            kind: kind
         )
     }
 
@@ -519,19 +586,26 @@ final class SessionStore {
         return localSlashCommands.contains(command)
     }
 
-    private static func buildPermissionQuestion(tool: String?, toolInput: [String: AnyCodable]?) -> PendingQuestion {
+    private static func buildPermissionQuestion(
+        tool: String?,
+        toolInput: [String: AnyCodable]?,
+        permissionSuggestions: [AnyCodable]?
+    ) -> PendingQuestion {
         let toolName = tool ?? "Tool"
         let input = toolInput?.mapValues { $0.value }
         let description = SessionEvent.deriveDescription(tool: tool, toolInput: input)
+        var options: [(label: String, description: String?)] = [
+            (label: PermissionRequestDecision.allowOnceLabel, description: nil),
+        ]
+        if HookInteractionResponse.hasRememberablePermissionSuggestion(permissionSuggestions) {
+            options.append((label: PermissionRequestDecision.allowAndRememberLabel, description: nil))
+        }
+        options.append((label: PermissionRequestDecision.denyLabel, description: nil))
+
         return PendingQuestion(
             question: description ?? "\(toolName) wants to proceed",
             header: "Permission Request",
-            // Claude Code permission prompts always present these three choices
-            options: [
-                (label: "Yes", description: nil),
-                (label: "Yes, and don't ask again", description: nil),
-                (label: "No", description: nil),
-            ]
+            options: options
         )
     }
 
@@ -637,12 +711,11 @@ nonisolated enum CodexFileSystem {
 nonisolated enum HookInteractionRequest {
     static let responseWaitTimeout: TimeInterval = 300
 
-    // PermissionRequest compatibility events can lack a tool_use_id, so this
-    // method may generate a fresh fallback id. Store the result on HookEvent
-    // instead of recomputing it later.
+    // PermissionRequest events lack a tool_use_id, so this method may generate
+    // a fresh fallback id. Store the result on HookEvent instead of
+    // recomputing it later.
     static func id(for envelope: AgentHookEnvelope) -> String? {
         guard envelope.provider == .claude,
-              envelope.tool == "AskUserQuestion",
               let event = NormalizedAgentEvent.claudeEvent(named: envelope.event) else {
             return nil
         }
@@ -650,6 +723,7 @@ nonisolated enum HookInteractionRequest {
         let toolUseId: String
         switch event {
         case .preToolUse:
+            guard envelope.tool == "AskUserQuestion" else { return nil }
             guard let existingToolUseId = envelope.toolUseId else { return nil }
             toolUseId = existingToolUseId
         case .permissionRequest:
@@ -726,6 +800,29 @@ nonisolated final class HookInteractionResponseBroker: @unchecked Sendable {
 #endif
 }
 
+nonisolated enum PermissionRequestDecision {
+    static let allowOnceLabel = "Yes"
+    static let allowAndRememberLabel = "Yes, and don't ask again"
+    static let denyLabel = "No"
+
+    case allowOnce
+    case allowAndRemember
+    case deny
+
+    init?(optionLabel: String) {
+        switch optionLabel {
+        case Self.allowOnceLabel:
+            self = .allowOnce
+        case Self.allowAndRememberLabel:
+            self = .allowAndRemember
+        case Self.denyLabel:
+            self = .deny
+        default:
+            return nil
+        }
+    }
+}
+
 nonisolated enum HookInteractionResponse {
     private static let userCanceledQuestionReason = "Question canceled by user."
 
@@ -792,6 +889,61 @@ nonisolated enum HookInteractionResponse {
         }
 
         return try? JSONSerialization.data(withJSONObject: output)
+    }
+
+    static func makePermissionRequestResponse(
+        decision: PermissionRequestDecision,
+        hookEventName: String,
+        toolInput: [String: AnyCodable]?,
+        permissionSuggestions: [AnyCodable]?
+    ) -> Data? {
+        let hookDecision: [String: Any]
+        switch decision {
+        case .allowOnce:
+            hookDecision = [
+                "behavior": "allow",
+                "updatedInput": recursivelyUnwrapped(toolInput) as? [String: Any] ?? [:],
+            ]
+        case .allowAndRemember:
+            guard let permissionUpdate = preferredPermissionUpdate(from: permissionSuggestions) else {
+                return nil
+            }
+            hookDecision = [
+                "behavior": "allow",
+                "updatedInput": recursivelyUnwrapped(toolInput) as? [String: Any] ?? [:],
+                "updatedPermissions": [permissionUpdate],
+            ]
+        case .deny:
+            hookDecision = [
+                "behavior": "deny",
+                "message": "User denied this action.",
+                "interrupt": false,
+            ]
+        }
+
+        let output: [String: Any] = [
+            "hookSpecificOutput": [
+                "hookEventName": hookEventName,
+                "decision": hookDecision,
+            ],
+        ]
+
+        return try? JSONSerialization.data(withJSONObject: output)
+    }
+
+    static func hasRememberablePermissionSuggestion(_ suggestions: [AnyCodable]?) -> Bool {
+        preferredPermissionUpdate(from: suggestions) != nil
+    }
+
+    private static func preferredPermissionUpdate(from suggestions: [AnyCodable]?) -> [String: Any]? {
+        guard let suggestions = recursivelyUnwrapped(suggestions) as? [[String: Any]] else { return nil }
+
+        return suggestions.first { suggestion in
+            suggestion["behavior"] as? String == "allow"
+                && suggestion["destination"] as? String == "localSettings"
+        } ?? suggestions.first { suggestion in
+            suggestion["behavior"] as? String == "allow"
+        }
     }
 
     private static func recursivelyUnwrapped(_ value: Any?) -> Any {

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -358,6 +358,33 @@ final class SessionStore {
         return true
     }
 
+    @discardableResult
+    func cancelPendingQuestion(in sessionKey: ProviderSessionKey) -> Bool {
+        guard let session = sessions[sessionKey],
+              !session.pendingQuestions.isEmpty else {
+            return false
+        }
+
+        // .working only when the broker actually relays the deny back to the hook;
+        // otherwise Claude isn't waiting on us, so drop to .idle.
+        let denySubmitted: Bool
+        if let context = session.pendingQuestionResponseContext,
+           let responseData = HookInteractionResponse.makeAskUserQuestionCancellationResponse(
+               hookEventName: context.hookEventName
+           ) {
+            denySubmitted = HookInteractionResponseBroker.shared.submitResponse(
+                responseData,
+                for: context.requestId
+            )
+        } else {
+            denySubmitted = false
+        }
+
+        session.clearPendingQuestions()
+        session.updateTask(denySubmitted ? .working : .idle)
+        return true
+    }
+
 #if DEBUG
     func refreshCodexThreadMetadataForTesting() -> [SessionData] {
         let updates = codexThreadMetadataRequests().map { request in
@@ -690,6 +717,8 @@ nonisolated final class HookInteractionResponseBroker: @unchecked Sendable {
 }
 
 nonisolated enum HookInteractionResponse {
+    private static let userCanceledQuestionReason = "Question canceled by user."
+
     static func makeAskUserQuestionResponse(
         hookEventName: String,
         toolInput: [String: AnyCodable]?,
@@ -720,6 +749,33 @@ nonisolated enum HookInteractionResponse {
                     "hookEventName": hookEventName,
                     "permissionDecision": "allow",
                     "updatedInput": updatedInput,
+                ],
+            ]
+        }
+
+        return try? JSONSerialization.data(withJSONObject: output)
+    }
+
+    static func makeAskUserQuestionCancellationResponse(hookEventName: String) -> Data? {
+        let output: [String: Any]
+        if hookEventName == NormalizedAgentEvent.permissionRequest.rawValue {
+            // PermissionRequest has a distinct deny shape from PreToolUse.
+            output = [
+                "hookSpecificOutput": [
+                    "hookEventName": hookEventName,
+                    "decision": [
+                        "behavior": "deny",
+                        "message": userCanceledQuestionReason,
+                        "interrupt": false,
+                    ],
+                ],
+            ]
+        } else {
+            output = [
+                "hookSpecificOutput": [
+                    "hookEventName": hookEventName,
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": userCanceledQuestionReason,
                 ],
             ]
         }

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -328,7 +328,8 @@ final class SessionStore {
     @discardableResult
     func answerPendingQuestions(
         in sessionKey: ProviderSessionKey,
-        selectedOptionIndexesByQuestion: [Int: Int]
+        selectedOptionIndexesByQuestion: [Int: Int],
+        customAnswersByQuestion: [Int: String] = [:]
     ) -> Bool {
         guard let session = sessions[sessionKey],
               let context = session.pendingQuestionResponseContext,
@@ -346,6 +347,13 @@ final class SessionStore {
 
         var answers: [String: String] = [:]
         for questionIndex in session.pendingQuestions.indices {
+            if let customAnswer = customAnswersByQuestion[questionIndex]?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !customAnswer.isEmpty {
+                let question = session.pendingQuestions[questionIndex]
+                answers[question.question] = customAnswer
+                continue
+            }
+
             guard let optionIndex = selectedOptionIndexesByQuestion[questionIndex] else {
                 return false
             }

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -125,7 +125,10 @@ final class SessionStore {
             session.recordPreToolUse(tool: event.tool, toolInput: toolInput, toolUseId: event.toolUseId)
             if event.tool == "AskUserQuestion" {
                 session.updateTask(.waiting)
-                session.setPendingQuestions(Self.parseQuestions(from: event.toolInput))
+                session.setPendingQuestions(
+                    Self.parseQuestions(from: event.toolInput),
+                    responseContext: Self.buildQuestionResponseContext(for: event)
+                )
             } else {
                 session.clearPendingQuestions()
                 session.updateTask(.working)
@@ -134,7 +137,10 @@ final class SessionStore {
         case .permissionRequest:
             session.updateTask(.waiting)
             if event.tool == "AskUserQuestion" {
-                session.setPendingQuestions(Self.parseQuestions(from: event.toolInput))
+                session.setPendingQuestions(
+                    Self.parseQuestions(from: event.toolInput),
+                    responseContext: Self.buildQuestionResponseContext(for: event)
+                )
             } else {
                 let question = Self.buildPermissionQuestion(tool: event.tool, toolInput: event.toolInput)
                 session.setPendingQuestions([question])
@@ -312,6 +318,46 @@ final class SessionStore {
         sessions[sessionKey]
     }
 
+    @discardableResult
+    func answerPendingQuestion(
+        in sessionKey: ProviderSessionKey,
+        questionIndex: Int,
+        optionIndex: Int
+    ) -> Bool {
+        guard let session = sessions[sessionKey],
+              let context = session.pendingQuestionResponseContext,
+              session.pendingQuestions.indices.contains(questionIndex) else {
+            return false
+        }
+
+        let question = session.pendingQuestions[questionIndex]
+        guard question.options.indices.contains(optionIndex) else { return false }
+
+        let option = question.options[optionIndex]
+        guard !PendingQuestion.isFreeTextOptionLabel(option.label),
+              let responseData = HookInteractionResponse.makeAskUserQuestionResponse(
+                hookEventName: context.hookEventName,
+                toolInput: context.toolInput,
+                question: question.question,
+                answer: option.label
+              ) else {
+            return false
+        }
+
+        guard HookInteractionResponseBroker.shared.submitResponse(
+            responseData,
+            for: context.requestId
+        ) else {
+            session.clearPendingQuestions()
+            session.updateTask(.idle)
+            return false
+        }
+
+        session.clearPendingQuestions()
+        session.updateTask(.working)
+        return true
+    }
+
 #if DEBUG
     func refreshCodexThreadMetadataForTesting() -> [SessionData] {
         let updates = codexThreadMetadataRequests().map { request in
@@ -404,17 +450,25 @@ final class SessionStore {
     private static func optionsWithFreeTextChoice(
         _ options: [(label: String, description: String?)]
     ) -> [(label: String, description: String?)] {
-        let trimmed = Self.freeTextLabelNormalized(PendingQuestion.freeTextOptionLabel)
         let alreadyIncludesFreeText = options.contains { option in
-            Self.freeTextLabelNormalized(option.label).caseInsensitiveCompare(trimmed) == .orderedSame
+            PendingQuestion.isFreeTextOptionLabel(option.label)
         }
 
         guard !alreadyIncludesFreeText else { return options }
         return options + [(label: PendingQuestion.freeTextOptionLabel, description: nil)]
     }
 
-    private static func freeTextLabelNormalized(_ label: String) -> String {
-        label.trimmingCharacters(in: CharacterSet(charactersIn: ". "))
+    private static func buildQuestionResponseContext(for event: HookEvent) -> PendingQuestionResponseContext? {
+        guard event.provider == .claude,
+              let requestId = event.interactionRequestId else {
+            return nil
+        }
+
+        return PendingQuestionResponseContext(
+            requestId: requestId,
+            hookEventName: event.event.rawValue,
+            toolInput: event.toolInput
+        )
     }
 
     private static let localSlashCommands: Set<String> = [
@@ -540,6 +594,156 @@ nonisolated enum CodexFileSystem {
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         return output?.isEmpty == false ? output : nil
+    }
+}
+
+nonisolated enum HookInteractionRequest {
+    static let responseWaitTimeout: TimeInterval = 300
+
+    // PermissionRequest compatibility events can lack a tool_use_id, so this
+    // method may generate a fresh fallback id. Store the result on HookEvent
+    // instead of recomputing it later.
+    static func id(for envelope: AgentHookEnvelope) -> String? {
+        guard envelope.provider == .claude,
+              envelope.tool == "AskUserQuestion",
+              let event = NormalizedAgentEvent.claudeEvent(named: envelope.event) else {
+            return nil
+        }
+
+        let toolUseId: String
+        switch event {
+        case .preToolUse:
+            guard let existingToolUseId = envelope.toolUseId else { return nil }
+            toolUseId = existingToolUseId
+        case .permissionRequest:
+            toolUseId = envelope.toolUseId ?? UUID().uuidString
+        default:
+            return nil
+        }
+
+        return id(
+            provider: envelope.provider,
+            rawSessionId: envelope.sessionId,
+            hookEventName: envelope.event,
+            toolUseId: toolUseId
+        )
+    }
+
+    static func id(
+        provider: AgentProvider,
+        rawSessionId: String,
+        hookEventName: String,
+        toolUseId: String
+    ) -> String {
+        [
+            provider.rawValue,
+            rawSessionId,
+            hookEventName,
+            toolUseId,
+        ].joined(separator: ":")
+    }
+}
+
+nonisolated final class HookInteractionResponseBroker: @unchecked Sendable {
+    static let shared = HookInteractionResponseBroker()
+
+    private let condition = NSCondition()
+    private var pendingRequestIds: Set<String> = []
+    private var responsesByRequestId: [String: Data] = [:]
+
+    func waitForResponse(requestId: String, timeout: TimeInterval) -> Data? {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        condition.lock()
+        pendingRequestIds.insert(requestId)
+        defer {
+            pendingRequestIds.remove(requestId)
+            responsesByRequestId.removeValue(forKey: requestId)
+            condition.unlock()
+        }
+
+        while responsesByRequestId[requestId] == nil, Date() < deadline {
+            condition.wait(until: deadline)
+        }
+
+        return responsesByRequestId[requestId]
+    }
+
+    @discardableResult
+    func submitResponse(_ response: Data, for requestId: String) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+
+        guard pendingRequestIds.contains(requestId) else { return false }
+        responsesByRequestId[requestId] = response
+        condition.broadcast()
+        return true
+    }
+
+#if DEBUG
+    func isWaitingForResponse(requestId: String) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        return pendingRequestIds.contains(requestId)
+    }
+#endif
+}
+
+nonisolated enum HookInteractionResponse {
+    static func makeAskUserQuestionResponse(
+        hookEventName: String,
+        toolInput: [String: AnyCodable]?,
+        question: String,
+        answer: String
+    ) -> Data? {
+        var updatedInput = recursivelyUnwrapped(toolInput) as? [String: Any] ?? [:]
+        var answers = updatedInput["answers"] as? [String: Any] ?? [:]
+        answers[question] = answer
+        updatedInput["answers"] = answers
+
+        let output: [String: Any]
+        if hookEventName == NormalizedAgentEvent.permissionRequest.rawValue {
+            // Claude versions observed in the wild can surface AskUserQuestion
+            // through PermissionRequest; keep the matching response shape.
+            output = [
+                "hookSpecificOutput": [
+                    "hookEventName": hookEventName,
+                    "decision": [
+                        "behavior": "allow",
+                        "updatedInput": updatedInput,
+                    ],
+                ],
+            ]
+        } else {
+            output = [
+                "hookSpecificOutput": [
+                    "hookEventName": hookEventName,
+                    "permissionDecision": "allow",
+                    "updatedInput": updatedInput,
+                ],
+            ]
+        }
+
+        return try? JSONSerialization.data(withJSONObject: output)
+    }
+
+    private static func recursivelyUnwrapped(_ value: Any?) -> Any {
+        switch value {
+        case nil:
+            return NSNull()
+        case let value as AnyCodable:
+            return recursivelyUnwrapped(value.value)
+        case let dict as [String: AnyCodable]:
+            return dict.mapValues { recursivelyUnwrapped($0) }
+        case let dict as [String: Any]:
+            return dict.mapValues { recursivelyUnwrapped($0) }
+        case let array as [AnyCodable]:
+            return array.map { recursivelyUnwrapped($0) }
+        case let array as [Any]:
+            return array.map { recursivelyUnwrapped($0) }
+        default:
+            return value ?? NSNull()
+        }
     }
 }
 

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -319,28 +319,38 @@ final class SessionStore {
     }
 
     @discardableResult
-    func answerPendingQuestion(
+    func answerPendingQuestions(
         in sessionKey: ProviderSessionKey,
-        questionIndex: Int,
-        optionIndex: Int
+        selectedOptionIndexesByQuestion: [Int: Int]
     ) -> Bool {
         guard let session = sessions[sessionKey],
               let context = session.pendingQuestionResponseContext,
-              session.pendingQuestions.indices.contains(questionIndex) else {
+              !session.pendingQuestions.isEmpty else {
             return false
         }
 
-        let question = session.pendingQuestions[questionIndex]
-        guard question.options.indices.contains(optionIndex) else { return false }
+        var answers: [String: String] = [:]
+        for questionIndex in session.pendingQuestions.indices {
+            guard let optionIndex = selectedOptionIndexesByQuestion[questionIndex] else {
+                return false
+            }
 
-        let option = question.options[optionIndex]
-        guard !PendingQuestion.isFreeTextOptionLabel(option.label),
-              let responseData = HookInteractionResponse.makeAskUserQuestionResponse(
-                hookEventName: context.hookEventName,
-                toolInput: context.toolInput,
-                question: question.question,
-                answer: option.label
-              ) else {
+            let question = session.pendingQuestions[questionIndex]
+            guard question.options.indices.contains(optionIndex) else { return false }
+
+            let option = question.options[optionIndex]
+            guard !PendingQuestion.isFreeTextOptionLabel(option.label) else {
+                return false
+            }
+
+            answers[question.question] = option.label
+        }
+
+        guard let responseData = HookInteractionResponse.makeAskUserQuestionResponse(
+            hookEventName: context.hookEventName,
+            toolInput: context.toolInput,
+            answers: answers
+        ) else {
             return false
         }
 
@@ -722,13 +732,14 @@ nonisolated enum HookInteractionResponse {
     static func makeAskUserQuestionResponse(
         hookEventName: String,
         toolInput: [String: AnyCodable]?,
-        question: String,
-        answer: String
+        answers: [String: String]
     ) -> Data? {
         var updatedInput = recursivelyUnwrapped(toolInput) as? [String: Any] ?? [:]
-        var answers = updatedInput["answers"] as? [String: Any] ?? [:]
-        answers[question] = answer
-        updatedInput["answers"] = answers
+        var updatedAnswers = updatedInput["answers"] as? [String: Any] ?? [:]
+        for (question, answer) in answers {
+            updatedAnswers[question] = answer
+        }
+        updatedInput["answers"] = updatedAnswers
 
         let output: [String: Any]
         if hookEventName == NormalizedAgentEvent.permissionRequest.rawValue {

--- a/notchi/notchi/Services/SocketServer.swift
+++ b/notchi/notchi/Services/SocketServer.swift
@@ -3,7 +3,7 @@ import os.log
 
 nonisolated private let logger = Logger(subsystem: "com.ruban.notchi", category: "SocketServer")
 
-typealias AgentHookEnvelopeHandler = @Sendable (AgentHookEnvelope) -> Void
+typealias AgentHookEnvelopeHandler = @Sendable (AgentHookEnvelope) -> Data?
 
 // WHY: SocketServer owns its synchronization via serverQueue/clientQueue rather
 // than the main actor, so it should not inherit the project's default UI
@@ -234,6 +234,21 @@ nonisolated final class SocketServer: @unchecked Sendable {
         if clientFlags >= 0, fcntl(clientSocket, F_SETFL, clientFlags & ~O_NONBLOCK) != 0 {
             logger.warning("Failed to clear O_NONBLOCK on client socket: \(errno)")
         }
+
+        var suppressSigPipe: Int32 = 1
+        let suppressSigPipeLength = socklen_t(MemoryLayout.size(ofValue: suppressSigPipe))
+        let suppressResult = withUnsafePointer(to: &suppressSigPipe) { pointer in
+            setsockopt(
+                clientSocket,
+                SOL_SOCKET,
+                SO_NOSIGPIPE,
+                pointer,
+                suppressSigPipeLength
+            )
+        }
+        if suppressResult != 0 {
+            logger.warning("Failed to suppress SIGPIPE on client socket: \(errno)")
+        }
     }
 
     private func handleClient(_ clientSocket: Int32, eventHandler: AgentHookEnvelopeHandler?) {
@@ -246,7 +261,8 @@ nonisolated final class SocketServer: @unchecked Sendable {
             return
         }
 
-        eventHandler?(event)
+        guard let response = eventHandler?(event), !response.isEmpty else { return }
+        writeResponse(response, to: clientSocket)
     }
 
     private func readClientPayload(from clientSocket: Int32) -> Data? {
@@ -322,6 +338,35 @@ nonisolated final class SocketServer: @unchecked Sendable {
         let clampedTimeout = max(timeout, 0)
         let milliseconds = Int((clampedTimeout * 1000).rounded(.up))
         return Int32(min(milliseconds, Int(Int32.max)))
+    }
+
+    private func writeResponse(_ response: Data, to clientSocket: Int32) {
+        response.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.bindMemory(to: UInt8.self).baseAddress else {
+                return
+            }
+
+            var totalBytesWritten = 0
+            while totalBytesWritten < response.count {
+                let bytesWritten = write(
+                    clientSocket,
+                    baseAddress.advanced(by: totalBytesWritten),
+                    response.count - totalBytesWritten
+                )
+
+                if bytesWritten > 0 {
+                    totalBytesWritten += bytesWritten
+                    continue
+                }
+
+                if bytesWritten < 0, errno == EINTR {
+                    continue
+                }
+
+                logger.warning("Failed to write client response: \(errno)")
+                return
+            }
+        }
     }
 
     private func scheduleStartRetry(

--- a/notchi/notchi/UI/ActivityRowView.swift
+++ b/notchi/notchi/UI/ActivityRowView.swift
@@ -56,12 +56,14 @@ struct ActivityRowView: View {
 
 struct QuestionPromptView: View {
     let questions: [PendingQuestion]
-    let onSelectOption: ((Int, Int) -> Void)?
+    let onSelectOption: ((Int, Int) -> Bool)?
     @State private var currentIndex = 0
+    @State private var hoveredOptionIndex: Int?
+    @State private var isSubmitting = false
 
     init(
         questions: [PendingQuestion],
-        onSelectOption: ((Int, Int) -> Void)? = nil
+        onSelectOption: ((Int, Int) -> Bool)? = nil
     ) {
         self.questions = questions
         self.onSelectOption = onSelectOption
@@ -80,11 +82,12 @@ struct QuestionPromptView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 0) {
             questionHeader
+                .padding(.bottom, 5)
             questionText
+                .padding(.bottom, 6)
             optionsList
-            answerHint
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -97,6 +100,12 @@ struct QuestionPromptView: View {
         .padding(.vertical, 4)
         .onChange(of: questions.count) {
             currentIndex = 0
+            hoveredOptionIndex = nil
+            isSubmitting = false
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .notchiQuestionOptionShortcut)) { notification in
+            guard let optionNumber = notification.object as? Int else { return }
+            selectOption(index: optionNumber - 1)
         }
     }
 
@@ -152,50 +161,128 @@ struct QuestionPromptView: View {
     }
 
     private var optionsList: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 6) {
             ForEach(Array(current.options.enumerated()), id: \.offset) { index, option in
                 let isInteractive = onSelectOption != nil
                 let isFreeTextOption = PendingQuestion.isFreeTextOptionLabel(option.label)
-                let isDisabledFreeText = isInteractive && isFreeTextOption
 
                 if isInteractive, !isFreeTextOption {
                     Button {
-                        onSelectOption?(clampedIndex, index)
+                        selectOption(index: index)
                     } label: {
-                        optionRow(index: index, option: option, isDisabled: false)
+                        highlightedOptionRow(index: index, option: option)
                     }
                     .buttonStyle(.plain)
-                } else {
-                    optionRow(
+                    .disabled(isSubmitting)
+                } else if isInteractive {
+                    highlightedOptionRow(
                         index: index,
-                        option: option,
-                        isDisabled: isDisabledFreeText,
-                        fallbackDescription: isDisabledFreeText ? "Use terminal for custom text" : nil
+                        option: (
+                            label: option.label,
+                            description: option.description ?? "Use terminal for custom text"
+                        )
                     )
+                } else {
+                    optionRow(index: index, option: option)
                 }
             }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func highlightedOptionRow(
+        index: Int,
+        option: (label: String, description: String?)
+    ) -> some View {
+        let isHovered = hoveredOptionIndex == index
+        let style = highlightedOptionStyle(isHovered: isHovered)
+
+        return HStack(alignment: .center, spacing: 9) {
+            Text("\(index + 1)")
+                .font(.system(size: 9, weight: .semibold).monospacedDigit())
+                .foregroundColor(TerminalColors.primaryText.opacity(0.82))
+                .frame(width: 20, height: 20)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(style.badgeFill)
+                )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(option.label)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(TerminalColors.primaryText)
+                if let description = option.description {
+                    Text(description)
+                        .font(.system(size: 10))
+                        .foregroundColor(TerminalColors.secondaryText)
+                        .lineLimit(2)
+                }
+            }
+        }
+        .padding(.horizontal, 7)
+        .padding(.vertical, 5)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(style.rowFill)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(style.stroke, lineWidth: 1)
+                )
+        )
+        .contentShape(RoundedRectangle(cornerRadius: 8))
+        .onHover { isHovering in
+            if isHovering {
+                hoveredOptionIndex = index
+            } else if hoveredOptionIndex == index {
+                hoveredOptionIndex = nil
+            }
+        }
+        .animation(.easeOut(duration: 0.12), value: isHovered)
+    }
+
+    private func highlightedOptionStyle(isHovered: Bool) -> (
+        rowFill: Color,
+        badgeFill: Color,
+        stroke: Color
+    ) {
+        (
+            rowFill: TerminalColors.claudeOrange.opacity(isHovered ? 0.32 : 0.22),
+            badgeFill: TerminalColors.claudeOrangeDeep.opacity(isHovered ? 1 : 0.92),
+            stroke: TerminalColors.claudeOrange.opacity(isHovered ? 0.42 : 0.16)
+        )
+    }
+
+    private func selectOption(index optionIndex: Int) {
+        guard !isSubmitting,
+              let onSelectOption,
+              current.options.indices.contains(optionIndex),
+              !PendingQuestion.isFreeTextOptionLabel(current.options[optionIndex].label) else {
+            return
+        }
+
+        isSubmitting = true
+        let didSubmit = onSelectOption(clampedIndex, optionIndex)
+        if !didSubmit {
+            isSubmitting = false
         }
     }
 
     private func optionRow(
         index: Int,
-        option: (label: String, description: String?),
-        isDisabled: Bool,
-        fallbackDescription: String? = nil
+        option: (label: String, description: String?)
     ) -> some View {
-        let description = option.description ?? fallbackDescription
-
-        return HStack(alignment: .top, spacing: 6) {
+        HStack(alignment: .top, spacing: 6) {
             Text("\(index + 1).")
                 .font(.system(size: 11, weight: .semibold).monospacedDigit())
-                .foregroundColor(isDisabled ? TerminalColors.dimmedText : TerminalColors.claudeOrange)
+                .foregroundColor(TerminalColors.claudeOrange)
                 .frame(width: 16, alignment: .trailing)
 
             VStack(alignment: .leading, spacing: 1) {
                 Text(option.label)
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(isDisabled ? TerminalColors.dimmedText : TerminalColors.primaryText)
-                if let description {
+                    .foregroundColor(TerminalColors.primaryText)
+                if let description = option.description {
                     Text(description)
                         .font(.system(size: 10))
                         .foregroundColor(TerminalColors.dimmedText)
@@ -204,12 +291,6 @@ struct QuestionPromptView: View {
             }
         }
         .contentShape(Rectangle())
-    }
-
-    private var answerHint: some View {
-        Text(onSelectOption == nil ? "Answer in terminal" : "Select an option")
-            .font(.system(size: 10).italic())
-            .foregroundColor(TerminalColors.dimmedText)
     }
 }
 

--- a/notchi/notchi/UI/ActivityRowView.swift
+++ b/notchi/notchi/UI/ActivityRowView.swift
@@ -59,6 +59,7 @@ struct QuestionPromptView: View {
     let onSelectOption: ((Int, Int) -> Bool)?
     @State private var currentIndex = 0
     @State private var hoveredOptionIndex: Int?
+    @State private var pressedOptionIndex: Int?
     @State private var isSubmitting = false
 
     init(
@@ -101,6 +102,7 @@ struct QuestionPromptView: View {
         .onChange(of: questions.count) {
             currentIndex = 0
             hoveredOptionIndex = nil
+            pressedOptionIndex = nil
             isSubmitting = false
         }
         .onReceive(NotificationCenter.default.publisher(for: .notchiQuestionOptionShortcut)) { notification in
@@ -170,17 +172,23 @@ struct QuestionPromptView: View {
                     Button {
                         selectOption(index: index)
                     } label: {
-                        highlightedOptionRow(index: index, option: option)
+                        highlightedOptionRow(
+                            index: index,
+                            option: option,
+                            isPressed: pressedOptionIndex == index
+                        )
                     }
                     .buttonStyle(.plain)
                     .disabled(isSubmitting)
+                    .simultaneousGesture(pressGesture(for: index))
                 } else if isInteractive {
                     highlightedOptionRow(
                         index: index,
                         option: (
                             label: option.label,
                             description: option.description ?? "Use terminal for custom text"
-                        )
+                        ),
+                        isPressed: false
                     )
                 } else {
                     optionRow(index: index, option: option)
@@ -192,10 +200,11 @@ struct QuestionPromptView: View {
 
     private func highlightedOptionRow(
         index: Int,
-        option: (label: String, description: String?)
+        option: (label: String, description: String?),
+        isPressed: Bool = false
     ) -> some View {
         let isHovered = hoveredOptionIndex == index
-        let style = highlightedOptionStyle(isHovered: isHovered)
+        let style = highlightedOptionStyle(isHovered: isHovered, isPressed: isPressed)
 
         return HStack(alignment: .center, spacing: 9) {
             Text("\(index + 1)")
@@ -227,30 +236,97 @@ struct QuestionPromptView: View {
                 .fill(style.rowFill)
                 .overlay(
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(style.stroke, lineWidth: 1)
+                        .stroke(style.stroke, lineWidth: style.strokeWidth)
                 )
         )
         .contentShape(RoundedRectangle(cornerRadius: 8))
+        .shadow(color: style.shadowColor, radius: style.shadowRadius, y: style.shadowYOffset)
+        .brightness(isPressed ? 0.035 : 0)
+        .scaleEffect(isPressed ? 0.985 : 1, anchor: .center)
         .onHover { isHovering in
             if isHovering {
                 hoveredOptionIndex = index
             } else if hoveredOptionIndex == index {
                 hoveredOptionIndex = nil
+                pressedOptionIndex = nil
             }
         }
         .animation(.easeOut(duration: 0.12), value: isHovered)
+        .animation(.interactiveSpring(response: 0.16, dampingFraction: 0.72, blendDuration: 0.04), value: isPressed)
     }
 
-    private func highlightedOptionStyle(isHovered: Bool) -> (
+    private func highlightedOptionStyle(isHovered: Bool, isPressed: Bool) -> (
         rowFill: Color,
         badgeFill: Color,
-        stroke: Color
+        stroke: Color,
+        strokeWidth: CGFloat,
+        shadowColor: Color,
+        shadowRadius: CGFloat,
+        shadowYOffset: CGFloat
     ) {
-        (
-            rowFill: TerminalColors.claudeOrange.opacity(isHovered ? 0.32 : 0.22),
-            badgeFill: TerminalColors.claudeOrangeDeep.opacity(isHovered ? 1 : 0.92),
-            stroke: TerminalColors.claudeOrange.opacity(isHovered ? 0.42 : 0.16)
+        let rowFillOpacity: Double
+        let badgeFillOpacity: Double
+        let strokeOpacity: Double
+        let strokeWidth: CGFloat
+        let shadowOpacity: Double
+        let shadowRadius: CGFloat
+        let shadowYOffset: CGFloat
+
+        if isPressed {
+            rowFillOpacity = 0.46
+            badgeFillOpacity = 1
+            strokeOpacity = 0.7
+            strokeWidth = 1.25
+            shadowOpacity = 0.08
+            shadowRadius = 3
+            shadowYOffset = 1
+        } else if isHovered {
+            rowFillOpacity = 0.34
+            badgeFillOpacity = 1
+            strokeOpacity = 0.46
+            strokeWidth = 1
+            shadowOpacity = 0.14
+            shadowRadius = 5
+            shadowYOffset = 2
+        } else {
+            rowFillOpacity = 0.22
+            badgeFillOpacity = 0.92
+            strokeOpacity = 0.16
+            strokeWidth = 1
+            shadowOpacity = 0
+            shadowRadius = 0
+            shadowYOffset = 2
+        }
+
+        return (
+            rowFill: TerminalColors.claudeOrange.opacity(rowFillOpacity),
+            badgeFill: TerminalColors.claudeOrangeDeep.opacity(badgeFillOpacity),
+            stroke: TerminalColors.claudeOrange.opacity(strokeOpacity),
+            strokeWidth: strokeWidth,
+            shadowColor: TerminalColors.claudeOrange.opacity(shadowOpacity),
+            shadowRadius: shadowRadius,
+            shadowYOffset: shadowYOffset
         )
+    }
+
+    private static let pressDragTolerance: CGFloat = 8
+
+    private func pressGesture(for index: Int) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                let withinTolerance =
+                    abs(value.translation.width) <= Self.pressDragTolerance &&
+                    abs(value.translation.height) <= Self.pressDragTolerance
+
+                if !isSubmitting && withinTolerance {
+                    pressedOptionIndex = index
+                } else if pressedOptionIndex == index {
+                    pressedOptionIndex = nil
+                }
+            }
+            .onEnded { _ in
+                pressedOptionIndex = nil
+            }
     }
 
     private func selectOption(index optionIndex: Int) {
@@ -263,6 +339,9 @@ struct QuestionPromptView: View {
 
         isSubmitting = true
         let didSubmit = onSelectOption(clampedIndex, optionIndex)
+        if didSubmit {
+            HapticService.shared.playNavigationTap()
+        }
         if !didSubmit {
             isSubmitting = false
         }

--- a/notchi/notchi/UI/ActivityRowView.swift
+++ b/notchi/notchi/UI/ActivityRowView.swift
@@ -56,7 +56,16 @@ struct ActivityRowView: View {
 
 struct QuestionPromptView: View {
     let questions: [PendingQuestion]
+    let onSelectOption: ((Int, Int) -> Void)?
     @State private var currentIndex = 0
+
+    init(
+        questions: [PendingQuestion],
+        onSelectOption: ((Int, Int) -> Void)? = nil
+    ) {
+        self.questions = questions
+        self.onSelectOption = onSelectOption
+    }
 
     private var clampedIndex: Int {
         min(currentIndex, questions.count - 1)
@@ -145,30 +154,60 @@ struct QuestionPromptView: View {
     private var optionsList: some View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(current.options.enumerated()), id: \.offset) { index, option in
-                HStack(alignment: .top, spacing: 6) {
-                    Text("\(index + 1).")
-                        .font(.system(size: 11, weight: .semibold).monospacedDigit())
-                        .foregroundColor(TerminalColors.claudeOrange)
-                        .frame(width: 16, alignment: .trailing)
+                let isInteractive = onSelectOption != nil
+                let isFreeTextOption = PendingQuestion.isFreeTextOptionLabel(option.label)
+                let isDisabledFreeText = isInteractive && isFreeTextOption
 
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(option.label)
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundColor(TerminalColors.primaryText)
-                        if let desc = option.description {
-                            Text(desc)
-                                .font(.system(size: 10))
-                                .foregroundColor(TerminalColors.dimmedText)
-                                .lineLimit(2)
-                        }
+                if isInteractive, !isFreeTextOption {
+                    Button {
+                        onSelectOption?(clampedIndex, index)
+                    } label: {
+                        optionRow(index: index, option: option, isDisabled: false)
                     }
+                    .buttonStyle(.plain)
+                } else {
+                    optionRow(
+                        index: index,
+                        option: option,
+                        isDisabled: isDisabledFreeText,
+                        fallbackDescription: isDisabledFreeText ? "Use terminal for custom text" : nil
+                    )
                 }
             }
         }
     }
 
+    private func optionRow(
+        index: Int,
+        option: (label: String, description: String?),
+        isDisabled: Bool,
+        fallbackDescription: String? = nil
+    ) -> some View {
+        let description = option.description ?? fallbackDescription
+
+        return HStack(alignment: .top, spacing: 6) {
+            Text("\(index + 1).")
+                .font(.system(size: 11, weight: .semibold).monospacedDigit())
+                .foregroundColor(isDisabled ? TerminalColors.dimmedText : TerminalColors.claudeOrange)
+                .frame(width: 16, alignment: .trailing)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(option.label)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(isDisabled ? TerminalColors.dimmedText : TerminalColors.primaryText)
+                if let description {
+                    Text(description)
+                        .font(.system(size: 10))
+                        .foregroundColor(TerminalColors.dimmedText)
+                        .lineLimit(2)
+                }
+            }
+        }
+        .contentShape(Rectangle())
+    }
+
     private var answerHint: some View {
-        Text("Answer in terminal")
+        Text(onSelectOption == nil ? "Answer in terminal" : "Select an option")
             .font(.system(size: 10).italic())
             .foregroundColor(TerminalColors.dimmedText)
     }

--- a/notchi/notchi/UI/ActivityRowView.swift
+++ b/notchi/notchi/UI/ActivityRowView.swift
@@ -56,18 +56,19 @@ struct ActivityRowView: View {
 
 struct QuestionPromptView: View {
     let questions: [PendingQuestion]
-    let onSelectOption: ((Int, Int) -> Bool)?
+    let onSubmitAnswers: (([Int: Int]) -> Bool)?
     @State private var currentIndex = 0
+    @State private var selectedOptionIndexesByQuestion: [Int: Int] = [:]
     @State private var hoveredOptionIndex: Int?
     @State private var pressedOptionIndex: Int?
     @State private var isSubmitting = false
 
     init(
         questions: [PendingQuestion],
-        onSelectOption: ((Int, Int) -> Bool)? = nil
+        onSubmitAnswers: (([Int: Int]) -> Bool)? = nil
     ) {
         self.questions = questions
-        self.onSelectOption = onSelectOption
+        self.onSubmitAnswers = onSubmitAnswers
     }
 
     private var clampedIndex: Int {
@@ -82,6 +83,10 @@ struct QuestionPromptView: View {
         questions.count > 1
     }
 
+    private var currentHasClickableOptions: Bool {
+        current.options.contains { !PendingQuestion.isFreeTextOptionLabel($0.label) }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             questionHeader
@@ -89,6 +94,10 @@ struct QuestionPromptView: View {
             questionText
                 .padding(.bottom, 6)
             optionsList
+            if onSubmitAnswers != nil, !currentHasClickableOptions {
+                terminalRequiredHint
+                    .padding(.top, 6)
+            }
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -99,11 +108,8 @@ struct QuestionPromptView: View {
                 .stroke(TerminalColors.claudeOrange.opacity(0.3), lineWidth: 1)
         )
         .padding(.vertical, 4)
-        .onChange(of: questions.count) {
-            currentIndex = 0
-            hoveredOptionIndex = nil
-            pressedOptionIndex = nil
-            isSubmitting = false
+        .onChange(of: questions.map(\.question)) {
+            resetAnswerState()
         }
         .onReceive(NotificationCenter.default.publisher(for: .notchiQuestionOptionShortcut)) { notification in
             guard let optionNumber = notification.object as? Int else { return }
@@ -137,21 +143,21 @@ struct QuestionPromptView: View {
 
     private var paginationControls: some View {
         HStack(spacing: 2) {
-            Button(action: { currentIndex = max(0, currentIndex - 1) }) {
+            Button(action: { showQuestion(at: currentIndex - 1) }) {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundColor(currentIndex > 0 ? TerminalColors.primaryText : TerminalColors.dimmedText)
             }
             .buttonStyle(.plain)
-            .disabled(currentIndex == 0)
+            .disabled(isSubmitting || currentIndex == 0)
 
-            Button(action: { currentIndex = min(questions.count - 1, currentIndex + 1) }) {
+            Button(action: { showQuestion(at: currentIndex + 1) }) {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundColor(currentIndex < questions.count - 1 ? TerminalColors.primaryText : TerminalColors.dimmedText)
             }
             .buttonStyle(.plain)
-            .disabled(currentIndex == questions.count - 1)
+            .disabled(isSubmitting || currentIndex == questions.count - 1)
         }
     }
 
@@ -165,7 +171,7 @@ struct QuestionPromptView: View {
     private var optionsList: some View {
         VStack(alignment: .leading, spacing: 6) {
             ForEach(Array(current.options.enumerated()), id: \.offset) { index, option in
-                let isInteractive = onSelectOption != nil
+                let isInteractive = onSubmitAnswers != nil
                 let isFreeTextOption = PendingQuestion.isFreeTextOptionLabel(option.label)
 
                 if isInteractive, !isFreeTextOption {
@@ -175,6 +181,7 @@ struct QuestionPromptView: View {
                         highlightedOptionRow(
                             index: index,
                             option: option,
+                            isSelected: selectedOptionIndexesByQuestion[clampedIndex] == index,
                             isPressed: pressedOptionIndex == index
                         )
                     }
@@ -201,10 +208,11 @@ struct QuestionPromptView: View {
     private func highlightedOptionRow(
         index: Int,
         option: (label: String, description: String?),
+        isSelected: Bool = false,
         isPressed: Bool = false
     ) -> some View {
         let isHovered = hoveredOptionIndex == index
-        let style = highlightedOptionStyle(isHovered: isHovered, isPressed: isPressed)
+        let style = highlightedOptionStyle(isHovered: isHovered, isSelected: isSelected, isPressed: isPressed)
 
         return HStack(alignment: .center, spacing: 9) {
             Text("\(index + 1)")
@@ -255,7 +263,14 @@ struct QuestionPromptView: View {
         .animation(.interactiveSpring(response: 0.16, dampingFraction: 0.72, blendDuration: 0.04), value: isPressed)
     }
 
-    private func highlightedOptionStyle(isHovered: Bool, isPressed: Bool) -> (
+    private var terminalRequiredHint: some View {
+        Text("Use terminal for this question")
+            .font(.system(size: 10, weight: .medium))
+            .foregroundColor(TerminalColors.dimmedText)
+            .italic()
+    }
+
+    private func highlightedOptionStyle(isHovered: Bool, isSelected: Bool, isPressed: Bool) -> (
         rowFill: Color,
         badgeFill: Color,
         stroke: Color,
@@ -281,13 +296,21 @@ struct QuestionPromptView: View {
             shadowRadius = 3
             shadowYOffset = 1
         } else if isHovered {
-            rowFillOpacity = 0.34
+            rowFillOpacity = isSelected ? 0.4 : 0.34
             badgeFillOpacity = 1
-            strokeOpacity = 0.46
-            strokeWidth = 1
-            shadowOpacity = 0.14
+            strokeOpacity = isSelected ? 0.58 : 0.46
+            strokeWidth = isSelected ? 1.15 : 1
+            shadowOpacity = isSelected ? 0.16 : 0.14
             shadowRadius = 5
             shadowYOffset = 2
+        } else if isSelected {
+            rowFillOpacity = 0.28
+            badgeFillOpacity = 1
+            strokeOpacity = 0.34
+            strokeWidth = 1
+            shadowOpacity = 0.06
+            shadowRadius = 3
+            shadowYOffset = 1
         } else {
             rowFillOpacity = 0.22
             badgeFillOpacity = 0.92
@@ -331,20 +354,57 @@ struct QuestionPromptView: View {
 
     private func selectOption(index optionIndex: Int) {
         guard !isSubmitting,
-              let onSelectOption,
+              let onSubmitAnswers,
               current.options.indices.contains(optionIndex),
               !PendingQuestion.isFreeTextOptionLabel(current.options[optionIndex].label) else {
             return
         }
 
+        selectedOptionIndexesByQuestion[clampedIndex] = optionIndex
+
+        if selectedOptionIndexesByQuestion.count < questions.count {
+            HapticService.shared.playNavigationTap()
+            if let nextIndex = nextUnansweredQuestionIndex(after: clampedIndex) {
+                showQuestion(at: nextIndex)
+            }
+            return
+        }
+
         isSubmitting = true
-        let didSubmit = onSelectOption(clampedIndex, optionIndex)
+        let didSubmit = onSubmitAnswers(selectedOptionIndexesByQuestion)
         if didSubmit {
             HapticService.shared.playNavigationTap()
-        }
-        if !didSubmit {
+        } else {
             isSubmitting = false
         }
+    }
+
+    private func showQuestion(at index: Int) {
+        currentIndex = min(max(0, index), questions.count - 1)
+        hoveredOptionIndex = nil
+        pressedOptionIndex = nil
+    }
+
+    private func nextUnansweredQuestionIndex(after index: Int) -> Int? {
+        let count = questions.count
+        guard count > 0 else { return nil }
+
+        for offset in 1...count {
+            let candidate = (index + offset) % count
+            if selectedOptionIndexesByQuestion[candidate] == nil {
+                return candidate
+            }
+        }
+
+        return nil
+    }
+
+    private func resetAnswerState() {
+        currentIndex = 0
+        selectedOptionIndexesByQuestion = [:]
+        hoveredOptionIndex = nil
+        pressedOptionIndex = nil
+        isSubmitting = false
     }
 
     private func optionRow(

--- a/notchi/notchi/UI/ActivityRowView.swift
+++ b/notchi/notchi/UI/ActivityRowView.swift
@@ -156,7 +156,6 @@ private struct InlineAnswerTextField: NSViewRepresentable {
             let movement = notification.userInfo?["NSTextMovement"] as? Int
             if movement == NSReturnTextMovement, !didSubmitCurrentEditingSession {
                 submitCurrentText(currentEditor()?.string ?? stringValue)
-                return
             }
 
             didSubmitCurrentEditingSession = false

--- a/notchi/notchi/UI/ActivityRowView.swift
+++ b/notchi/notchi/UI/ActivityRowView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Combine
 import SwiftUI
 
@@ -54,18 +55,131 @@ struct ActivityRowView: View {
     }
 }
 
+private struct InlineAnswerTextField: NSViewRepresentable {
+    @Binding var text: String
+    let isFocused: Bool
+    let onSubmit: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> NSTextField {
+        let textField = SubmittingTextField(string: text)
+        textField.delegate = context.coordinator
+        textField.target = context.coordinator
+        textField.action = #selector(Coordinator.submitFromAction(_:))
+        textField.onSubmitText = { submittedText in
+            context.coordinator.submit(submittedText)
+        }
+        textField.isBezeled = false
+        textField.isBordered = false
+        textField.drawsBackground = false
+        textField.focusRingType = .none
+        textField.placeholderString = "Type answer"
+        textField.font = .systemFont(ofSize: 10)
+        textField.textColor = .white
+        textField.lineBreakMode = .byTruncatingTail
+        textField.cell?.usesSingleLineMode = true
+        textField.cell?.wraps = false
+        textField.cell?.isScrollable = true
+        return textField
+    }
+
+    func updateNSView(_ textField: NSTextField, context: Context) {
+        context.coordinator.parent = self
+        if let textField = textField as? SubmittingTextField {
+            textField.onSubmitText = { submittedText in
+                context.coordinator.submit(submittedText)
+            }
+        }
+
+        if textField.stringValue != text {
+            textField.stringValue = text
+        }
+
+        guard isFocused else { return }
+        Task { @MainActor in
+            guard textField.window?.firstResponder !== textField.currentEditor() else { return }
+            textField.window?.makeFirstResponder(textField)
+            textField.currentEditor()?.selectedRange = NSRange(location: textField.stringValue.count, length: 0)
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: InlineAnswerTextField
+
+        init(_ parent: InlineAnswerTextField) {
+            self.parent = parent
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let textField = notification.object as? NSTextField else { return }
+            parent.text = textField.stringValue
+        }
+
+        @objc func submitFromAction(_ sender: NSTextField) {
+            (sender as? SubmittingTextField)?.submitCurrentText(sender.stringValue)
+        }
+
+        func submit(_ submittedText: String) {
+            parent.text = submittedText
+            parent.onSubmit(submittedText)
+        }
+
+        func control(
+            _ control: NSControl,
+            textView: NSTextView,
+            doCommandBy commandSelector: Selector
+        ) -> Bool {
+            guard commandSelector == #selector(NSResponder.insertNewline(_:)) ||
+                commandSelector == #selector(NSResponder.insertNewlineIgnoringFieldEditor(_:)),
+                let textField = control as? SubmittingTextField
+            else {
+                return false
+            }
+            textField.submitCurrentText(textView.string)
+            return true
+        }
+    }
+
+    private final class SubmittingTextField: NSTextField {
+        var onSubmitText: ((String) -> Void)?
+        private var didSubmitCurrentEditingSession = false
+
+        func submitCurrentText(_ text: String) {
+            didSubmitCurrentEditingSession = true
+            onSubmitText?(text)
+        }
+
+        override func textDidEndEditing(_ notification: Notification) {
+            let movement = notification.userInfo?["NSTextMovement"] as? Int
+            if movement == NSReturnTextMovement, !didSubmitCurrentEditingSession {
+                submitCurrentText(currentEditor()?.string ?? stringValue)
+                return
+            }
+
+            didSubmitCurrentEditingSession = false
+            super.textDidEndEditing(notification)
+        }
+    }
+}
+
 struct QuestionPromptView: View {
     let questions: [PendingQuestion]
-    let onSubmitAnswers: (([Int: Int]) -> Bool)?
+    let onSubmitAnswers: (([Int: Int], [Int: String]) -> Bool)?
     @State private var currentIndex = 0
     @State private var selectedOptionIndexesByQuestion: [Int: Int] = [:]
+    @State private var customAnswersByQuestion: [Int: String] = [:]
+    @State private var editingFreeTextQuestionIndex: Int?
     @State private var hoveredOptionIndex: Int?
     @State private var pressedOptionIndex: Int?
     @State private var isSubmitting = false
+    @State private var focusedFreeTextQuestionIndex: Int?
 
     init(
         questions: [PendingQuestion],
-        onSubmitAnswers: (([Int: Int]) -> Bool)? = nil
+        onSubmitAnswers: (([Int: Int], [Int: String]) -> Bool)? = nil
     ) {
         self.questions = questions
         self.onSubmitAnswers = onSubmitAnswers
@@ -83,10 +197,6 @@ struct QuestionPromptView: View {
         questions.count > 1
     }
 
-    private var currentHasClickableOptions: Bool {
-        current.options.contains { !PendingQuestion.isFreeTextOptionLabel($0.label) }
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             questionHeader
@@ -94,10 +204,6 @@ struct QuestionPromptView: View {
             questionText
                 .padding(.bottom, 6)
             optionsList
-            if onSubmitAnswers != nil, !currentHasClickableOptions {
-                terminalRequiredHint
-                    .padding(.top, 6)
-            }
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -189,20 +295,105 @@ struct QuestionPromptView: View {
                     .disabled(isSubmitting)
                     .simultaneousGesture(pressGesture(for: index))
                 } else if isInteractive {
-                    highlightedOptionRow(
-                        index: index,
-                        option: (
-                            label: option.label,
-                            description: option.description ?? "Use terminal for custom text"
-                        ),
-                        isPressed: false
-                    )
+                    if editingFreeTextQuestionIndex == clampedIndex {
+                        freeTextInputRow(index: index, option: option)
+                    } else {
+                        highlightedOptionRow(
+                            index: index,
+                            option: (
+                                label: option.label,
+                                description: freeTextDescription(for: clampedIndex)
+                            ),
+                            isSelected: customAnswersByQuestion[clampedIndex]?.isEmpty == false,
+                            isPressed: pressedOptionIndex == index
+                        )
+                        .onTapGesture {
+                            beginFreeTextEntry()
+                        }
+                        .simultaneousGesture(pressGesture(for: index))
+                    }
                 } else {
                     optionRow(index: index, option: option)
                 }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func freeTextInputRow(
+        index: Int,
+        option: (label: String, description: String?)
+    ) -> some View {
+        let questionIndex = clampedIndex
+        let answer = customAnswersByQuestion[questionIndex] ?? ""
+        let isHovered = hoveredOptionIndex == index
+        let isSelected = !answer.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let style = highlightedOptionStyle(isHovered: isHovered, isSelected: isSelected, isPressed: false)
+
+        return HStack(alignment: .center, spacing: 9) {
+            Text("\(index + 1)")
+                .font(.system(size: 9, weight: .semibold).monospacedDigit())
+                .foregroundColor(TerminalColors.primaryText.opacity(0.82))
+                .frame(width: 20, height: 20)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(style.badgeFill)
+                )
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(option.label)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(TerminalColors.primaryText)
+
+                InlineAnswerTextField(text: Binding(
+                    get: { customAnswersByQuestion[questionIndex] ?? "" },
+                    set: { newValue in
+                        customAnswersByQuestion[questionIndex] = newValue
+                        selectedOptionIndexesByQuestion[questionIndex] = nil
+                    }
+                ), isFocused: focusedFreeTextQuestionIndex == questionIndex) { submittedText in
+                    submitFreeTextAnswer(submittedText, for: questionIndex)
+                }
+                .frame(height: 14)
+            }
+
+            Spacer(minLength: 8)
+
+            Button {
+                submitFreeTextAnswer(answer, for: questionIndex)
+            } label: {
+                Image(systemName: "arrow.turn.down.left")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(isSelected ? TerminalColors.primaryText : TerminalColors.dimmedText)
+                    .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.plain)
+            .disabled(!isSelected || isSubmitting)
+        }
+        .padding(.horizontal, 7)
+        .padding(.vertical, 5)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(style.rowFill)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(style.stroke, lineWidth: style.strokeWidth)
+                )
+        )
+        .contentShape(RoundedRectangle(cornerRadius: 8))
+        .shadow(color: style.shadowColor, radius: style.shadowRadius, y: style.shadowYOffset)
+        .onHover { isHovering in
+            if isHovering {
+                hoveredOptionIndex = index
+            } else if hoveredOptionIndex == index {
+                hoveredOptionIndex = nil
+            }
+        }
+        .onAppear {
+            focusedFreeTextQuestionIndex = questionIndex
+        }
+        .animation(.easeOut(duration: 0.12), value: isHovered)
     }
 
     private func highlightedOptionRow(
@@ -263,11 +454,9 @@ struct QuestionPromptView: View {
         .animation(.interactiveSpring(response: 0.16, dampingFraction: 0.72, blendDuration: 0.04), value: isPressed)
     }
 
-    private var terminalRequiredHint: some View {
-        Text("Use terminal for this question")
-            .font(.system(size: 10, weight: .medium))
-            .foregroundColor(TerminalColors.dimmedText)
-            .italic()
+    private func freeTextDescription(for questionIndex: Int) -> String {
+        let answer = customAnswersByQuestion[questionIndex]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return answer.isEmpty ? "Type a custom answer" : answer
     }
 
     private func highlightedOptionStyle(isHovered: Bool, isSelected: Bool, isPressed: Bool) -> (
@@ -355,14 +544,22 @@ struct QuestionPromptView: View {
     private func selectOption(index optionIndex: Int) {
         guard !isSubmitting,
               let onSubmitAnswers,
-              current.options.indices.contains(optionIndex),
-              !PendingQuestion.isFreeTextOptionLabel(current.options[optionIndex].label) else {
+              current.options.indices.contains(optionIndex) else {
+            return
+        }
+
+        if PendingQuestion.isFreeTextOptionLabel(current.options[optionIndex].label) {
+            pressedOptionIndex = nil
+            beginFreeTextEntry()
             return
         }
 
         selectedOptionIndexesByQuestion[clampedIndex] = optionIndex
+        customAnswersByQuestion[clampedIndex] = nil
+        editingFreeTextQuestionIndex = nil
+        focusedFreeTextQuestionIndex = nil
 
-        if selectedOptionIndexesByQuestion.count < questions.count {
+        if !hasAnsweredAllQuestions {
             HapticService.shared.playNavigationTap()
             if let nextIndex = nextUnansweredQuestionIndex(after: clampedIndex) {
                 showQuestion(at: nextIndex)
@@ -371,7 +568,7 @@ struct QuestionPromptView: View {
         }
 
         isSubmitting = true
-        let didSubmit = onSubmitAnswers(selectedOptionIndexesByQuestion)
+        let didSubmit = onSubmitAnswers(selectedOptionIndexesByQuestion, customAnswersByQuestion)
         if didSubmit {
             HapticService.shared.playNavigationTap()
         } else {
@@ -379,10 +576,64 @@ struct QuestionPromptView: View {
         }
     }
 
+    private var hasAnsweredAllQuestions: Bool {
+        questions.indices.allSatisfy(hasAnswer(for:))
+    }
+
+    private func hasAnswer(for questionIndex: Int) -> Bool {
+        if selectedOptionIndexesByQuestion[questionIndex] != nil { return true }
+        let trimmed = customAnswersByQuestion[questionIndex]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return !trimmed.isEmpty
+    }
+
+    private func beginFreeTextEntry() {
+        guard !isSubmitting, onSubmitAnswers != nil else { return }
+        editingFreeTextQuestionIndex = clampedIndex
+        selectedOptionIndexesByQuestion[clampedIndex] = nil
+        if customAnswersByQuestion[clampedIndex] == nil {
+            customAnswersByQuestion[clampedIndex] = ""
+        }
+        focusedFreeTextQuestionIndex = clampedIndex
+    }
+
+    private func submitFreeTextAnswer(_ rawAnswer: String, for questionIndex: Int) {
+        let answer = rawAnswer.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !isSubmitting,
+              let onSubmitAnswers,
+              questionIndex == clampedIndex,
+              !answer.isEmpty else {
+            return
+        }
+
+        customAnswersByQuestion[questionIndex] = answer
+        selectedOptionIndexesByQuestion[questionIndex] = nil
+        editingFreeTextQuestionIndex = nil
+        focusedFreeTextQuestionIndex = nil
+
+        if !hasAnsweredAllQuestions {
+            HapticService.shared.playNavigationTap()
+            if let nextIndex = nextUnansweredQuestionIndex(after: questionIndex) {
+                showQuestion(at: nextIndex)
+            }
+            return
+        }
+
+        isSubmitting = true
+        let didSubmit = onSubmitAnswers(selectedOptionIndexesByQuestion, customAnswersByQuestion)
+        if didSubmit {
+            HapticService.shared.playNavigationTap()
+        } else {
+            isSubmitting = false
+            editingFreeTextQuestionIndex = questionIndex
+            focusedFreeTextQuestionIndex = questionIndex
+        }
+    }
+
     private func showQuestion(at index: Int) {
         currentIndex = min(max(0, index), questions.count - 1)
         hoveredOptionIndex = nil
         pressedOptionIndex = nil
+        focusedFreeTextQuestionIndex = editingFreeTextQuestionIndex == currentIndex ? currentIndex : nil
     }
 
     private func nextUnansweredQuestionIndex(after index: Int) -> Int? {
@@ -391,7 +642,7 @@ struct QuestionPromptView: View {
 
         for offset in 1...count {
             let candidate = (index + offset) % count
-            if selectedOptionIndexesByQuestion[candidate] == nil {
+            if !hasAnswer(for: candidate) {
                 return candidate
             }
         }
@@ -402,6 +653,9 @@ struct QuestionPromptView: View {
     private func resetAnswerState() {
         currentIndex = 0
         selectedOptionIndexesByQuestion = [:]
+        customAnswersByQuestion = [:]
+        editingFreeTextQuestionIndex = nil
+        focusedFreeTextQuestionIndex = nil
         hoveredOptionIndex = nil
         pressedOptionIndex = nil
         isSubmitting = false

--- a/notchi/notchi/UI/TerminalColors.swift
+++ b/notchi/notchi/UI/TerminalColors.swift
@@ -5,6 +5,7 @@ struct TerminalColors {
     static let amber = Color(red: 1.0, green: 0.7, blue: 0.0)
     static let red = Color(red: 1.0, green: 0.3, blue: 0.3)
     static let claudeOrange = Color(red: 0.85, green: 0.47, blue: 0.34)
+    static let claudeOrangeDeep = Color(red: 0.78, green: 0.36, blue: 0.19)
     static let codexAccent = Color(red: 0.4, green: 0.435, blue: 0.945)
     static let iMessageBlue = Color(red: 0, green: 0.478, blue: 1)
     static let planMode = Color(red: 72.0 / 255.0, green: 150.0 / 255.0, blue: 140.0 / 255.0)

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -580,8 +580,8 @@ struct ExpandedPanelView: View {
                                 let questions = effectiveSession?.pendingQuestions ?? []
                                 if !questions.isEmpty {
                                     QuestionPromptView(questions: questions) { questionIndex, optionIndex in
-                                        guard let sessionKey = effectiveSession?.sessionKey else { return }
-                                        _ = sessionStore.answerPendingQuestion(
+                                        guard let sessionKey = effectiveSession?.sessionKey else { return false }
+                                        return sessionStore.answerPendingQuestion(
                                             in: sessionKey,
                                             questionIndex: questionIndex,
                                             optionIndex: optionIndex

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -579,12 +579,11 @@ struct ExpandedPanelView: View {
 
                                 let questions = effectiveSession?.pendingQuestions ?? []
                                 if !questions.isEmpty {
-                                    QuestionPromptView(questions: questions) { questionIndex, optionIndex in
+                                    QuestionPromptView(questions: questions) { selectedOptionIndexesByQuestion in
                                         guard let sessionKey = effectiveSession?.sessionKey else { return false }
-                                        return sessionStore.answerPendingQuestion(
+                                        return sessionStore.answerPendingQuestions(
                                             in: sessionKey,
-                                            questionIndex: questionIndex,
-                                            optionIndex: optionIndex
+                                            selectedOptionIndexesByQuestion: selectedOptionIndexesByQuestion
                                         )
                                     }
                                         .id("question-prompt")

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -579,11 +579,12 @@ struct ExpandedPanelView: View {
 
                                 let questions = effectiveSession?.pendingQuestions ?? []
                                 if !questions.isEmpty {
-                                    QuestionPromptView(questions: questions) { selectedOptionIndexesByQuestion in
+                                    QuestionPromptView(questions: questions) { selectedOptionIndexesByQuestion, customAnswersByQuestion in
                                         guard let sessionKey = effectiveSession?.sessionKey else { return false }
                                         return sessionStore.answerPendingQuestions(
                                             in: sessionKey,
-                                            selectedOptionIndexesByQuestion: selectedOptionIndexesByQuestion
+                                            selectedOptionIndexesByQuestion: selectedOptionIndexesByQuestion,
+                                            customAnswersByQuestion: customAnswersByQuestion
                                         )
                                     }
                                         .id("question-prompt")

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -579,7 +579,14 @@ struct ExpandedPanelView: View {
 
                                 let questions = effectiveSession?.pendingQuestions ?? []
                                 if !questions.isEmpty {
-                                    QuestionPromptView(questions: questions)
+                                    QuestionPromptView(questions: questions) { questionIndex, optionIndex in
+                                        guard let sessionKey = effectiveSession?.sessionKey else { return }
+                                        _ = sessionStore.answerPendingQuestion(
+                                            in: sessionKey,
+                                            questionIndex: questionIndex,
+                                            optionIndex: optionIndex
+                                        )
+                                    }
                                         .id("question-prompt")
                                 }
                             }


### PR DESCRIPTION
## Summary

Adds two-way interaction support for Claude prompts in the notch:

- Renders Claude AskUserQuestion options as interactive rows with click and number-key selection.
- Supports answering Claude permission requests directly from the notch.
- Adds inline custom text entry for the Type something row and sends the completed answer set back through updatedInput.answers.
- Handles multi-question prompts by collecting answers before submitting the response to Claude.
- Adds cancellation support for pending question prompts and tests for the response shapes.

## Validation

- ./scripts/test.sh focused
- git diff --check

## Notes

Manual smoke testing should cover single-question custom text, mixed multi-question prompts, Return and arrow-button submit, and Escape cancellation.