### PR TITLE
Wiggle reply hint for Codex display-only prompts

### DIFF
--- a/notchi/Tests/ExpandedPanelViewTests.swift
+++ b/notchi/Tests/ExpandedPanelViewTests.swift
@@ -124,6 +124,17 @@ final class ExpandedPanelViewTests: XCTestCase {
         XCTAssertFalse(ExpandedPanelView.hasMixedClaudeAndCodexSessions([codex]))
     }
 
+    func testCodexQuestionPromptShowsDirectReplyHint() {
+        let claude = SessionData(sessionId: "claude-question-session", provider: .claude, cwd: "/tmp/project")
+        let codex = SessionData(sessionId: "codex-question-session", provider: .codex, cwd: "/tmp/project")
+
+        XCTAssertNil(ExpandedPanelView.questionResponseHint(for: claude))
+        XCTAssertEqual(
+            ExpandedPanelView.questionResponseHint(for: codex),
+            "Reply directly in the Codex app or CLI"
+        )
+    }
+
     func testMixedProviderSessionsUseSelectedProviderResetLabelPrefix() {
         let claudeSession = SessionData(sessionId: "claude-session", provider: .claude, cwd: "/tmp/project")
         let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")

--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -475,6 +475,28 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(session.task, .idle)
     }
 
+    func testCodexPermissionRequestUsesJustificationAsQuestionText() {
+        let store = SessionStore.shared
+        let session = store.process(makeEvent(
+            sessionId: "codex-permission-question-\(UUID().uuidString)",
+            provider: .codex,
+            event: .permissionRequest,
+            status: "waiting_for_input",
+            tool: "Bash",
+            toolInput: [
+                "command": AnyCodable("psd"),
+                "justification": AnyCodable("Do you want to allow a permission-request test command for `psd` in the current workspace?"),
+            ]
+        ))
+
+        XCTAssertEqual(
+            session.pendingQuestions.first?.question,
+            "Do you want to allow a permission-request test command for `psd` in the current workspace?"
+        )
+        XCTAssertEqual(session.pendingQuestions.first?.options.map(\.label), ["Yes", "No"])
+        XCTAssertNil(session.pendingQuestionResponseContext)
+    }
+
     func testAnswerPermissionRequestSubmitsAllowResponse() async throws {
         let store = SessionStore.shared
         let sessionId = "permission-request-allow-\(UUID().uuidString)"

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -143,6 +143,7 @@ final class SessionStore {
                 )
             } else {
                 let question = Self.buildPermissionQuestion(
+                    provider: event.provider,
                     tool: event.tool,
                     toolInput: event.toolInput,
                     permissionSuggestions: event.permissionSuggestions
@@ -595,13 +596,14 @@ final class SessionStore {
     }
 
     private static func buildPermissionQuestion(
+        provider: AgentProvider,
         tool: String?,
         toolInput: [String: AnyCodable]?,
         permissionSuggestions: [AnyCodable]?
     ) -> PendingQuestion {
         let toolName = tool ?? "Tool"
         let input = toolInput?.mapValues { $0.value }
-        let description = SessionEvent.deriveDescription(tool: tool, toolInput: input)
+        let description = Self.permissionQuestionText(provider: provider, tool: tool, toolInput: input)
         var options: [(label: String, description: String?)] = [
             (label: PermissionRequestDecision.allowOnceLabel, description: nil),
         ]
@@ -615,6 +617,20 @@ final class SessionStore {
             header: "Permission Request",
             options: options
         )
+    }
+
+    private static func permissionQuestionText(
+        provider: AgentProvider,
+        tool: String?,
+        toolInput: [String: Any]?
+    ) -> String? {
+        if provider == .codex,
+           let justification = toolInput?["justification"] as? String,
+           !justification.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return justification
+        }
+
+        return SessionEvent.deriveDescription(tool: tool, toolInput: toolInput)
     }
 
     private static func isProcessingStatus(_ status: String) -> Bool {

--- a/notchi/notchi/UI/ActivityRowView.swift
+++ b/notchi/notchi/UI/ActivityRowView.swift
@@ -177,6 +177,7 @@ struct QuestionPromptView: View {
     @State private var pressedOptionIndex: Int?
     @State private var isSubmitting = false
     @State private var focusedFreeTextQuestionIndex: Int?
+    @State private var responseHintShakePhase: CGFloat = 0
 
     init(
         questions: [PendingQuestion],
@@ -214,6 +215,7 @@ struct QuestionPromptView: View {
                     .font(.system(size: 10, weight: .medium).italic())
                     .foregroundColor(TerminalColors.secondaryText)
                     .padding(.top, 7)
+                    .modifier(QuestionHintShake(animatableData: responseHintShakePhase))
             }
         }
         .padding(10)
@@ -324,9 +326,20 @@ struct QuestionPromptView: View {
                         .simultaneousGesture(pressGesture(for: index))
                     }
                 } else if shouldRenderDisplayOnlyRowsHighlighted {
-                    highlightedOptionRow(index: index, option: option)
+                    highlightedOptionRow(
+                        index: index,
+                        option: option,
+                        isPressed: pressedOptionIndex == index
+                    )
+                    .onTapGesture {
+                        wiggleResponseHint()
+                    }
+                    .simultaneousGesture(pressGesture(for: index))
                 } else {
                     optionRow(index: index, option: option)
+                        .onTapGesture {
+                            wiggleResponseHint()
+                        }
                 }
             }
         }
@@ -558,6 +571,9 @@ struct QuestionPromptView: View {
         guard !isSubmitting,
               let onSubmitAnswers,
               current.options.indices.contains(optionIndex) else {
+            if onSubmitAnswers == nil, current.options.indices.contains(optionIndex) {
+                wiggleResponseHint()
+            }
             return
         }
 
@@ -642,6 +658,13 @@ struct QuestionPromptView: View {
         }
     }
 
+    private func wiggleResponseHint() {
+        guard responseHint != nil else { return }
+        withAnimation(.easeInOut(duration: 0.28)) {
+            responseHintShakePhase += 1
+        }
+    }
+
     private func showQuestion(at index: Int) {
         currentIndex = min(max(0, index), questions.count - 1)
         hoveredOptionIndex = nil
@@ -709,6 +732,21 @@ struct QuestionPromptView: View {
 
     private var shouldRenderDisplayOnlyRowsHighlighted: Bool {
         provider == .codex
+    }
+}
+
+private struct QuestionHintShake: GeometryEffect {
+    var travelDistance: CGFloat = 4
+    var cyclesPerUnit: CGFloat = 1.5
+    var animatableData: CGFloat
+
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        ProjectionTransform(
+            CGAffineTransform(
+                translationX: travelDistance * sin(animatableData * .pi * 2 * cyclesPerUnit),
+                y: 0
+            )
+        )
     }
 }
 

--- a/notchi/notchi/UI/ActivityRowView.swift
+++ b/notchi/notchi/UI/ActivityRowView.swift
@@ -166,6 +166,8 @@ private struct InlineAnswerTextField: NSViewRepresentable {
 
 struct QuestionPromptView: View {
     let questions: [PendingQuestion]
+    let provider: AgentProvider
+    let responseHint: String?
     let onSubmitAnswers: (([Int: Int], [Int: String]) -> Bool)?
     @State private var currentIndex = 0
     @State private var selectedOptionIndexesByQuestion: [Int: Int] = [:]
@@ -178,9 +180,13 @@ struct QuestionPromptView: View {
 
     init(
         questions: [PendingQuestion],
+        provider: AgentProvider = .claude,
+        responseHint: String? = nil,
         onSubmitAnswers: (([Int: Int], [Int: String]) -> Bool)? = nil
     ) {
         self.questions = questions
+        self.provider = provider
+        self.responseHint = responseHint
         self.onSubmitAnswers = onSubmitAnswers
     }
 
@@ -203,6 +209,12 @@ struct QuestionPromptView: View {
             questionText
                 .padding(.bottom, 6)
             optionsList
+            if let responseHint {
+                Text(responseHint)
+                    .font(.system(size: 10, weight: .medium).italic())
+                    .foregroundColor(TerminalColors.secondaryText)
+                    .padding(.top, 7)
+            }
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -210,7 +222,7 @@ struct QuestionPromptView: View {
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .overlay(
             RoundedRectangle(cornerRadius: 8)
-                .stroke(TerminalColors.claudeOrange.opacity(0.3), lineWidth: 1)
+                .stroke(accentColor.opacity(0.3), lineWidth: 1)
         )
         .padding(.vertical, 4)
         .onChange(of: questions.map(\.question)) {
@@ -227,7 +239,7 @@ struct QuestionPromptView: View {
             if let header = current.header {
                 Text(header)
                     .font(.system(size: 10, weight: .semibold))
-                    .foregroundColor(TerminalColors.claudeOrange)
+                    .foregroundColor(accentColor)
                     .textCase(.uppercase)
                     .tracking(0.5)
             }
@@ -311,6 +323,8 @@ struct QuestionPromptView: View {
                         }
                         .simultaneousGesture(pressGesture(for: index))
                     }
+                } else if shouldRenderDisplayOnlyRowsHighlighted {
+                    highlightedOptionRow(index: index, option: option)
                 } else {
                     optionRow(index: index, option: option)
                 }
@@ -510,11 +524,11 @@ struct QuestionPromptView: View {
         }
 
         return (
-            rowFill: TerminalColors.claudeOrange.opacity(rowFillOpacity),
-            badgeFill: TerminalColors.claudeOrangeDeep.opacity(badgeFillOpacity),
-            stroke: TerminalColors.claudeOrange.opacity(strokeOpacity),
+            rowFill: accentColor.opacity(rowFillOpacity),
+            badgeFill: deepAccentColor.opacity(badgeFillOpacity),
+            stroke: accentColor.opacity(strokeOpacity),
             strokeWidth: strokeWidth,
-            shadowColor: TerminalColors.claudeOrange.opacity(shadowOpacity),
+            shadowColor: accentColor.opacity(shadowOpacity),
             shadowRadius: shadowRadius,
             shadowYOffset: shadowYOffset
         )
@@ -667,7 +681,7 @@ struct QuestionPromptView: View {
         HStack(alignment: .top, spacing: 6) {
             Text("\(index + 1).")
                 .font(.system(size: 11, weight: .semibold).monospacedDigit())
-                .foregroundColor(TerminalColors.claudeOrange)
+                .foregroundColor(accentColor)
                 .frame(width: 16, alignment: .trailing)
 
             VStack(alignment: .leading, spacing: 1) {
@@ -683,6 +697,18 @@ struct QuestionPromptView: View {
             }
         }
         .contentShape(Rectangle())
+    }
+
+    private var accentColor: Color {
+        provider.accentColor
+    }
+
+    private var deepAccentColor: Color {
+        provider.deepAccentColor
+    }
+
+    private var shouldRenderDisplayOnlyRowsHighlighted: Bool {
+        provider == .codex
     }
 }
 

--- a/notchi/notchi/UI/TerminalColors.swift
+++ b/notchi/notchi/UI/TerminalColors.swift
@@ -7,6 +7,7 @@ struct TerminalColors {
     static let claudeOrange = Color(red: 0.85, green: 0.47, blue: 0.34)
     static let claudeOrangeDeep = Color(red: 0.78, green: 0.36, blue: 0.19)
     static let codexAccent = Color(red: 0.4, green: 0.435, blue: 0.945)
+    static let codexAccentDeep = Color(red: 0.25, green: 0.28, blue: 0.72)
     static let iMessageBlue = Color(red: 0, green: 0.478, blue: 1)
     static let planMode = Color(red: 72.0 / 255.0, green: 150.0 / 255.0, blue: 140.0 / 255.0)
     static let acceptEdits = Color(red: 169.0 / 255.0, green: 137.0 / 255.0, blue: 248.0 / 255.0)
@@ -25,6 +26,15 @@ extension AgentProvider {
             TerminalColors.claudeOrange
         case .codex:
             TerminalColors.codexAccent
+        }
+    }
+
+    var deepAccentColor: Color {
+        switch self {
+        case .claude:
+            TerminalColors.claudeOrangeDeep
+        case .codex:
+            TerminalColors.codexAccentDeep
         }
     }
 }

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -474,6 +474,11 @@ struct ExpandedPanelView: View {
             && activeSessions.contains { $0.provider == .codex }
     }
 
+    static func questionResponseHint(for session: SessionData?) -> String? {
+        guard session?.provider == .codex else { return nil }
+        return "Reply directly in the Codex app or CLI"
+    }
+
     static func sharedUsageResetLabelPrefix(
         state: SharedUsageBarState?,
         activeSessions: [SessionData]
@@ -579,15 +584,23 @@ struct ExpandedPanelView: View {
 
                                 let questions = effectiveSession?.pendingQuestions ?? []
                                 if !questions.isEmpty {
-                                    QuestionPromptView(questions: questions) { selectedOptionIndexesByQuestion, customAnswersByQuestion in
-                                        guard let sessionKey = effectiveSession?.sessionKey else { return false }
-                                        return sessionStore.answerPendingQuestions(
-                                            in: sessionKey,
-                                            selectedOptionIndexesByQuestion: selectedOptionIndexesByQuestion,
-                                            customAnswersByQuestion: customAnswersByQuestion
-                                        )
-                                    }
-                                        .id("question-prompt")
+                                    let questionProvider = effectiveSession?.provider ?? .claude
+                                    let submitAnswers: (([Int: Int], [Int: String]) -> Bool)? =
+                                        effectiveSession?.pendingQuestionResponseContext == nil ? nil : { selectedOptionIndexesByQuestion, customAnswersByQuestion in
+                                            guard let sessionKey = effectiveSession?.sessionKey else { return false }
+                                            return sessionStore.answerPendingQuestions(
+                                                in: sessionKey,
+                                                selectedOptionIndexesByQuestion: selectedOptionIndexesByQuestion,
+                                                customAnswersByQuestion: customAnswersByQuestion
+                                            )
+                                        }
+                                    QuestionPromptView(
+                                        questions: questions,
+                                        provider: questionProvider,
+                                        responseHint: Self.questionResponseHint(for: effectiveSession),
+                                        onSubmitAnswers: submitAnswers
+                                    )
+                                    .id("question-prompt")
                                 }
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- Show Codex permission prompts in Notchi as display-only cards with a reply hint.
- Wiggle the reply hint when a user taps an option or presses its number shortcut, so the app points them back to Codex without attempting to approve.
- Keep Claude inline approval behavior unchanged.

## Validation
- `./scripts/test.sh focused`
- `git diff --check`