### PR TITLE
Easy wins: grass-island rendering, hook install status, global toggle shortcut, minimise guard

### DIFF
--- a/notchi/Tests/AgentProviderAdapterTests.swift
+++ b/notchi/Tests/AgentProviderAdapterTests.swift
@@ -6,8 +6,21 @@ final class AgentProviderAdapterTests: XCTestCase {
         nonisolated let provider: AgentProvider
         nonisolated let available: Bool
         nonisolated let installed: Bool
+        nonisolated let installSucceeds: Bool
 
-        nonisolated func installIfNeeded() -> Bool { installed }
+        nonisolated init(
+            provider: AgentProvider,
+            available: Bool,
+            installed: Bool,
+            installSucceeds: Bool = true
+        ) {
+            self.provider = provider
+            self.available = available
+            self.installed = installed
+            self.installSucceeds = installSucceeds
+        }
+
+        nonisolated func installIfNeeded() -> Bool { installSucceeds }
         nonisolated func isProviderAvailable() -> Bool { available }
         nonisolated func isInstalled() -> Bool { installed }
         nonisolated func configureForLaunch() {}
@@ -291,5 +304,29 @@ final class AgentProviderAdapterTests: XCTestCase {
 
         XCTAssertFalse(coordinator.isProviderAvailable(for: .claude))
         XCTAssertTrue(coordinator.isProviderAvailable(for: .codex))
+    }
+
+    func testIntegrationCoordinatorDistinguishesProviderUnavailableFromInstallFailure() {
+        let coordinator = IntegrationCoordinator(
+            socketServer: SocketServer(socketPath: "/tmp/notchi-test-\(UUID().uuidString).sock"),
+            adapters: [
+                TestProviderAdapter(
+                    provider: .claude,
+                    available: false,
+                    installed: false
+                ),
+                TestProviderAdapter(
+                    provider: .codex,
+                    available: true,
+                    installed: false,
+                    installSucceeds: false
+                ),
+            ]
+        )
+
+        XCTAssertEqual(coordinator.installStatus(for: .claude), .providerUnavailable)
+        XCTAssertEqual(coordinator.installHooksIfNeededStatus(for: .claude), .providerUnavailable)
+        XCTAssertEqual(coordinator.installStatus(for: .codex), .notInstalled)
+        XCTAssertEqual(coordinator.installHooksIfNeededStatus(for: .codex), .failed)
     }
 }

--- a/notchi/Tests/GlobalShortcutServiceTests.swift
+++ b/notchi/Tests/GlobalShortcutServiceTests.swift
@@ -1,0 +1,108 @@
+import AppKit
+import Carbon.HIToolbox
+import XCTest
+@testable import notchi
+
+@MainActor
+final class GlobalShortcutServiceTests: XCTestCase {
+    func testDefaultTogglePanelShortcutUsesCommandOptionN() {
+        XCTAssertEqual(GlobalShortcut.defaultTogglePanel.keyCode, UInt32(kVK_ANSI_N))
+        XCTAssertEqual(GlobalShortcut.defaultTogglePanel.modifiers, UInt32(cmdKey | optionKey))
+        XCTAssertEqual(GlobalShortcut.defaultTogglePanel.displayName, "⌘⌥N")
+    }
+
+    func testShortcutRawValueRoundTrips() throws {
+        let shortcut = GlobalShortcut(keyCode: UInt32(kVK_ANSI_Period), modifiers: UInt32(cmdKey | shiftKey))
+        let decoded = try XCTUnwrap(GlobalShortcut(rawValue: shortcut.rawValue))
+
+        XCTAssertEqual(decoded, shortcut)
+        XCTAssertEqual(decoded.displayName, "⌘⇧.")
+    }
+
+    func testShortcutTranscribesKeyEventWithPrimaryModifier() throws {
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .option],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "p",
+            charactersIgnoringModifiers: "p",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_P)
+        ))
+
+        let shortcut = try XCTUnwrap(GlobalShortcut(event: event))
+
+        XCTAssertEqual(shortcut.keyCode, UInt32(kVK_ANSI_P))
+        XCTAssertEqual(shortcut.modifiers, UInt32(cmdKey | optionKey))
+        XCTAssertEqual(shortcut.displayName, "⌘⌥P")
+    }
+
+    func testShortcutRecordingPreviewShowsHeldModifiers() throws {
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .flagsChanged,
+            location: .zero,
+            modifierFlags: [.command, .option],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: UInt16(kVK_Option)
+        ))
+
+        XCTAssertEqual(GlobalShortcut.recordingDisplayName(for: event), "⌘⌥")
+    }
+
+    func testShortcutRecordingPreviewShowsFullChord() throws {
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .option, .shift],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "n",
+            charactersIgnoringModifiers: "n",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_N)
+        ))
+
+        XCTAssertEqual(GlobalShortcut.recordingDisplayName(for: event), "⌘⌥⇧N")
+    }
+
+    func testShortcutRejectsBareKeyEvent() throws {
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "n",
+            charactersIgnoringModifiers: "n",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_N)
+        ))
+
+        XCTAssertNil(GlobalShortcut(event: event))
+    }
+
+    func testTogglePanelHotKeyIDMatchesOnlyNotchiShortcut() {
+        XCTAssertTrue(
+            GlobalShortcutService.isTogglePanelHotKey(
+                signature: GlobalShortcutService.togglePanelHotKeyID.signature,
+                id: GlobalShortcutService.togglePanelHotKeyID.id
+            )
+        )
+        XCTAssertFalse(
+            GlobalShortcutService.isTogglePanelHotKey(
+                signature: GlobalShortcutService.togglePanelHotKeyID.signature,
+                id: GlobalShortcutService.togglePanelHotKeyID.id + 1
+            )
+        )
+    }
+}

--- a/notchi/Tests/GlobalShortcutServiceTests.swift
+++ b/notchi/Tests/GlobalShortcutServiceTests.swift
@@ -8,7 +8,7 @@ final class GlobalShortcutServiceTests: XCTestCase {
     func testDefaultTogglePanelShortcutUsesCommandOptionN() {
         XCTAssertEqual(GlobalShortcut.defaultTogglePanel.keyCode, UInt32(kVK_ANSI_N))
         XCTAssertEqual(GlobalShortcut.defaultTogglePanel.modifiers, UInt32(cmdKey | optionKey))
-        XCTAssertEqual(GlobalShortcut.defaultTogglePanel.displayName, "⌘⌥N")
+        XCTAssertEqual(GlobalShortcut.defaultTogglePanel.displayName, "⌥⌘N")
     }
 
     func testShortcutRawValueRoundTrips() throws {
@@ -16,7 +16,7 @@ final class GlobalShortcutServiceTests: XCTestCase {
         let decoded = try XCTUnwrap(GlobalShortcut(rawValue: shortcut.rawValue))
 
         XCTAssertEqual(decoded, shortcut)
-        XCTAssertEqual(decoded.displayName, "⌘⇧.")
+        XCTAssertEqual(decoded.displayName, "⇧⌘.")
     }
 
     func testShortcutTranscribesKeyEventWithPrimaryModifier() throws {
@@ -37,7 +37,7 @@ final class GlobalShortcutServiceTests: XCTestCase {
 
         XCTAssertEqual(shortcut.keyCode, UInt32(kVK_ANSI_P))
         XCTAssertEqual(shortcut.modifiers, UInt32(cmdKey | optionKey))
-        XCTAssertEqual(shortcut.displayName, "⌘⌥P")
+        XCTAssertEqual(shortcut.displayName, "⌥⌘P")
     }
 
     func testShortcutRecordingPreviewShowsHeldModifiers() throws {
@@ -54,7 +54,7 @@ final class GlobalShortcutServiceTests: XCTestCase {
             keyCode: UInt16(kVK_Option)
         ))
 
-        XCTAssertEqual(GlobalShortcut.recordingDisplayName(for: event), "⌘⌥")
+        XCTAssertEqual(GlobalShortcut.recordingDisplayName(for: event), "⌥⌘")
     }
 
     func testShortcutRecordingPreviewShowsFullChord() throws {
@@ -71,7 +71,7 @@ final class GlobalShortcutServiceTests: XCTestCase {
             keyCode: UInt16(kVK_ANSI_N)
         ))
 
-        XCTAssertEqual(GlobalShortcut.recordingDisplayName(for: event), "⌘⌥⇧N")
+        XCTAssertEqual(GlobalShortcut.recordingDisplayName(for: event), "⌥⇧⌘N")
     }
 
     func testShortcutRejectsBareKeyEvent() throws {

--- a/notchi/Tests/NotchContentViewTests.swift
+++ b/notchi/Tests/NotchContentViewTests.swift
@@ -67,4 +67,38 @@ final class NotchContentViewTests: XCTestCase {
             )
         )
     }
+
+    func testGrassIslandRendersOnlyForExpandedActivityView() {
+        XCTAssertTrue(
+            NotchContentView.shouldRenderGrassIsland(
+                isExpanded: true,
+                showingPanelSettings: false
+            )
+        )
+    }
+
+    func testGrassIslandStaysRenderedDuringCollapseHandoff() {
+        XCTAssertTrue(
+            NotchContentView.shouldRenderGrassIsland(
+                isExpanded: false,
+                showingPanelSettings: false,
+                keepsGrassIslandRenderedForHandoff: true
+            )
+        )
+    }
+
+    func testGrassIslandDoesNotRenderWhenCollapsedWithoutHandoffOrShowingSettings() {
+        XCTAssertFalse(
+            NotchContentView.shouldRenderGrassIsland(
+                isExpanded: false,
+                showingPanelSettings: false
+            )
+        )
+        XCTAssertFalse(
+            NotchContentView.shouldRenderGrassIsland(
+                isExpanded: true,
+                showingPanelSettings: true
+            )
+        )
+    }
 }

--- a/notchi/Tests/NotchPanelTests.swift
+++ b/notchi/Tests/NotchPanelTests.swift
@@ -1,0 +1,33 @@
+import AppKit
+import Carbon.HIToolbox
+import XCTest
+@testable import notchi
+
+final class NotchPanelTests: XCTestCase {
+    func testMiniaturizeShortcutMatchesCommandMAndCommandOptionM() throws {
+        XCTAssertTrue(NotchPanel.isMiniaturizeShortcut(try keyEvent(keyCode: kVK_ANSI_M, modifiers: [.command])))
+        XCTAssertTrue(NotchPanel.isMiniaturizeShortcut(try keyEvent(keyCode: kVK_ANSI_M, modifiers: [.command, .option])))
+    }
+
+    func testMiniaturizeShortcutIgnoresOtherKeyCombinations() throws {
+        XCTAssertFalse(NotchPanel.isMiniaturizeShortcut(try keyEvent(keyCode: kVK_ANSI_M, modifiers: [])))
+        XCTAssertFalse(NotchPanel.isMiniaturizeShortcut(try keyEvent(keyCode: kVK_ANSI_M, modifiers: [.option])))
+        XCTAssertFalse(NotchPanel.isMiniaturizeShortcut(try keyEvent(keyCode: kVK_ANSI_M, modifiers: [.command, .shift])))
+        XCTAssertFalse(NotchPanel.isMiniaturizeShortcut(try keyEvent(keyCode: kVK_ANSI_N, modifiers: [.command, .option])))
+    }
+
+    private func keyEvent(keyCode: Int, modifiers: NSEvent.ModifierFlags) throws -> NSEvent {
+        try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: UInt16(keyCode)
+        ))
+    }
+}

--- a/notchi/notchi/AppDelegate.swift
+++ b/notchi/notchi/AppDelegate.swift
@@ -10,6 +10,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
     private var notchPanel: NotchPanel?
     private let windowHeight: CGFloat = 500
     private let integrationCoordinator = IntegrationCoordinator.shared
+    private let globalShortcutService = GlobalShortcutService.shared
 
     private var updaterStarted = false
     private var temporarilyRegularForUpdateSession = false
@@ -41,6 +42,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
         NSApplication.shared.setActivationPolicy(.accessory)
         integrationCoordinator.prepareForLaunch()
         setupNotchWindow()
+        globalShortcutService.start()
         observeScreenChanges()
         observeWakeNotifications()
         startHookServices()
@@ -60,6 +62,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        globalShortcutService.stop()
         integrationCoordinator.stop()
         ClaudeUsageService.shared.stopPolling()
     }

--- a/notchi/notchi/AppDelegate.swift
+++ b/notchi/notchi/AppDelegate.swift
@@ -11,6 +11,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
     private let windowHeight: CGFloat = 500
     private let integrationCoordinator = IntegrationCoordinator.shared
     private let globalShortcutService = GlobalShortcutService.shared
+    private var minimizeShortcutMonitor: Any?
 
     private var updaterStarted = false
     private var temporarilyRegularForUpdateSession = false
@@ -43,6 +44,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
         integrationCoordinator.prepareForLaunch()
         setupNotchWindow()
         globalShortcutService.start()
+        installMinimizeShortcutGuard()
         observeScreenChanges()
         observeWakeNotifications()
         startHookServices()
@@ -62,6 +64,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        removeMinimizeShortcutGuard()
         globalShortcutService.stop()
         integrationCoordinator.stop()
         ClaudeUsageService.shared.stopPolling()
@@ -92,6 +95,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
         panel.orderFrontRegardless()
 
         self.notchPanel = panel
+    }
+
+    private func installMinimizeShortcutGuard() {
+        guard minimizeShortcutMonitor == nil else { return }
+        minimizeShortcutMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self,
+                  NSApp.activationPolicy() == .accessory,
+                  notchPanel?.isVisible == true,
+                  NotchPanel.isMiniaturizeShortcut(event) else {
+                return event
+            }
+
+            return nil
+        }
+    }
+
+    private func removeMinimizeShortcutGuard() {
+        if let minimizeShortcutMonitor {
+            NSEvent.removeMonitor(minimizeShortcutMonitor)
+            self.minimizeShortcutMonitor = nil
+        }
     }
 
     private func observeScreenChanges() {

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -88,6 +88,7 @@ enum EmotionAnalysisModel: String, CaseIterable, Identifiable {
 
 struct AppSettings {
     static let hideSpriteWhenIdleKey = "hideSpriteWhenIdle"
+    static let panelToggleShortcutKey = "panelToggleShortcut"
 
     private static let notificationSoundKey = "notificationSound"
     private static let notificationSoundSelectionKey = "notificationSoundSelection"
@@ -111,6 +112,19 @@ struct AppSettings {
     static var hideSpriteWhenIdle: Bool {
         get { UserDefaults.standard.bool(forKey: hideSpriteWhenIdleKey) }
         set { UserDefaults.standard.set(newValue, forKey: hideSpriteWhenIdleKey) }
+    }
+
+    static var panelToggleShortcut: GlobalShortcut {
+        get {
+            guard let rawValue = UserDefaults.standard.string(forKey: panelToggleShortcutKey),
+                  let shortcut = GlobalShortcut(rawValue: rawValue) else {
+                return .defaultTogglePanel
+            }
+            return shortcut
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: panelToggleShortcutKey)
+        }
     }
 
     static var lastUsedAgentProvider: AgentProvider {

--- a/notchi/notchi/Core/GlobalShortcut.swift
+++ b/notchi/notchi/Core/GlobalShortcut.swift
@@ -1,0 +1,155 @@
+import AppKit
+import Carbon.HIToolbox
+import Foundation
+
+nonisolated struct GlobalShortcut: Equatable, Sendable {
+    let keyCode: UInt32
+    let modifiers: UInt32
+
+    static let defaultTogglePanel = GlobalShortcut(
+        keyCode: UInt32(kVK_ANSI_N),
+        modifiers: UInt32(cmdKey | optionKey)
+    )
+
+    init(keyCode: UInt32, modifiers: UInt32) {
+        self.keyCode = keyCode
+        self.modifiers = modifiers
+    }
+
+    init?(rawValue: String) {
+        let parts = rawValue.split(separator: "|")
+        guard parts.count == 2,
+              let keyCode = UInt32(parts[0]),
+              let modifiers = UInt32(parts[1]) else {
+            return nil
+        }
+
+        self.keyCode = keyCode
+        self.modifiers = modifiers
+    }
+
+    init?(event: NSEvent) {
+        let keyCode = UInt32(event.keyCode)
+        guard !Self.modifierKeyCodes.contains(keyCode) else { return nil }
+
+        let modifiers = Self.carbonModifiers(from: event.modifierFlags)
+        guard Self.hasPrimaryModifier(modifiers) else { return nil }
+
+        self.keyCode = keyCode
+        self.modifiers = modifiers
+    }
+
+    var rawValue: String {
+        "\(keyCode)|\(modifiers)"
+    }
+
+    var displayName: String {
+        Self.displayName(modifiers: modifiers, keyCode: keyCode)
+    }
+
+    private nonisolated static let modifierKeyCodes: Set<UInt32> = [
+        UInt32(kVK_Command),
+        UInt32(kVK_RightCommand),
+        UInt32(kVK_Option),
+        UInt32(kVK_RightOption),
+        UInt32(kVK_Control),
+        UInt32(kVK_RightControl),
+        UInt32(kVK_Shift),
+        UInt32(kVK_RightShift),
+        UInt32(kVK_Function)
+    ]
+
+    nonisolated static func recordingDisplayName(for event: NSEvent) -> String? {
+        let keyCode = UInt32(event.keyCode)
+        let modifiers = carbonModifiers(from: event.modifierFlags)
+        let displayName = displayName(
+            modifiers: modifiers,
+            keyCode: modifierKeyCodes.contains(keyCode) ? nil : keyCode
+        )
+        return displayName.isEmpty ? nil : displayName
+    }
+
+    nonisolated static func displayName(modifiers: UInt32, keyCode: UInt32? = nil) -> String {
+        var symbols: [String] = []
+        if modifiers & UInt32(cmdKey) != 0 { symbols.append("⌘") }
+        if modifiers & UInt32(optionKey) != 0 { symbols.append("⌥") }
+        if modifiers & UInt32(controlKey) != 0 { symbols.append("⌃") }
+        if modifiers & UInt32(shiftKey) != 0 { symbols.append("⇧") }
+        if let keyCode {
+            symbols.append(keyDisplayName(for: keyCode))
+        }
+        return symbols.joined()
+    }
+
+    nonisolated static func carbonModifiers(from flags: NSEvent.ModifierFlags) -> UInt32 {
+        var modifiers: UInt32 = 0
+        if flags.contains(.command) { modifiers |= UInt32(cmdKey) }
+        if flags.contains(.option) { modifiers |= UInt32(optionKey) }
+        if flags.contains(.control) { modifiers |= UInt32(controlKey) }
+        if flags.contains(.shift) { modifiers |= UInt32(shiftKey) }
+        return modifiers
+    }
+
+    private nonisolated static func hasPrimaryModifier(_ modifiers: UInt32) -> Bool {
+        modifiers & UInt32(cmdKey | optionKey | controlKey) != 0
+    }
+
+    private nonisolated static func keyDisplayName(for keyCode: UInt32) -> String {
+        keyDisplayNames[keyCode] ?? "Key \(keyCode)"
+    }
+
+    private nonisolated static let keyDisplayNames: [UInt32: String] = [
+        UInt32(kVK_ANSI_A): "A",
+        UInt32(kVK_ANSI_B): "B",
+        UInt32(kVK_ANSI_C): "C",
+        UInt32(kVK_ANSI_D): "D",
+        UInt32(kVK_ANSI_E): "E",
+        UInt32(kVK_ANSI_F): "F",
+        UInt32(kVK_ANSI_G): "G",
+        UInt32(kVK_ANSI_H): "H",
+        UInt32(kVK_ANSI_I): "I",
+        UInt32(kVK_ANSI_J): "J",
+        UInt32(kVK_ANSI_K): "K",
+        UInt32(kVK_ANSI_L): "L",
+        UInt32(kVK_ANSI_M): "M",
+        UInt32(kVK_ANSI_N): "N",
+        UInt32(kVK_ANSI_O): "O",
+        UInt32(kVK_ANSI_P): "P",
+        UInt32(kVK_ANSI_Q): "Q",
+        UInt32(kVK_ANSI_R): "R",
+        UInt32(kVK_ANSI_S): "S",
+        UInt32(kVK_ANSI_T): "T",
+        UInt32(kVK_ANSI_U): "U",
+        UInt32(kVK_ANSI_V): "V",
+        UInt32(kVK_ANSI_W): "W",
+        UInt32(kVK_ANSI_X): "X",
+        UInt32(kVK_ANSI_Y): "Y",
+        UInt32(kVK_ANSI_Z): "Z",
+        UInt32(kVK_ANSI_0): "0",
+        UInt32(kVK_ANSI_1): "1",
+        UInt32(kVK_ANSI_2): "2",
+        UInt32(kVK_ANSI_3): "3",
+        UInt32(kVK_ANSI_4): "4",
+        UInt32(kVK_ANSI_5): "5",
+        UInt32(kVK_ANSI_6): "6",
+        UInt32(kVK_ANSI_7): "7",
+        UInt32(kVK_ANSI_8): "8",
+        UInt32(kVK_ANSI_9): "9",
+        UInt32(kVK_ANSI_Period): ".",
+        UInt32(kVK_ANSI_Comma): ",",
+        UInt32(kVK_ANSI_Slash): "/",
+        UInt32(kVK_ANSI_Semicolon): ";",
+        UInt32(kVK_ANSI_Quote): "'",
+        UInt32(kVK_ANSI_LeftBracket): "[",
+        UInt32(kVK_ANSI_RightBracket): "]",
+        UInt32(kVK_ANSI_Backslash): "\\",
+        UInt32(kVK_ANSI_Grave): "`",
+        UInt32(kVK_ANSI_Minus): "-",
+        UInt32(kVK_ANSI_Equal): "=",
+        UInt32(kVK_Space): "Space",
+        UInt32(kVK_Return): "Return",
+        UInt32(kVK_Tab): "Tab",
+        UInt32(kVK_Delete): "Delete",
+        UInt32(kVK_Escape): "Esc"
+    ]
+}

--- a/notchi/notchi/Core/GlobalShortcut.swift
+++ b/notchi/notchi/Core/GlobalShortcut.swift
@@ -69,12 +69,13 @@ nonisolated struct GlobalShortcut: Equatable, Sendable {
         return displayName.isEmpty ? nil : displayName
     }
 
+    // Modifier glyph order follows the macOS HIG: Control, Option, Shift, Command.
     nonisolated static func displayName(modifiers: UInt32, keyCode: UInt32? = nil) -> String {
         var symbols: [String] = []
-        if modifiers & UInt32(cmdKey) != 0 { symbols.append("⌘") }
-        if modifiers & UInt32(optionKey) != 0 { symbols.append("⌥") }
         if modifiers & UInt32(controlKey) != 0 { symbols.append("⌃") }
+        if modifiers & UInt32(optionKey) != 0 { symbols.append("⌥") }
         if modifiers & UInt32(shiftKey) != 0 { symbols.append("⇧") }
+        if modifiers & UInt32(cmdKey) != 0 { symbols.append("⌘") }
         if let keyCode {
             symbols.append(keyDisplayName(for: keyCode))
         }

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -46,6 +46,7 @@ struct NotchContentView: View {
 
         let direction: Direction
         let sessionId: String
+        let keepsGrassIslandRendered: Bool
     }
 
     struct LaunchWave: Equatable {
@@ -154,6 +155,32 @@ struct NotchContentView: View {
             mirrorSeed: "fallback-\(launchSpriteFamily.rawValue)"
         )
     }
+
+    static func shouldRenderGrassIsland(
+        isExpanded: Bool,
+        showingPanelSettings: Bool,
+        keepsGrassIslandRenderedForHandoff: Bool = false
+    ) -> Bool {
+        shouldShowGrassIsland(isExpanded: isExpanded, showingPanelSettings: showingPanelSettings)
+            || keepsGrassIslandRenderedForHandoff
+    }
+
+    static func shouldShowGrassIsland(isExpanded: Bool, showingPanelSettings: Bool) -> Bool {
+        isExpanded && !showingPanelSettings
+    }
+
+    private var shouldRenderGrassIsland: Bool {
+        Self.shouldRenderGrassIsland(
+            isExpanded: isExpanded,
+            showingPanelSettings: showingPanelSettings,
+            keepsGrassIslandRenderedForHandoff: spriteHandoff?.keepsGrassIslandRendered == true
+        )
+    }
+
+    private var shouldShowGrassIsland: Bool {
+        Self.shouldShowGrassIsland(isExpanded: isExpanded, showingPanelSettings: showingPanelSettings)
+    }
+
     private var collapsedHoverHorizontalInset: CGFloat {
         !isExpanded && panelManager.isCollapsedHovered
             ? NotchPanelManager.collapsedHoverHorizontalInset
@@ -281,6 +308,10 @@ struct NotchContentView: View {
         .easeInOut(duration: LaunchWaveTiming.preparationDuration)
     }
 
+    private var grassIslandOpacityAnimation: Animation {
+        .easeOut(duration: SpriteHandoffTiming.collapseAnimationDuration)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             notchLayout
@@ -295,20 +326,23 @@ struct NotchContentView: View {
         .background {
             ZStack(alignment: .top) {
                 Color.black
-                GrassIslandView(
-                    sessions: sessionStore.sortedSessions,
-                    selectedSessionId: sessionStore.selectedSessionId,
-                    hoveredSessionId: hoveredSessionId,
-                    handoffSessionId: spriteHandoff?.sessionId,
-                    handoffProgress: spriteHandoffProgress,
-                    isHandoffCollapsing: spriteHandoff?.direction == .collapsing
-                )
+                if shouldRenderGrassIsland {
+                    GrassIslandView(
+                        sessions: sessionStore.sortedSessions,
+                        selectedSessionId: sessionStore.selectedSessionId,
+                        hoveredSessionId: hoveredSessionId,
+                        handoffSessionId: spriteHandoff?.sessionId,
+                        handoffProgress: spriteHandoffProgress,
+                        isHandoffCollapsing: spriteHandoff?.direction == .collapsing
+                    )
                     .frame(height: grassHeight, alignment: .bottom)
-                    .opacity(isExpanded && !showingPanelSettings ? 1 : 0)
+                    .opacity(shouldShowGrassIsland ? 1 : 0)
+                    .animation(grassIslandOpacityAnimation, value: shouldShowGrassIsland)
+                }
             }
         }
         .overlay(alignment: .top) {
-            if isExpanded && !showingPanelSettings {
+            if shouldShowGrassIsland {
                 GrassTapOverlay(
                     sessions: sessionStore.sortedSessions,
                     selectedSessionId: sessionStore.selectedSessionId,
@@ -324,7 +358,7 @@ struct NotchContentView: View {
             }
         }
         .overlay(alignment: .topTrailing) {
-            if isExpanded && !showingPanelSettings {
+            if shouldShowGrassIsland {
                 Button(action: {
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
                         isActivityCollapsed.toggle()
@@ -375,8 +409,11 @@ struct NotchContentView: View {
             }
             panelManager.collapse()
         }
-        .onChange(of: isExpanded) { _, expanded in
-            startSpriteHandoff(for: expanded)
+        .onChange(of: isExpanded) { wasExpanded, expanded in
+            startSpriteHandoff(
+                for: expanded,
+                keepsGrassIslandRendered: wasExpanded && !showingPanelSettings
+            )
             updateKeyboardFocus(for: expanded)
             if !expanded {
                 showingPanelSettings = false
@@ -535,7 +572,7 @@ struct NotchContentView: View {
         if let headerSpriteContent {
             SessionSpriteView(
                 state: headerSpriteContent.state,
-                isSelected: true,
+                isPrimarySprite: true,
                 mirrorSeed: headerSpriteContent.mirrorSeed,
                 animationStartDate: headerSpriteContent.startedAt,
                 repeatsAnimation: headerSpriteContent.repeatsAnimation
@@ -545,7 +582,7 @@ struct NotchContentView: View {
         }
     }
 
-    private func startSpriteHandoff(for expanded: Bool) {
+    private func startSpriteHandoff(for expanded: Bool, keepsGrassIslandRendered: Bool) {
         spriteHandoffGeneration += 1
         let generation = spriteHandoffGeneration
 
@@ -559,7 +596,8 @@ struct NotchContentView: View {
 
         spriteHandoff = SpriteHandoff(
             direction: expanded ? .expanding : .collapsing,
-            sessionId: activeSession.id
+            sessionId: activeSession.id,
+            keepsGrassIslandRendered: keepsGrassIslandRendered
         )
         spriteHandoffProgress = 0
 

--- a/notchi/notchi/NotchPanel.swift
+++ b/notchi/notchi/NotchPanel.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon.HIToolbox
 
 /// A borderless, transparent panel positioned at the MacBook notch area
 final class NotchPanel: NSPanel {
@@ -25,6 +26,7 @@ final class NotchPanel: NSPanel {
         backgroundColor = .clear
         hasShadow = false
         isMovable = false
+        isExcludedFromWindowsMenu = true
 
         // Hit testing is handled by NotchHitTestView (the content view wrapper)
         // which selectively passes through events based on notch/panel rect
@@ -32,6 +34,10 @@ final class NotchPanel: NSPanel {
 
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
+
+    override func miniaturize(_ sender: Any?) {}
+
+    override func performMiniaturize(_ sender: Any?) {}
 
     override func sendEvent(_ event: NSEvent) {
         if event.type == .leftMouseDown, !isKeyWindow {
@@ -41,7 +47,7 @@ final class NotchPanel: NSPanel {
     }
 
     override func keyDown(with event: NSEvent) {
-        if event.keyCode == 53 {
+        if event.keyCode == UInt16(kVK_Escape) {
             NotificationCenter.default.post(name: .notchiShouldCollapse, object: nil)
             return
         }
@@ -59,5 +65,11 @@ final class NotchPanel: NSPanel {
         }
 
         super.keyDown(with: event)
+    }
+
+    nonisolated static func isMiniaturizeShortcut(_ event: NSEvent) -> Bool {
+        guard event.keyCode == UInt16(kVK_ANSI_M) else { return false }
+        let modifiers = event.modifierFlags.intersection([.command, .control, .option, .shift])
+        return modifiers == [.command] || modifiers == [.command, .option]
     }
 }

--- a/notchi/notchi/Services/AgentProviderAdapter.swift
+++ b/notchi/notchi/Services/AgentProviderAdapter.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+nonisolated enum AgentHookInstallStatus: Equatable, Sendable {
+    case installed
+    case notInstalled
+    case providerUnavailable
+    case failed
+}
+
 nonisolated protocol AgentProviderAdapter: Sendable {
     nonisolated var provider: AgentProvider { get }
 
@@ -12,4 +19,24 @@ nonisolated protocol AgentProviderAdapter: Sendable {
     nonisolated func isInstalled() -> Bool
     nonisolated func configureForLaunch()
     nonisolated func normalize(_ envelope: AgentHookEnvelope) -> HookEvent?
+}
+
+nonisolated extension AgentProviderAdapter {
+    func installStatus() -> AgentHookInstallStatus {
+        guard isProviderAvailable() else {
+            return .providerUnavailable
+        }
+        return isInstalled() ? .installed : .notInstalled
+    }
+
+    @discardableResult
+    func installIfNeededStatus() -> AgentHookInstallStatus {
+        guard isProviderAvailable() else {
+            return .providerUnavailable
+        }
+        guard installIfNeeded(), isInstalled() else {
+            return .failed
+        }
+        return .installed
+    }
 }

--- a/notchi/notchi/Services/GlobalShortcutService.swift
+++ b/notchi/notchi/Services/GlobalShortcutService.swift
@@ -1,0 +1,162 @@
+import Carbon.HIToolbox
+import Foundation
+import os.log
+
+private let globalShortcutLogger = Logger(subsystem: "com.ruban.notchi", category: "GlobalShortcutService")
+
+@MainActor
+final class GlobalShortcutService {
+    static let shared = GlobalShortcutService()
+
+    static var togglePanelShortcut: GlobalShortcut { AppSettings.panelToggleShortcut }
+    nonisolated static let togglePanelHotKeyID = EventHotKeyID(signature: 0x4E544348, id: 1)
+
+    private let togglePanel: @MainActor () -> Void
+    private var hotKeyRef: EventHotKeyRef?
+    private var eventHandlerRef: EventHandlerRef?
+    private var settingsObserver: NSObjectProtocol?
+    private var lastAttemptedShortcut: GlobalShortcut?
+    private var isShortcutSuspended = false
+
+    init(togglePanel: @escaping @MainActor () -> Void = { NotchPanelManager.shared.toggle() }) {
+        self.togglePanel = togglePanel
+    }
+
+    func start() {
+        guard eventHandlerRef == nil else {
+            reloadShortcutIfNeeded()
+            return
+        }
+
+        var eventType = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+
+        let handlerStatus = InstallEventHandler(
+            GetApplicationEventTarget(),
+            Self.hotKeyEventHandler,
+            1,
+            &eventType,
+            Unmanaged.passUnretained(self).toOpaque(),
+            &eventHandlerRef
+        )
+        guard handlerStatus == noErr else {
+            eventHandlerRef = nil
+            globalShortcutLogger.error("Failed to install global shortcut handler: \(handlerStatus)")
+            return
+        }
+
+        settingsObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak service = self] in
+                service?.reloadShortcutIfNeeded()
+            }
+        }
+
+        registerCurrentShortcut()
+    }
+
+    func stop() {
+        unregisterCurrentShortcut()
+        lastAttemptedShortcut = nil
+        isShortcutSuspended = false
+
+        if let eventHandlerRef {
+            RemoveEventHandler(eventHandlerRef)
+            self.eventHandlerRef = nil
+        }
+
+        if let settingsObserver {
+            NotificationCenter.default.removeObserver(settingsObserver)
+            self.settingsObserver = nil
+        }
+    }
+
+    func suspendShortcut() {
+        isShortcutSuspended = true
+        unregisterCurrentShortcut()
+    }
+
+    func reloadShortcut() {
+        guard eventHandlerRef != nil else { return }
+        isShortcutSuspended = false
+        unregisterCurrentShortcut()
+        registerCurrentShortcut()
+    }
+
+    private func reloadShortcutIfNeeded() {
+        guard eventHandlerRef != nil, !isShortcutSuspended else { return }
+        let shortcut = Self.togglePanelShortcut
+        guard shortcut != lastAttemptedShortcut else { return }
+        reloadShortcut()
+    }
+
+    private func registerCurrentShortcut() {
+        let shortcut = Self.togglePanelShortcut
+        lastAttemptedShortcut = shortcut
+        var registeredHotKeyRef: EventHotKeyRef?
+        let registerStatus = RegisterEventHotKey(
+            shortcut.keyCode,
+            shortcut.modifiers,
+            Self.togglePanelHotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &registeredHotKeyRef
+        )
+        guard registerStatus == noErr else {
+            globalShortcutLogger.error("Failed to register global shortcut: \(registerStatus)")
+            return
+        }
+
+        hotKeyRef = registeredHotKeyRef
+    }
+
+    private func unregisterCurrentShortcut() {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+            self.hotKeyRef = nil
+        }
+    }
+
+    func handleHotKey(signature: OSType, id: UInt32) {
+        guard Self.isTogglePanelHotKey(signature: signature, id: id) else { return }
+        togglePanel()
+    }
+
+    func handleHotKey(_ hotKeyID: EventHotKeyID) {
+        handleHotKey(signature: hotKeyID.signature, id: hotKeyID.id)
+    }
+
+    nonisolated static func isTogglePanelHotKey(signature: OSType, id: UInt32) -> Bool {
+        signature == togglePanelHotKeyID.signature &&
+            id == togglePanelHotKeyID.id
+    }
+
+    private nonisolated static let hotKeyEventHandler: EventHandlerUPP = { _, eventRef, userData in
+        guard let eventRef, let userData else { return noErr }
+
+        var hotKeyID = EventHotKeyID()
+        let status = GetEventParameter(
+            eventRef,
+            EventParamName(kEventParamDirectObject),
+            EventParamType(typeEventHotKeyID),
+            nil,
+            MemoryLayout<EventHotKeyID>.size,
+            nil,
+            &hotKeyID
+        )
+        guard status == noErr else { return status }
+
+        let service = Unmanaged<GlobalShortcutService>.fromOpaque(userData).takeUnretainedValue()
+        let capturedHotKeyID = hotKeyID
+        Task { @MainActor in
+            service.handleHotKey(capturedHotKeyID)
+        }
+
+        return noErr
+    }
+}

--- a/notchi/notchi/Services/IntegrationCoordinator.swift
+++ b/notchi/notchi/Services/IntegrationCoordinator.swift
@@ -36,13 +36,17 @@ nonisolated final class IntegrationCoordinator: @unchecked Sendable {
 
     func installHooksIfNeeded() {
         for provider in AgentProvider.allCases {
-            _ = adaptersByProvider[provider]?.installIfNeeded()
+            _ = adaptersByProvider[provider]?.installIfNeededStatus()
         }
     }
 
     @discardableResult
-    func installHooksIfNeeded(for provider: AgentProvider) -> Bool {
-        adaptersByProvider[provider]?.installIfNeeded() ?? false
+    func installHooksIfNeededStatus(for provider: AgentProvider) -> AgentHookInstallStatus {
+        adaptersByProvider[provider]?.installIfNeededStatus() ?? .providerUnavailable
+    }
+
+    func installStatus(for provider: AgentProvider) -> AgentHookInstallStatus {
+        adaptersByProvider[provider]?.installStatus() ?? .providerUnavailable
     }
 
     func isInstalled(for provider: AgentProvider) -> Bool {

--- a/notchi/notchi/Views/Components/ShortcutRecorderView.swift
+++ b/notchi/notchi/Views/Components/ShortcutRecorderView.swift
@@ -1,0 +1,187 @@
+import AppKit
+import Carbon.HIToolbox
+import SwiftUI
+
+struct ShortcutRecorderView: View {
+    private static let recordingPrompt = "Press keys"
+
+    let shortcut: GlobalShortcut
+    var onBeginRecording: () -> Void = {}
+    var onCancelRecording: () -> Void = {}
+    var onReset: () -> Void
+    var onShortcutChange: (GlobalShortcut) -> Void
+
+    @State private var isRecording = false
+    @State private var didRejectLastKey = false
+    @State private var recordingPreview = Self.recordingPrompt
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if shortcut != .defaultTogglePanel {
+                Button(action: resetShortcut) {
+                    Image(systemName: "arrow.counterclockwise")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(TerminalColors.dimmedText)
+                        .frame(width: 18, height: 18)
+                }
+                .buttonStyle(.plain)
+                .help("Reset shortcut")
+            }
+
+            Button(action: beginRecording) {
+                Text(buttonText)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(buttonForeground)
+                    .lineLimit(1)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 3)
+                    .background(buttonBackground)
+                    .cornerRadius(5)
+            }
+            .buttonStyle(.plain)
+            .modifier(HorizontalShake(animatableData: didRejectLastKey ? 1 : 0))
+        }
+        .background {
+            if isRecording {
+                ShortcutCaptureView(
+                    onCapture: captureShortcut,
+                    onCancel: cancelRecording,
+                    onPreview: updateRecordingPreview,
+                    onReject: rejectShortcut
+                )
+                .frame(width: 1, height: 1)
+                .opacity(0.01)
+            }
+        }
+        .onDisappear {
+            guard isRecording else { return }
+            isRecording = false
+            onCancelRecording()
+        }
+    }
+
+    private var buttonText: String {
+        if isRecording {
+            return recordingPreview
+        }
+        return shortcut.displayName
+    }
+
+    private var buttonForeground: Color {
+        isRecording ? TerminalColors.amber : TerminalColors.primaryText
+    }
+
+    private var buttonBackground: Color {
+        isRecording ? TerminalColors.amber.opacity(0.15) : Color.white.opacity(0.09)
+    }
+
+    private func beginRecording() {
+        guard !isRecording else { return }
+        didRejectLastKey = false
+        recordingPreview = Self.recordingPrompt
+        isRecording = true
+        onBeginRecording()
+    }
+
+    private func captureShortcut(_ newShortcut: GlobalShortcut) {
+        isRecording = false
+        didRejectLastKey = false
+        recordingPreview = Self.recordingPrompt
+        onShortcutChange(newShortcut)
+    }
+
+    private func cancelRecording() {
+        isRecording = false
+        didRejectLastKey = false
+        recordingPreview = Self.recordingPrompt
+        onCancelRecording()
+    }
+
+    private func resetShortcut() {
+        onReset()
+    }
+
+    private func rejectShortcut() {
+        NSSound.beep()
+        withAnimation(.linear(duration: 0.12)) {
+            didRejectLastKey = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+            didRejectLastKey = false
+        }
+    }
+
+    private func updateRecordingPreview(_ preview: String?) {
+        recordingPreview = preview ?? Self.recordingPrompt
+    }
+}
+
+private struct ShortcutCaptureView: NSViewRepresentable {
+    var onCapture: (GlobalShortcut) -> Void
+    var onCancel: () -> Void
+    var onPreview: (String?) -> Void
+    var onReject: () -> Void
+
+    func makeNSView(context: Context) -> CaptureView {
+        let view = CaptureView()
+        view.onCapture = onCapture
+        view.onCancel = onCancel
+        view.onPreview = onPreview
+        view.onReject = onReject
+        return view
+    }
+
+    func updateNSView(_ nsView: CaptureView, context: Context) {
+        nsView.onCapture = onCapture
+        nsView.onCancel = onCancel
+        nsView.onPreview = onPreview
+        nsView.onReject = onReject
+
+        DispatchQueue.main.async {
+            nsView.window?.makeFirstResponder(nsView)
+        }
+    }
+
+    final class CaptureView: NSView {
+        var onCapture: (GlobalShortcut) -> Void = { _ in }
+        var onCancel: () -> Void = {}
+        var onPreview: (String?) -> Void = { _ in }
+        var onReject: () -> Void = {}
+
+        override var acceptsFirstResponder: Bool { true }
+
+        override func keyDown(with event: NSEvent) {
+            if event.keyCode == UInt16(kVK_Escape) {
+                onCancel()
+                return
+            }
+
+            guard let shortcut = GlobalShortcut(event: event) else {
+                onPreview(GlobalShortcut.recordingDisplayName(for: event))
+                onReject()
+                return
+            }
+
+            onCapture(shortcut)
+        }
+
+        override func flagsChanged(with event: NSEvent) {
+            onPreview(GlobalShortcut.recordingDisplayName(for: event))
+        }
+    }
+}
+
+private struct HorizontalShake: GeometryEffect {
+    var travelDistance: CGFloat = 3
+    var cyclesPerUnit: CGFloat = 1
+    var animatableData: CGFloat
+
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        ProjectionTransform(
+            CGAffineTransform(
+                translationX: travelDistance * sin(animatableData * .pi * 2 * cyclesPerUnit),
+                y: 0
+            )
+        )
+    }
+}

--- a/notchi/notchi/Views/Components/ShortcutRecorderView.swift
+++ b/notchi/notchi/Views/Components/ShortcutRecorderView.swift
@@ -138,6 +138,7 @@ private struct ShortcutCaptureView: NSViewRepresentable {
         nsView.onReject = onReject
 
         DispatchQueue.main.async {
+            guard nsView.superview != nil else { return }
             nsView.window?.makeFirstResponder(nsView)
         }
     }

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -57,6 +57,7 @@ struct PanelSettingsView: View {
     @Binding private var showingEmotionAnalysisSettings: Bool
     private let sessionStore: SessionStore
     @AppStorage(AppSettings.hideSpriteWhenIdleKey) private var hideSpriteWhenIdle = false
+    @State private var panelToggleShortcut = AppSettings.panelToggleShortcut
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var claudeHooksStatus = IntegrationCoordinator.shared.installStatus(for: .claude)
     @State private var codexHooksStatus = IntegrationCoordinator.shared.installStatus(for: .codex)
@@ -94,7 +95,10 @@ struct PanelSettingsView: View {
         .padding(.horizontal, SettingsLayout.panelHorizontalPadding)
         .padding(.top, SettingsLayout.topPadding)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .onAppear(perform: refreshHookStatuses)
+        .onAppear {
+            refreshHookStatuses()
+            panelToggleShortcut = AppSettings.panelToggleShortcut
+        }
     }
 
     private var mainSettings: some View {
@@ -122,6 +126,16 @@ struct PanelSettingsView: View {
             ScreenPickerRow(screenSelector: ScreenSelector.shared)
 
             SoundPickerView()
+
+            SettingsRowView(icon: "keyboard", title: "Toggle Panel") {
+                ShortcutRecorderView(
+                    shortcut: panelToggleShortcut,
+                    onBeginRecording: beginPanelShortcutRecording,
+                    onCancelRecording: endPanelShortcutRecording,
+                    onReset: resetPanelToggleShortcut,
+                    onShortcutChange: updatePanelToggleShortcut
+                )
+            }
 
             Button(action: toggleLaunchAtLogin) {
                 SettingsRowView(icon: "power", title: "Launch at Login") {
@@ -286,6 +300,24 @@ struct PanelSettingsView: View {
 
     private func toggleHideSpriteWhenIdle() {
         hideSpriteWhenIdle.toggle()
+    }
+
+    private func beginPanelShortcutRecording() {
+        GlobalShortcutService.shared.suspendShortcut()
+    }
+
+    private func endPanelShortcutRecording() {
+        GlobalShortcutService.shared.reloadShortcut()
+    }
+
+    private func updatePanelToggleShortcut(_ shortcut: GlobalShortcut) {
+        panelToggleShortcut = shortcut
+        AppSettings.panelToggleShortcut = shortcut
+        GlobalShortcutService.shared.reloadShortcut()
+    }
+
+    private func resetPanelToggleShortcut() {
+        updatePanelToggleShortcut(.defaultTogglePanel)
     }
 
     private func toggleHooksExpanded() {

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -4,13 +4,6 @@ import os.log
 
 private let logger = Logger(subsystem: "com.ruban.notchi", category: "PanelSettingsView")
 
-private enum HookInstallBadgeState {
-    case installed
-    case notInstalled
-    case providerMissing
-    case error
-}
-
 private struct StatusBadge {
     let text: String
     let color: Color
@@ -65,10 +58,8 @@ struct PanelSettingsView: View {
     private let sessionStore: SessionStore
     @AppStorage(AppSettings.hideSpriteWhenIdleKey) private var hideSpriteWhenIdle = false
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
-    @State private var claudeHooksInstalled = IntegrationCoordinator.shared.isInstalled(for: .claude)
-    @State private var claudeHooksError = false
-    @State private var codexHooksInstalled = IntegrationCoordinator.shared.isInstalled(for: .codex)
-    @State private var codexHooksError = false
+    @State private var claudeHooksStatus = IntegrationCoordinator.shared.installStatus(for: .claude)
+    @State private var codexHooksStatus = IntegrationCoordinator.shared.installStatus(for: .codex)
     @State private var areHooksExpanded = false
     @ObservedObject private var updateManager = UpdateManager.shared
     private var usageConnected: Bool { ClaudeUsageService.shared.isConnected }
@@ -103,6 +94,7 @@ struct PanelSettingsView: View {
         .padding(.horizontal, SettingsLayout.panelHorizontalPadding)
         .padding(.top, SettingsLayout.topPadding)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onAppear(perform: refreshHookStatuses)
     }
 
     private var mainSettings: some View {
@@ -182,15 +174,15 @@ struct PanelSettingsView: View {
 
     private var hooksProviderList: some View {
         VStack(alignment: .leading, spacing: 4) {
-            hookProviderRow(for: .claude, installed: claudeHooksInstalled, error: claudeHooksError)
-            hookProviderRow(for: .codex, installed: codexHooksInstalled, error: codexHooksError)
+            hookProviderRow(for: .claude, status: claudeHooksStatus)
+            hookProviderRow(for: .codex, status: codexHooksStatus)
         }
         .padding(.vertical, SettingsLayout.pickerInset)
         .background(TerminalColors.subtleBackground)
         .cornerRadius(8)
     }
 
-    private func hookProviderRow(for provider: AgentProvider, installed: Bool, error: Bool) -> some View {
+    private func hookProviderRow(for provider: AgentProvider, status: AgentHookInstallStatus) -> some View {
         Button(action: { installHooksIfNeeded(for: provider) }) {
             HStack(spacing: 8) {
                 Text(provider.displayName)
@@ -199,8 +191,7 @@ struct PanelSettingsView: View {
 
                 Spacer()
 
-                let status = hookProviderStatus(for: provider, installed: installed, error: error)
-                statusBadge(status)
+                statusBadge(hookProviderStatus(status))
             }
             .padding(.horizontal, SettingsLayout.pickerOptionHorizontalPadding)
             .padding(.vertical, SettingsLayout.pickerOptionVerticalPadding)
@@ -301,6 +292,9 @@ struct PanelSettingsView: View {
         withAnimation(.spring(response: 0.3)) {
             areHooksExpanded.toggle()
         }
+        if areHooksExpanded {
+            refreshHookStatuses()
+        }
     }
 
     private func handleUpdatesAction() {
@@ -311,19 +305,6 @@ struct PanelSettingsView: View {
         }
     }
 
-    private func hookStatus(for provider: AgentProvider, installed: Bool, error: Bool) -> HookInstallBadgeState {
-        guard IntegrationCoordinator.shared.isProviderAvailable(for: provider) else {
-            return .providerMissing
-        }
-        return hookStatus(installed: installed, error: error)
-    }
-
-    private func hookStatus(installed: Bool, error: Bool) -> HookInstallBadgeState {
-        if error { return .error }
-        if installed { return .installed }
-        return .notInstalled
-    }
-
     private func hooksSummaryStatus() -> StatusBadge {
         let states = availableHookStates()
 
@@ -331,7 +312,7 @@ struct PanelSettingsView: View {
             return StatusBadge(text: "Unavailable", color: TerminalColors.amber)
         }
 
-        if states.contains(.error) {
+        if states.contains(.failed) {
             return StatusBadge(text: "Error", color: TerminalColors.red)
         }
 
@@ -347,30 +328,21 @@ struct PanelSettingsView: View {
         return StatusBadge(text: "Set Up", color: TerminalColors.amber)
     }
 
-    private func availableHookStates() -> [HookInstallBadgeState] {
-        AgentProvider.allCases.compactMap { provider in
-            guard IntegrationCoordinator.shared.isProviderAvailable(for: provider) else {
-                return nil
-            }
-
-            switch provider {
-            case .claude:
-                return hookStatus(installed: claudeHooksInstalled, error: claudeHooksError)
-            case .codex:
-                return hookStatus(installed: codexHooksInstalled, error: codexHooksError)
-            }
+    private func availableHookStates() -> [AgentHookInstallStatus] {
+        [claudeHooksStatus, codexHooksStatus].filter { status in
+            status != .providerUnavailable
         }
     }
 
-    private func hookProviderStatus(for provider: AgentProvider, installed: Bool, error: Bool) -> StatusBadge {
-        switch hookStatus(for: provider, installed: installed, error: error) {
+    private func hookProviderStatus(_ status: AgentHookInstallStatus) -> StatusBadge {
+        switch status {
         case .installed:
             StatusBadge(text: "Installed", color: TerminalColors.green)
         case .notInstalled:
             StatusBadge(text: "Install", color: TerminalColors.amber)
-        case .providerMissing:
+        case .providerUnavailable:
             StatusBadge(text: "Not Found", color: TerminalColors.amber)
-        case .error:
+        case .failed:
             StatusBadge(text: "Error", color: TerminalColors.red)
         }
     }
@@ -381,7 +353,7 @@ struct PanelSettingsView: View {
             isClaudeUsageConnected: usageConnected,
             hasActiveClaudeSession: sessions.contains { $0.provider == .claude },
             hasActiveCodexSession: sessions.contains { $0.provider == .codex },
-            codexHooksInstalled: codexHooksInstalled
+            codexHooksInstalled: codexHooksStatus == .installed
         )
         return StatusBadge(text: state.text, color: state.color)
     }
@@ -389,36 +361,17 @@ struct PanelSettingsView: View {
     private func installHooksIfNeeded(for provider: AgentProvider) {
         switch provider {
         case .claude:
-            guard !claudeHooksInstalled else { return }
-            claudeHooksError = false
+            guard claudeHooksStatus != .installed else { return }
+            claudeHooksStatus = IntegrationCoordinator.shared.installHooksIfNeededStatus(for: provider)
         case .codex:
-            guard !codexHooksInstalled else { return }
-            codexHooksError = false
+            guard codexHooksStatus != .installed else { return }
+            codexHooksStatus = IntegrationCoordinator.shared.installHooksIfNeededStatus(for: provider)
         }
+    }
 
-        guard IntegrationCoordinator.shared.isProviderAvailable(for: provider) else {
-            switch provider {
-            case .claude:
-                claudeHooksInstalled = false
-                claudeHooksError = false
-            case .codex:
-                codexHooksInstalled = false
-                codexHooksError = false
-            }
-            return
-        }
-
-        let success = IntegrationCoordinator.shared.installHooksIfNeeded(for: provider)
-        let installed = IntegrationCoordinator.shared.isInstalled(for: provider)
-
-        switch provider {
-        case .claude:
-            claudeHooksInstalled = installed
-            claudeHooksError = !success || !installed
-        case .codex:
-            codexHooksInstalled = installed
-            codexHooksError = !success || !installed
-        }
+    private func refreshHookStatuses() {
+        claudeHooksStatus = IntegrationCoordinator.shared.installStatus(for: .claude)
+        codexHooksStatus = IntegrationCoordinator.shared.installStatus(for: .codex)
     }
 
     private func statusBadge(_ text: String, color: Color) -> some View {

--- a/notchi/notchi/Views/SessionSpriteView.swift
+++ b/notchi/notchi/Views/SessionSpriteView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct SessionSpriteView: View {
     let state: NotchiState
-    let isSelected: Bool
+    let isPrimarySprite: Bool
     var mirrorSeed: String = "session-sprite"
     var animationStartDate: Date = SpriteAnimationPhase.sharedLoopAnchor
     var repeatsAnimation = true
@@ -12,7 +12,7 @@ struct SessionSpriteView: View {
 
     private var bobAmplitude: CGFloat {
         guard state.bobAmplitude > 0 else { return 0 }
-        return isSelected ? state.bobAmplitude : state.bobAmplitude * 0.67
+        return isPrimarySprite ? state.bobAmplitude : state.bobAmplitude * 0.67
     }
 
     private static let sobTrembleAmplitude: CGFloat = 0.2


### PR DESCRIPTION
## Summary

A batch of "Easy Wins" cleanups and small features, each self-contained and tested.

- **perf: render grass island only when expanded or handing off** (`c18d56c`)
  Mount `GrassIslandView` conditionally instead of always-on-with-opacity, while keeping it alive through the collapse handoff so the sprite animation still renders.

- **feat: distinguish hook install failure from not-installed** (`c162b0a`)
  New `AgentHookInstallStatus` enum lets settings tell a real install failure apart from hooks simply not being set up yet; status logic centralised in an `AgentProviderAdapter` extension.

- **feat: configurable global shortcut to toggle the panel** (`fcee8ed`)
  Carbon global hotkey (default ⌘⌥N) with an in-settings recorder to rebind/reset. Works under the App Sandbox with no Accessibility permission; recording reads keys only while the in-app recorder is focused.

- **feat: stop the notch panel from minimising on ⌘M / ⌘⌥M** (`60830b1`)
  No-op `miniaturize`/`performMiniaturize`, exclude from the Windows menu, and swallow the shortcut via a local monitor.

## Testing

`./scripts/test.sh all` — all green, including new `GlobalShortcutServiceTests` and `NotchPanelTests`.