### PR TITLE
fix(hooks): stop blocking AskUserQuestion's PreToolUse leg so the Claude Code TUI renders the picker

### DIFF
--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -828,27 +828,33 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertFalse(session.pendingQuestions.isEmpty)
     }
 
-    func testAskUserQuestionInteractionIdRequiresToolUseIdForPreToolUse() throws {
-        let payload: [String: Any] = [
-            "provider": "claude",
-            "session_id": "missing-tool-use-id",
-            "cwd": "/tmp",
-            "event": "PreToolUse",
-            "status": "running_tool",
-            "tool": "AskUserQuestion",
-            "tool_input": [
-                "questions": [
-                    [
-                        "question": "Which path?",
-                        "options": [["label": "Fast"]],
+    func testPreToolUseAskUserQuestionDoesNotProduceInteractionId() throws {
+        func envelope(toolUseId: String?) throws -> AgentHookEnvelope {
+            var payload: [String: Any] = [
+                "provider": "claude",
+                "session_id": "ask-user-question-tui-first",
+                "cwd": "/tmp",
+                "event": "PreToolUse",
+                "status": "running_tool",
+                "tool": "AskUserQuestion",
+                "tool_input": [
+                    "questions": [
+                        [
+                            "question": "Which path?",
+                            "options": [["label": "Fast"]],
+                        ],
                     ],
                 ],
-            ],
-        ]
-        let data = try JSONSerialization.data(withJSONObject: payload)
-        let envelope = try JSONDecoder().decode(AgentHookEnvelope.self, from: data)
+            ]
+            if let toolUseId {
+                payload["tool_use_id"] = toolUseId
+            }
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            return try JSONDecoder().decode(AgentHookEnvelope.self, from: data)
+        }
 
-        XCTAssertNil(HookInteractionRequest.id(for: envelope))
+        XCTAssertNil(HookInteractionRequest.id(for: try envelope(toolUseId: nil)))
+        XCTAssertNil(HookInteractionRequest.id(for: try envelope(toolUseId: "toolu_present")))
     }
 
     func testPermissionRequestInteractionIdDoesNotRequireToolUseId() throws {

--- a/notchi/notchi/Resources/notchi-hook.sh
+++ b/notchi/notchi/Resources/notchi-hook.sh
@@ -139,9 +139,7 @@ def should_wait_for_response():
     if os.environ.get('NOTCHI_INTERACTIVE', 'true') != 'true':
         return False
 
-    return hook_event == 'PermissionRequest' or (
-        hook_event == 'PreToolUse' and tool == 'AskUserQuestion'
-    )
+    return hook_event == 'PermissionRequest'
 
 try:
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -763,10 +763,6 @@ nonisolated enum HookInteractionRequest {
 
         let toolUseId: String
         switch event {
-        case .preToolUse:
-            guard envelope.tool == "AskUserQuestion" else { return nil }
-            guard let existingToolUseId = envelope.toolUseId else { return nil }
-            toolUseId = existingToolUseId
         case .permissionRequest:
             toolUseId = envelope.toolUseId ?? UUID().uuidString
         default:


### PR DESCRIPTION
## Summary

Claude Code fires `PreToolUse` and then `PermissionRequest` for `AskUserQuestion`. Notchi was waiting on (blocking) the `PreToolUse` leg, which blanked the Claude Code TUI picker. This makes Notchi only block on `PermissionRequest`, letting the TUI render its picker normally.

## Changes

- **`notchi-hook.sh`** — `should_wait_for_response()` now only returns `True` for `PermissionRequest`; it no longer waits on `PreToolUse`/`AskUserQuestion`.
- **`SessionStore.swift`** — removed the now-dead `.preToolUse` case in `HookInteractionRequest.id(for:)` that derived an interaction id from `AskUserQuestion`'s `tool_use_id`.
- **`SessionStoreTests.swift`** — rewrote the test to assert `PreToolUse` produces **no** interaction id, both with and without `tool_use_id`.

## Validation

- `./scripts/test.sh focused` — **TEST SUCCEEDED**