### PR TITLE
Add Codex quota display for notch

### DIFF
--- a/notchi/Tests/NotchPanelManagerTests.swift
+++ b/notchi/Tests/NotchPanelManagerTests.swift
@@ -116,6 +116,21 @@ final class NotchPanelManagerTests: XCTestCase {
         XCTAssertEqual(manager.collapsedMode, .compactIdle)
     }
 
+    func testTestingGeometryCanRepresentPhysicalNotchWithoutSystemPath() async {
+        let defaults = makeDefaults()
+        let sessionCount = SessionCountBox(1)
+        let manager = makeManager(sessionCount: sessionCount, defaults: defaults)
+
+        manager.setGeometryForTesting(
+            notchSize: CGSize(width: 224, height: 38),
+            notchRect: CGRect(x: 100, y: 0, width: 302, height: 38),
+            hasPhysicalNotch: true
+        )
+
+        XCTAssertTrue(manager.hasPhysicalNotch)
+        XCTAssertNil(manager.systemNotchPath)
+    }
+
     func testCompactHoverExpansionStartsImmediatelyAndReturnsAfterDelay() async {
         let defaults = makeDefaults()
         defaults.set(true, forKey: AppSettings.hideSpriteWhenIdleKey)

--- a/notchi/notchi/NSScreen+Notch.swift
+++ b/notchi/notchi/NSScreen+Notch.swift
@@ -22,7 +22,7 @@ extension NSScreen {
     /// Calculates the notch dimensions for this screen
     var notchSize: CGSize {
         guard hasNotch else {
-            return CGSize(width: 224, height: 38)
+            return CGSize(width: 224, height: 28)
         }
 
         let fullWidth = frame.width

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -118,6 +118,10 @@ struct NotchContentView: View {
         sessionStore.effectiveSession
     }
 
+    private var codexUsageService: CodexUsageService {
+        .shared
+    }
+
     private var notchSize: CGSize { panelManager.notchSize }
     private var isExpanded: Bool { panelManager.isExpanded }
     private var collapsedMode: NotchPanelManager.CollapsedMode { panelManager.collapsedMode }
@@ -253,6 +257,9 @@ struct NotchContentView: View {
     }
 
     private var collapsedHeaderSpriteOffsetX: CGFloat {
+        if panelManager.hasPhysicalNotch {
+            return 0
+        }
         let baseOffset: CGFloat = 15
         guard !isExpanded && panelManager.isCollapsedHovered else { return baseOffset }
         return baseOffset + 6
@@ -300,10 +307,33 @@ struct NotchContentView: View {
         max(0, notchSize.height - 12) + 24
     }
 
+    private var usageRingProvider: AgentProvider {
+        activeSession?.provider ?? AppSettings.lastUsedAgentProvider
+    }
+
     private var usageRingPercentage: Int? {
         guard AppSettings.isUsageEnabled,
-              let usage = usageService.currentUsage else { return nil }
+              sessionStore.activeSessionCount > 0 else { return nil }
+
+        let usage: QuotaPeriod?
+        switch usageRingProvider {
+        case .claude:
+            usage = usageService.currentUsage
+        case .codex:
+            usage = codexUsageService.currentUsage
+        }
+
+        guard let usage, !usage.isExpired else { return nil }
         return usage.usagePercentage
+    }
+
+    private var isUsageRingStale: Bool {
+        switch usageRingProvider {
+        case .claude:
+            usageService.isUsageStale
+        case .codex:
+            codexUsageService.isUsageStale
+        }
     }
 
     private var compactContentWidth: CGFloat {
@@ -318,12 +348,8 @@ struct NotchContentView: View {
         isExpanded ? cornerRadiusInsets.opened.bottom : cornerRadiusInsets.closed.bottom
     }
 
-    /// Uses the system notch curve in collapsed mode when available.
     private var notchClipShape: AnyShape {
-        if !isExpanded, let systemPath = panelManager.systemNotchPath {
-            return AnyShape(SystemNotchShape(cgPath: systemPath))
-        }
-        return AnyShape(NotchShape(
+        AnyShape(NotchShape(
             topCornerRadius: topCornerRadius,
             bottomCornerRadius: bottomCornerRadius
         ))
@@ -482,7 +508,7 @@ struct NotchContentView: View {
                     ExpandedPanelView(
                         sessionStore: sessionStore,
                         usageService: usageService,
-                        codexUsageService: CodexUsageService.shared,
+                        codexUsageService: codexUsageService,
                         showingSettings: $showingPanelSettings,
                         showingSettingsDetail: $showingPanelSettingsDetail,
                         showingSessionActivity: $showingSessionActivity,
@@ -595,7 +621,10 @@ struct NotchContentView: View {
 
     @ViewBuilder
     private var headerRow: some View {
-        if isCompactIdle && launchWave == nil && !isLaunchWavePreparing {
+        if isExpanded {
+            Color.clear
+                .frame(width: notchSize.width)
+        } else if isCompactIdle && launchWave == nil && !isLaunchWavePreparing {
             Color.clear
                 .frame(width: compactContentWidth)
         } else {
@@ -628,7 +657,7 @@ struct NotchContentView: View {
     private func logRingState(side: NotchSide) {
         guard side == .left else { return }
         let hidden = usageRingPercentage == nil || isLaunchWaveActive
-        let line = "hidden=\(hidden) pct=\(String(describing: usageRingPercentage)) launchWave=\(isLaunchWaveActive) enabled=\(AppSettings.isUsageEnabled) sessions=\(sessionStore.activeSessionCount) claudeUsage=\(usageService.currentUsage != nil) stale=\(usageService.isUsageStale) connected=\(usageService.isConnected) fallback=\(usageService.isUsingHeadersFallback)"
+        let line = "hidden=\(hidden) provider=\(usageRingProvider.rawValue) pct=\(String(describing: usageRingPercentage)) launchWave=\(isLaunchWaveActive) enabled=\(AppSettings.isUsageEnabled) sessions=\(sessionStore.activeSessionCount) claudeUsage=\(usageService.currentUsage != nil) codexUsage=\(codexUsageService.currentUsage != nil) stale=\(isUsageRingStale) connected=\(usageService.isConnected) fallback=\(usageService.isUsingHeadersFallback)"
         guard line != Self.lastRingDebugLine else { return }
         Self.lastRingDebugLine = line
         Self.ringDebugLogger.error("RING-DEBUG \(line, privacy: .public)")
@@ -638,7 +667,7 @@ struct NotchContentView: View {
     private func ringSlot(side: NotchSide) -> some View {
         let _ = logRingState(side: side)
         if let usageRingPercentage, !isLaunchWaveActive {
-            UsageRingView(percentage: usageRingPercentage, isStale: usageService.isUsageStale)
+            UsageRingView(percentage: usageRingPercentage, isStale: isUsageRingStale)
                 .opacity(collapsedHeaderSpriteVisuals.opacity)
                 .animation(collapsedHeaderSpriteVisibilityAnimation, value: isExpanded)
                 .frame(width: sideWidth)

--- a/notchi/notchi/Services/CodexUsageService.swift
+++ b/notchi/notchi/Services/CodexUsageService.swift
@@ -191,7 +191,6 @@ nonisolated enum CodexUsageSnapshotResolver {
                   let observedAt = parseDate(event.timestamp) else {
                 continue
             }
-
             let weeklyUsage = event.payload?.rateLimits?.secondary.map { secondary in
                 QuotaPeriod(
                     utilization: secondary.usedPercent.rounded(),

--- a/notchi/notchi/Services/CodexUsageService.swift
+++ b/notchi/notchi/Services/CodexUsageService.swift
@@ -191,6 +191,7 @@ nonisolated enum CodexUsageSnapshotResolver {
                   let observedAt = parseDate(event.timestamp) else {
                 continue
             }
+
             let weeklyUsage = event.payload?.rateLimits?.secondary.map { secondary in
                 QuotaPeriod(
                     utilization: secondary.usedPercent.rounded(),

--- a/notchi/notchi/Services/NotchPanelManager.swift
+++ b/notchi/notchi/Services/NotchPanelManager.swift
@@ -14,6 +14,7 @@ final class NotchPanelManager {
     static let collapsedHoverBottomInset: CGFloat = 5
 
     private static let compactNotchPaddingTotal: CGFloat = 16
+    private static let physicalNotchExtraWidth: CGFloat = 28
     private static func makeCompactNotchRect(notchSize: CGSize, notchRect: CGRect) -> CGRect {
         CGRect(
             x: notchRect.midX - ((notchSize.width + compactNotchPaddingTotal) / 2),
@@ -53,6 +54,7 @@ final class NotchPanelManager {
     private(set) var notchRect: CGRect = .zero
     private(set) var compactNotchRect: CGRect = .zero
     private(set) var panelRect: CGRect = .zero
+    private(set) var hasPhysicalNotch = false
     /// The exact notch shape from the system bezel path, or nil if unavailable
     private(set) var systemNotchPath: CGPath?
 
@@ -110,11 +112,12 @@ final class NotchPanelManager {
         let screenFrame = screen.frame
 
         notchSize = newNotchSize
+        hasPhysicalNotch = screen.hasNotch
         systemNotchPath = screen.notchPath
 
         let notchCenterX = screenFrame.origin.x + screenFrame.width / 2
         let sideWidth = max(0, newNotchSize.height - 12) + 24
-        let notchTotalWidth = newNotchSize.width + sideWidth
+        let notchTotalWidth = newNotchSize.width + sideWidth + (screen.hasNotch ? Self.physicalNotchExtraWidth : 0)
 
         notchRect = CGRect(
             x: notchCenterX - notchTotalWidth / 2,
@@ -147,6 +150,7 @@ final class NotchPanelManager {
         self.notchSize = notchSize
         self.notchRect = notchRect
         self.panelRect = panelRect
+        hasPhysicalNotch = systemNotchPath != nil
         self.systemNotchPath = systemNotchPath
 
         compactNotchRect = Self.makeCompactNotchRect(notchSize: notchSize, notchRect: notchRect)

--- a/notchi/notchi/Services/NotchPanelManager.swift
+++ b/notchi/notchi/Services/NotchPanelManager.swift
@@ -145,12 +145,13 @@ final class NotchPanelManager {
         notchSize: CGSize,
         notchRect: CGRect,
         panelRect: CGRect = .zero,
-        systemNotchPath: CGPath? = nil
+        systemNotchPath: CGPath? = nil,
+        hasPhysicalNotch: Bool = false
     ) {
         self.notchSize = notchSize
         self.notchRect = notchRect
         self.panelRect = panelRect
-        hasPhysicalNotch = systemNotchPath != nil
+        self.hasPhysicalNotch = hasPhysicalNotch
         self.systemNotchPath = systemNotchPath
 
         compactNotchRect = Self.makeCompactNotchRect(notchSize: notchSize, notchRect: notchRect)


### PR DESCRIPTION
## Summary
- Add Codex quota parsing from token_count events, including primary and weekly rate limits.
- Show Codex usage in the collapsed notch UI.
- Avoid rendering over the physical MacBook notch by placing a compact quota ring and sprite on the sides.
- Show fuller quota text on external displays without a physical notch.
- Hide collapsed status content when the panel is expanded.

## Testing
- Built locally with xcodebuild using Xcode 26.5 SDK.
- Verified the running app receives Codex hook updates through /tmp/notchi.sock.
- Checked physical notch and external display layouts locally.