### PR TITLE
feat: collapsed usage ring + tap-to-open usage detail for Claude & Codex

### DIFF
--- a/notchi/Tests/ClaudeUsageServiceTests+HeadersFallback.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests+HeadersFallback.swift
@@ -27,7 +27,7 @@ extension ClaudeUsageServiceTests {
             await service.performFetch(with: "token")
 
             recorder.assertOAuthOnly()
-            XCTAssertEqual(service.error, "Claude authentication needs attention. Tap to reconnect.")
+            XCTAssertEqual(service.error, "Claude authentication needs attention.")
             XCTAssertEqual(service.recoveryAction, .reconnect)
             XCTAssertFalse(service.isConnected)
             XCTAssertTrue(scheduler.intervals.isEmpty)
@@ -214,7 +214,7 @@ extension ClaudeUsageServiceTests {
         XCTAssertEqual(refreshCalls, 1)
         XCTAssertEqual(clearCalls, 1)
         XCTAssertEqual(requestURLs, ["/api/oauth/usage", "/v1/messages"])
-        XCTAssertEqual(service.error, "Claude authentication needs attention. Tap to reconnect.")
+        XCTAssertEqual(service.error, "Claude authentication needs attention.")
         XCTAssertEqual(service.recoveryAction, .reconnect)
         XCTAssertTrue(scheduler.intervals.isEmpty)
     }
@@ -237,7 +237,7 @@ extension ClaudeUsageServiceTests {
         await service.performFetch(with: "token")
 
         XCTAssertNil(service.currentUsage)
-        XCTAssertEqual(service.error, "Claude authentication needs attention. Tap to reconnect.")
+        XCTAssertEqual(service.error, "Claude authentication needs attention.")
         XCTAssertEqual(service.recoveryAction, .reconnect)
         XCTAssertTrue(scheduler.intervals.isEmpty)
     }
@@ -262,7 +262,7 @@ extension ClaudeUsageServiceTests {
         await service.performFetch(with: "token")
 
         XCTAssertEqual(clearCalls, 1)
-        XCTAssertEqual(service.error, "Token expired. Tap to reconnect.")
+        XCTAssertEqual(service.error, "Token expired.")
         XCTAssertEqual(service.recoveryAction, .reconnect)
         XCTAssertFalse(service.isConnected)
     }
@@ -726,7 +726,7 @@ extension ClaudeUsageServiceTests {
         await service.performFetch(with: "token")
 
         XCTAssertNil(service.currentUsage)
-        XCTAssertEqual(service.error, "Claude authentication needs attention. Tap to reconnect.")
+        XCTAssertEqual(service.error, "Claude authentication needs attention.")
         XCTAssertEqual(service.recoveryAction, .reconnect)
         XCTAssertTrue(scheduler.intervals.isEmpty)
     }
@@ -749,7 +749,7 @@ extension ClaudeUsageServiceTests {
         await service.performFetch(with: "token")
 
         XCTAssertNil(service.currentUsage)
-        XCTAssertEqual(service.error, "Claude authentication needs attention. Tap to reconnect.")
+        XCTAssertEqual(service.error, "Claude authentication needs attention.")
         XCTAssertEqual(service.recoveryAction, .reconnect)
         XCTAssertTrue(scheduler.intervals.isEmpty)
     }

--- a/notchi/Tests/ClaudeUsageServiceTests+Polling.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests+Polling.swift
@@ -20,6 +20,38 @@ extension ClaudeUsageServiceTests {
         XCTAssertEqual(service.currentWeeklyUsage?.usagePercentage, 58)
     }
 
+    func testSuccessfulFetchPublishesSonnetUsageFromSevenDaySonnet() async throws {
+        let dependencies = makeDependencies(
+            scheduler: PollSchedulerSpy(),
+            resolveUserAgent: { "claude-code/2.1.77" },
+            fetchUsage: { _ in
+                (self.makeSuccessPayload(utilization: 42, weeklyUtilization: 58, sonnetUtilization: 22), self.makeResponse(statusCode: 200))
+            }
+        )
+
+        let service = ClaudeUsageService(dependencies: dependencies)
+
+        await service.performFetch(with: "token")
+
+        XCTAssertEqual(service.currentSonnetUsage?.usagePercentage, 22)
+    }
+
+    func testSuccessfulFetchWithoutSevenDaySonnetLeavesSonnetUsageNil() async throws {
+        let dependencies = makeDependencies(
+            scheduler: PollSchedulerSpy(),
+            resolveUserAgent: { "claude-code/2.1.77" },
+            fetchUsage: { _ in
+                (self.makeSuccessPayload(utilization: 42, weeklyUtilization: 58), self.makeResponse(statusCode: 200))
+            }
+        )
+
+        let service = ClaudeUsageService(dependencies: dependencies)
+
+        await service.performFetch(with: "token")
+
+        XCTAssertNil(service.currentSonnetUsage)
+    }
+
     func testSuccessfulFetchWithoutSevenDayLeavesWeeklyUsageNil() async throws {
         let dependencies = makeDependencies(
             scheduler: PollSchedulerSpy(),

--- a/notchi/Tests/ClaudeUsageServiceTests+Polling.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests+Polling.swift
@@ -3,6 +3,40 @@ import XCTest
 @testable import notchi
 
 extension ClaudeUsageServiceTests {
+    func testSuccessfulFetchPublishesWeeklyUsageFromSevenDay() async throws {
+        let dependencies = makeDependencies(
+            scheduler: PollSchedulerSpy(),
+            resolveUserAgent: { "claude-code/2.1.77" },
+            fetchUsage: { _ in
+                (self.makeSuccessPayload(utilization: 42, weeklyUtilization: 58), self.makeResponse(statusCode: 200))
+            }
+        )
+
+        let service = ClaudeUsageService(dependencies: dependencies)
+
+        await service.performFetch(with: "token")
+
+        XCTAssertEqual(service.currentUsage?.usagePercentage, 42)
+        XCTAssertEqual(service.currentWeeklyUsage?.usagePercentage, 58)
+    }
+
+    func testSuccessfulFetchWithoutSevenDayLeavesWeeklyUsageNil() async throws {
+        let dependencies = makeDependencies(
+            scheduler: PollSchedulerSpy(),
+            resolveUserAgent: { "claude-code/2.1.77" },
+            fetchUsage: { _ in
+                (self.makeSuccessPayload(utilization: 42), self.makeResponse(statusCode: 200))
+            }
+        )
+
+        let service = ClaudeUsageService(dependencies: dependencies)
+
+        await service.performFetch(with: "token")
+
+        XCTAssertEqual(service.currentUsage?.usagePercentage, 42)
+        XCTAssertNil(service.currentWeeklyUsage)
+    }
+
     func testSuccessfulFetchClearsStaleStateAndSchedulesNormalPolling() async throws {
         let scheduler = PollSchedulerSpy()
         let dependencies = makeDependencies(

--- a/notchi/Tests/ClaudeUsageServiceTests+TokenRecovery.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests+TokenRecovery.swift
@@ -37,7 +37,7 @@ extension ClaudeUsageServiceTests {
         XCTAssertEqual(environmentTokenCalls, 1)
         XCTAssertEqual(getCachedTokenCalls, [false])
         XCTAssertEqual(getOAuthCredentialCalls, [false])
-        XCTAssertEqual(service.error, "Claude authentication needs attention. Tap to reconnect.")
+        XCTAssertEqual(service.error, "Claude authentication needs attention.")
         XCTAssertEqual(service.recoveryAction, .reconnect)
         XCTAssertTrue(scheduler.intervals.isEmpty)
         XCTAssertFalse(AppSettings.isUsageEnabled)
@@ -171,7 +171,7 @@ extension ClaudeUsageServiceTests {
         XCTAssertFalse(AppSettings.isUsageEnabled)
         XCTAssertFalse(service.isConnected)
         XCTAssertNil(service.error)
-        XCTAssertEqual(service.statusMessage, "Claude authentication needs attention. Tap to reconnect.")
+        XCTAssertEqual(service.statusMessage, "Claude authentication needs attention.")
         XCTAssertTrue(service.isUsageStale)
         XCTAssertEqual(service.recoveryAction, .reconnect)
         XCTAssertEqual(service.currentUsage?.usagePercentage, 42)
@@ -681,7 +681,7 @@ extension ClaudeUsageServiceTests {
         await service.performFetch(with: "token", userInitiated: true)
 
         XCTAssertFalse(fetchCalled)
-        XCTAssertEqual(service.error, "Claude authentication needs attention. Tap to reconnect.")
+        XCTAssertEqual(service.error, "Claude authentication needs attention.")
         XCTAssertEqual(service.recoveryAction, .reconnect)
         XCTAssertTrue(scheduler.intervals.isEmpty)
     }

--- a/notchi/Tests/ClaudeUsageServiceTests.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests.swift
@@ -197,6 +197,8 @@ final class ClaudeUsageServiceTests: XCTestCase {
     func makeSuccessPayload(
         utilization: Double,
         resetAt: String = "2099-01-01T01:00:00Z",
+        weeklyUtilization: Double? = nil,
+        weeklyResetAt: String = "2099-01-08T01:00:00Z",
         extraUsage: ExtraUsage? = nil
     ) -> Data {
         var payload: [String: Any] = [
@@ -204,7 +206,9 @@ final class ClaudeUsageServiceTests: XCTestCase {
                 "utilization": utilization,
                 "resets_at": resetAt,
             ],
-            "seven_day": NSNull(),
+            "seven_day": weeklyUtilization.map { weekly in
+                ["utilization": weekly, "resets_at": weeklyResetAt] as [String: Any]
+            } ?? NSNull(),
         ]
 
         if let extraUsage {
@@ -230,6 +234,7 @@ final class ClaudeUsageServiceTests: XCTestCase {
         oauthHeadersFallbackProbeUntil: Date? = nil,
         isHeadersFallbackActive: Bool = false,
         lastGoodUsage: QuotaPeriod? = nil,
+        lastGoodWeeklyUsage: QuotaPeriod? = nil,
         lastGoodExtraUsage: ExtraUsage? = nil,
         lastObservedExtraUsageCredits: Double? = nil,
         extraUsageResetMarker: String? = nil,
@@ -240,6 +245,7 @@ final class ClaudeUsageServiceTests: XCTestCase {
             oauthHeadersFallbackProbeUntil: oauthHeadersFallbackProbeUntil,
             isHeadersFallbackActive: isHeadersFallbackActive,
             lastGoodUsage: lastGoodUsage,
+            lastGoodWeeklyUsage: lastGoodWeeklyUsage,
             lastGoodExtraUsage: lastGoodExtraUsage,
             lastObservedExtraUsageCredits: lastObservedExtraUsageCredits,
             extraUsageResetMarker: extraUsageResetMarker,

--- a/notchi/Tests/ClaudeUsageServiceTests.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests.swift
@@ -199,6 +199,7 @@ final class ClaudeUsageServiceTests: XCTestCase {
         resetAt: String = "2099-01-01T01:00:00Z",
         weeklyUtilization: Double? = nil,
         weeklyResetAt: String = "2099-01-08T01:00:00Z",
+        sonnetUtilization: Double? = nil,
         extraUsage: ExtraUsage? = nil
     ) -> Data {
         var payload: [String: Any] = [
@@ -210,6 +211,10 @@ final class ClaudeUsageServiceTests: XCTestCase {
                 ["utilization": weekly, "resets_at": weeklyResetAt] as [String: Any]
             } ?? NSNull(),
         ]
+
+        if let sonnetUtilization {
+            payload["seven_day_sonnet"] = ["utilization": sonnetUtilization]
+        }
 
         if let extraUsage {
             payload["extra_usage"] = [
@@ -235,6 +240,7 @@ final class ClaudeUsageServiceTests: XCTestCase {
         isHeadersFallbackActive: Bool = false,
         lastGoodUsage: QuotaPeriod? = nil,
         lastGoodWeeklyUsage: QuotaPeriod? = nil,
+        lastGoodSonnetUsage: QuotaPeriod? = nil,
         lastGoodExtraUsage: ExtraUsage? = nil,
         lastObservedExtraUsageCredits: Double? = nil,
         extraUsageResetMarker: String? = nil,
@@ -246,6 +252,7 @@ final class ClaudeUsageServiceTests: XCTestCase {
             isHeadersFallbackActive: isHeadersFallbackActive,
             lastGoodUsage: lastGoodUsage,
             lastGoodWeeklyUsage: lastGoodWeeklyUsage,
+            lastGoodSonnetUsage: lastGoodSonnetUsage,
             lastGoodExtraUsage: lastGoodExtraUsage,
             lastObservedExtraUsageCredits: lastObservedExtraUsageCredits,
             extraUsageResetMarker: extraUsageResetMarker,

--- a/notchi/Tests/CodexUsageAPITests.swift
+++ b/notchi/Tests/CodexUsageAPITests.swift
@@ -1,0 +1,200 @@
+import XCTest
+@testable import notchi
+
+final class CodexUsageAPITests: XCTestCase {
+    private func makeJWT(exp: Double) -> String {
+        let payload = try! JSONSerialization.data(withJSONObject: ["exp": exp])
+        let encoded = payload.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "header.\(encoded).signature"
+    }
+
+    func testAuthLoadReadsAccessTokenAndAccountId() throws {
+        let data = Data("""
+        { "tokens": { "access_token": "tok-123", "account_id": "acc-9", "refresh_token": "r" } }
+        """.utf8)
+
+        let auth = try XCTUnwrap(CodexAPIAuth.load(from: data))
+
+        XCTAssertEqual(auth.accessToken, "tok-123")
+        XCTAssertEqual(auth.accountId, "acc-9")
+    }
+
+    func testAuthLoadReturnsNilWhenAccessTokenMissing() {
+        let data = Data(#"{ "tokens": { "account_id": "acc-9" } }"#.utf8)
+        XCTAssertNil(CodexAPIAuth.load(from: data))
+    }
+
+    func testAccessTokenExpiryParsesJWTExp() throws {
+        let token = makeJWT(exp: 1_777_000_000)
+        let expiry = try XCTUnwrap(CodexUsageAPI.accessTokenExpiry(token))
+        XCTAssertEqual(expiry.timeIntervalSince1970, 1_777_000_000, accuracy: 0.001)
+    }
+
+    func testIsAccessTokenExpiredTrueForPastExpiry() {
+        let token = makeJWT(exp: 1_000)
+        XCTAssertTrue(CodexUsageAPI.isAccessTokenExpired(token, now: Date(timeIntervalSince1970: 2_000)))
+    }
+
+    func testIsAccessTokenExpiredFalseForFutureExpiry() {
+        let token = makeJWT(exp: 9_000)
+        XCTAssertFalse(CodexUsageAPI.isAccessTokenExpired(token, now: Date(timeIntervalSince1970: 2_000)))
+    }
+
+    func testUnparseableTokenIsTreatedAsUsable() {
+        XCTAssertFalse(CodexUsageAPI.isAccessTokenExpired("not-a-jwt", now: Date()))
+    }
+
+    func testRequestCarriesBearerTokenAndAccountHeader() {
+        let request = CodexUsageAPI.makeRequest(auth: CodexAPIAuth(accessToken: "tok-123", accountId: "acc-9"))
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer tok-123")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "ChatGPT-Account-Id"), "acc-9")
+        XCTAssertEqual(request.url, CodexUsageAPI.usageURL)
+    }
+
+    func testUsageParsesReviewsWindowAndCreditsBalance() throws {
+        let data = Data("""
+        {
+          "code_review_rate_limit": { "primary_window": { "used_percent": 42.0, "reset_at": 1777621726 } },
+          "credits": { "balance": 310 }
+        }
+        """.utf8)
+        let response = try JSONDecoder().decode(CodexUsageAPIResponse.self, from: data)
+
+        let usage = CodexUsageAPI.usage(from: response, now: Date(timeIntervalSince1970: 1_000))
+
+        XCTAssertEqual(usage.reviews?.usagePercentage, 42)
+        let reviewReset = try XCTUnwrap(usage.reviews?.resetDate)
+        XCTAssertEqual(reviewReset.timeIntervalSince1970, 1_777_621_726, accuracy: 0.001)
+        XCTAssertEqual(usage.creditsBalance, 310)
+    }
+
+    func testUsageUsesResetAfterSecondsWhenAbsoluteResetMissing() throws {
+        let data = Data("""
+        { "code_review_rate_limit": { "primary_window": { "used_percent": 10.0, "reset_after_seconds": 3600 } } }
+        """.utf8)
+        let response = try JSONDecoder().decode(CodexUsageAPIResponse.self, from: data)
+
+        let usage = CodexUsageAPI.usage(from: response, now: Date(timeIntervalSince1970: 1_000))
+
+        let reviewReset = try XCTUnwrap(usage.reviews?.resetDate)
+        XCTAssertEqual(reviewReset.timeIntervalSince1970, 4_600, accuracy: 0.001)
+    }
+
+    func testUsageParsesStringCreditsBalance() throws {
+        let data = Data(#"{ "credits": { "has_credits": true, "balance": "1250" } }"#.utf8)
+        let response = try JSONDecoder().decode(CodexUsageAPIResponse.self, from: data)
+
+        XCTAssertEqual(CodexUsageAPI.usage(from: response, now: Date()).creditsBalance, 1250)
+    }
+
+    func testUsageTreatsHasCreditsFalseAsZeroBalance() throws {
+        let data = Data(#"{ "credits": { "has_credits": false } }"#.utf8)
+        let response = try JSONDecoder().decode(CodexUsageAPIResponse.self, from: data)
+
+        XCTAssertEqual(CodexUsageAPI.usage(from: response, now: Date()).creditsBalance, 0)
+    }
+
+    func testUsageLeavesReviewsAndCreditsNilWhenAbsent() throws {
+        let response = try JSONDecoder().decode(CodexUsageAPIResponse.self, from: Data("{}".utf8))
+        let usage = CodexUsageAPI.usage(from: response, now: Date())
+        XCTAssertNil(usage.reviews)
+        XCTAssertNil(usage.creditsBalance)
+    }
+
+    @MainActor
+    func testRefreshPublishesReviewsAndCreditsFromAPI() async throws {
+        let service = CodexUsageService(dependencies: CodexUsageServiceDependencies(
+            resolveUsage: { _ in
+                CodexUsageSnapshot(
+                    usage: QuotaPeriod(utilization: 5, resetDate: Date(timeIntervalSince1970: 9_999_999_999)),
+                    weeklyUsage: nil,
+                    observedAt: Date(timeIntervalSince1970: 9_000_000_000)
+                )
+            },
+            fetchAPIUsage: {
+                CodexAPIUsage(
+                    reviews: QuotaPeriod(utilization: 42, resetDate: Date(timeIntervalSince1970: 9_999_999_999)),
+                    creditsBalance: 310
+                )
+            },
+            now: { Date(timeIntervalSince1970: 9_000_000_000) }
+        ))
+
+        await service.refresh(transcriptPaths: ["/tmp/rollout.jsonl"])
+
+        XCTAssertEqual(service.currentReviewsUsage?.usagePercentage, 42)
+        let credits = try XCTUnwrap(service.currentExtraCreditsUSD)
+        XCTAssertEqual(credits, 310 * CodexUsageAPI.creditUSDRate, accuracy: 0.0001)
+    }
+
+    @MainActor
+    func testTransientAPIFailureRetainsLastGoodValues() async throws {
+        let state = MutableFetchState(now: Date(timeIntervalSince1970: 1_000))
+        state.result = CodexAPIUsage(
+            reviews: QuotaPeriod(utilization: 30, resetDate: Date(timeIntervalSince1970: 9_999_999_999)),
+            creditsBalance: 100
+        )
+        let service = CodexUsageService(dependencies: CodexUsageServiceDependencies(
+            resolveUsage: { _ in
+                CodexUsageSnapshot(
+                    usage: QuotaPeriod(utilization: 5, resetDate: Date(timeIntervalSince1970: 9_999_999_999)),
+                    weeklyUsage: nil,
+                    observedAt: Date(timeIntervalSince1970: 1_000)
+                )
+            },
+            fetchAPIUsage: { state.result },
+            now: { state.now }
+        ))
+
+        await service.refresh(transcriptPaths: ["/tmp/rollout.jsonl"])
+        let firstCredits = try XCTUnwrap(service.currentExtraCreditsUSD)
+        XCTAssertEqual(firstCredits, 100 * CodexUsageAPI.creditUSDRate, accuracy: 0.0001)
+
+        state.now = Date(timeIntervalSince1970: 1_000 + 120)
+        state.result = nil
+        await service.refresh(transcriptPaths: ["/tmp/rollout.jsonl"])
+
+        XCTAssertEqual(service.currentReviewsUsage?.usagePercentage, 30)
+        let retainedCredits = try XCTUnwrap(service.currentExtraCreditsUSD)
+        XCTAssertEqual(retainedCredits, 100 * CodexUsageAPI.creditUSDRate, accuracy: 0.0001)
+    }
+
+    @MainActor
+    func testRapidRefreshesThrottleTheNetworkedAPIFetch() async {
+        let counter = CallCounter()
+        let service = CodexUsageService(dependencies: CodexUsageServiceDependencies(
+            resolveUsage: { _ in
+                CodexUsageSnapshot(
+                    usage: QuotaPeriod(utilization: 5, resetDate: Date(timeIntervalSince1970: 9_999_999_999)),
+                    weeklyUsage: nil,
+                    observedAt: Date(timeIntervalSince1970: 9_000_000_000)
+                )
+            },
+            fetchAPIUsage: {
+                await counter.bump()
+                return CodexAPIUsage(reviews: nil, creditsBalance: nil)
+            },
+            now: { Date(timeIntervalSince1970: 9_000_000_000) }
+        ))
+
+        await service.refresh(transcriptPaths: ["/tmp/rollout.jsonl"])
+        await service.refresh(transcriptPaths: ["/tmp/rollout.jsonl"])
+
+        let count = await counter.count
+        XCTAssertEqual(count, 1)
+    }
+}
+
+private actor CallCounter {
+    private(set) var count = 0
+    func bump() { count += 1 }
+}
+
+private final class MutableFetchState: @unchecked Sendable {
+    var now: Date
+    var result: CodexAPIUsage?
+    init(now: Date) { self.now = now }
+}

--- a/notchi/Tests/CodexUsageServiceTests.swift
+++ b/notchi/Tests/CodexUsageServiceTests.swift
@@ -3,6 +3,39 @@ import XCTest
 
 @MainActor
 final class CodexUsageServiceTests: XCTestCase {
+    func testResolverDecodesSecondaryRateLimitAsWeeklyUsage() throws {
+        let rolloutURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-usage-\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: rolloutURL) }
+
+        let contents = """
+        {"timestamp":"2026-04-25T07:03:14.886Z","type":"event_msg","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":11.0,"window_minutes":300,"resets_at":1777103326},"secondary":{"used_percent":27.0,"window_minutes":10080,"resets_at":1777621726}}}}
+        """
+        try contents.write(to: rolloutURL, atomically: true, encoding: .utf8)
+
+        let snapshot = try XCTUnwrap(CodexUsageSnapshotResolver.latestSnapshot(transcriptPath: rolloutURL.path))
+
+        XCTAssertEqual(snapshot.usage.usagePercentage, 11)
+        XCTAssertEqual(snapshot.weeklyUsage?.usagePercentage, 27)
+        let weeklyReset = try XCTUnwrap(snapshot.weeklyUsage?.resetDate)
+        XCTAssertEqual(weeklyReset.timeIntervalSince1970, 1_777_621_726, accuracy: 0.001)
+    }
+
+    func testResolverLeavesWeeklyUsageNilWhenSecondaryMissing() throws {
+        let rolloutURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-usage-\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: rolloutURL) }
+
+        let contents = """
+        {"timestamp":"2026-04-25T07:03:14.886Z","type":"event_msg","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":11.0,"window_minutes":300,"resets_at":1777103326}}}}
+        """
+        try contents.write(to: rolloutURL, atomically: true, encoding: .utf8)
+
+        let snapshot = try XCTUnwrap(CodexUsageSnapshotResolver.latestSnapshot(transcriptPath: rolloutURL.path))
+
+        XCTAssertNil(snapshot.weeklyUsage)
+    }
+
     func testResolverReadsLatestTokenCountFromRollout() throws {
         let rolloutURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("codex-usage-\(UUID().uuidString).jsonl")
@@ -104,6 +137,7 @@ final class CodexUsageServiceTests: XCTestCase {
             resolveUsage: { _ in
                 CodexUsageSnapshot(
                     usage: QuotaPeriod(utilization: 11, resetDate: Date(timeIntervalSince1970: 2_000)),
+                    weeklyUsage: nil,
                     observedAt: observedAt
                 )
             },
@@ -123,6 +157,7 @@ final class CodexUsageServiceTests: XCTestCase {
             resolveUsage: { _ in
                 CodexUsageSnapshot(
                     usage: QuotaPeriod(utilization: 11, resetDate: Date(timeIntervalSince1970: 900)),
+                    weeklyUsage: nil,
                     observedAt: Date(timeIntervalSince1970: 800)
                 )
             },

--- a/notchi/Tests/NotchContentViewTests.swift
+++ b/notchi/Tests/NotchContentViewTests.swift
@@ -2,70 +2,31 @@ import XCTest
 @testable import notchi
 
 final class NotchContentViewTests: XCTestCase {
-    func testActiveSessionStateTakesPrecedenceOverLaunchWave() {
-        let wave = NotchContentView.LaunchWave(
-            state: NotchiState(task: .waving, spriteFamily: .claude),
-            startedAt: Date()
-        )
-
-        let result = NotchContentView.resolveHeaderSpriteContent(
-            activeSessionState: .working,
-            activeSessionId: "claude:active",
-            launchWave: wave,
-            isCompactIdle: true,
-            launchSpriteFamily: .claude
-        )
-
-        XCTAssertEqual(
-            result,
-            NotchContentView.HeaderSpriteContent(state: .working, mirrorSeed: "claude:active")
-        )
+    func testSameNonNothingContentsConflict() {
+        XCTAssertTrue(NotchSlotContent.conflict(.ring, .ring))
+        XCTAssertTrue(NotchSlotContent.conflict(.latest, .latest))
+        XCTAssertTrue(NotchSlotContent.conflict(.claude, .claude))
+        XCTAssertTrue(NotchSlotContent.conflict(.codex, .codex))
     }
 
-    func testLaunchWaveOverridesCompactIdleWhenNoActiveSession() {
-        let startedAt = Date(timeIntervalSinceReferenceDate: 1000)
-        let waveState = NotchiState(task: .waving, spriteFamily: .codex)
-        let wave = NotchContentView.LaunchWave(state: waveState, startedAt: startedAt)
-
-        let result = NotchContentView.resolveHeaderSpriteContent(
-            activeSessionState: nil,
-            launchWave: wave,
-            isCompactIdle: true,
-            launchSpriteFamily: .claude
-        )
-
-        XCTAssertEqual(result?.state, waveState)
-        XCTAssertEqual(result?.mirrorSeed, "launch-wave-codex")
-        XCTAssertEqual(result?.startedAt, startedAt)
-        XCTAssertEqual(result?.repeatsAnimation, false)
+    func testNothingNeverConflicts() {
+        XCTAssertFalse(NotchSlotContent.conflict(.nothing, .nothing))
+        XCTAssertFalse(NotchSlotContent.conflict(.nothing, .claude))
+        XCTAssertFalse(NotchSlotContent.conflict(.latest, .nothing))
     }
 
-    func testCompactIdleReturnsNilWhenNoSessionOrWave() {
-        let result = NotchContentView.resolveHeaderSpriteContent(
-            activeSessionState: nil,
-            launchWave: nil,
-            isCompactIdle: true,
-            launchSpriteFamily: .claude
-        )
-
-        XCTAssertNil(result)
+    func testLatestSessionConflictsWithAnySprite() {
+        XCTAssertTrue(NotchSlotContent.conflict(.latest, .claude))
+        XCTAssertTrue(NotchSlotContent.conflict(.codex, .latest))
     }
 
-    func testIdleFallbackUsesLaunchSpriteFamilyOutsideCompactIdle() {
-        let result = NotchContentView.resolveHeaderSpriteContent(
-            activeSessionState: nil,
-            launchWave: nil,
-            isCompactIdle: false,
-            launchSpriteFamily: .codex
-        )
+    func testTwoDistinctProvidersDoNotConflict() {
+        XCTAssertFalse(NotchSlotContent.conflict(.claude, .codex))
+    }
 
-        XCTAssertEqual(
-            result,
-            NotchContentView.HeaderSpriteContent(
-                state: NotchiState(task: .idle, spriteFamily: .codex),
-                mirrorSeed: "fallback-codex"
-            )
-        )
+    func testUsageRingDoesNotConflictWithASprite() {
+        XCTAssertFalse(NotchSlotContent.conflict(.ring, .claude))
+        XCTAssertFalse(NotchSlotContent.conflict(.ring, .latest))
     }
 
     func testGrassIslandRendersOnlyForExpandedActivityView() {

--- a/notchi/Tests/UsageBarViewTests.swift
+++ b/notchi/Tests/UsageBarViewTests.swift
@@ -72,18 +72,18 @@ final class UsageBarViewTests: XCTestCase {
         XCTAssertTrue(view.shouldShowRecoveryButton)
     }
 
-    func testRecoveryButtonShowsForWaitForClaudeCodeState() {
+    func testRecoveryButtonHiddenForWaitForClaudeCodeState() {
         let view = UsageBarView(
-            usage: QuotaPeriod(utilization: 42, resetDate: Date(timeIntervalSince1970: 4_102_444_800)),
+            usage: nil,
             isLoading: false,
-            error: nil,
-            statusMessage: "Start Claude Code to track usage",
-            isStale: true,
+            error: "Start a Claude Code session to track usage",
+            statusMessage: nil,
+            isStale: false,
             recoveryAction: .waitForClaudeCode,
             isEnabled: true
         )
 
-        XCTAssertTrue(view.shouldShowRecoveryButton)
+        XCTAssertFalse(view.shouldShowRecoveryButton)
     }
 
     func testRecoveryButtonShowsForRetryStateWithoutUsage() {

--- a/notchi/Tests/UsageBarViewTests.swift
+++ b/notchi/Tests/UsageBarViewTests.swift
@@ -44,7 +44,7 @@ final class UsageBarViewTests: XCTestCase {
         XCTAssertFalse(view.shouldShowConnectPlaceholder)
     }
 
-    func testUsagePresentRetryStateIsNotTappable() {
+    func testRecoveryButtonShowsForRetryStateWithUsagePresent() {
         let view = UsageBarView(
             usage: QuotaPeriod(utilization: 42, resetDate: Date(timeIntervalSince1970: 4_102_444_800)),
             isLoading: false,
@@ -55,24 +55,24 @@ final class UsageBarViewTests: XCTestCase {
             isEnabled: true
         )
 
-        XCTAssertFalse(view.shouldAllowTapAction)
+        XCTAssertTrue(view.shouldShowRecoveryButton)
     }
 
-    func testUsagePresentReconnectStateRemainsTappable() {
+    func testRecoveryButtonShowsForReconnectStateWithUsagePresent() {
         let view = UsageBarView(
             usage: QuotaPeriod(utilization: 42, resetDate: Date(timeIntervalSince1970: 4_102_444_800)),
             isLoading: false,
             error: nil,
-            statusMessage: "Tap to reconnect Claude Code",
+            statusMessage: "Reconnect Claude Code",
             isStale: true,
             recoveryAction: .reconnect,
             isEnabled: true
         )
 
-        XCTAssertTrue(view.shouldAllowTapAction)
+        XCTAssertTrue(view.shouldShowRecoveryButton)
     }
 
-    func testUsagePresentWaitForClaudeCodeStateRemainsTappableWithoutRetryHint() {
+    func testRecoveryButtonShowsForWaitForClaudeCodeState() {
         let view = UsageBarView(
             usage: QuotaPeriod(utilization: 42, resetDate: Date(timeIntervalSince1970: 4_102_444_800)),
             isLoading: false,
@@ -83,11 +83,10 @@ final class UsageBarViewTests: XCTestCase {
             isEnabled: true
         )
 
-        XCTAssertNil(view.actionHint)
-        XCTAssertTrue(view.shouldAllowTapAction)
+        XCTAssertTrue(view.shouldShowRecoveryButton)
     }
 
-    func testNoUsageRetryStateStillShowsTapHint() {
+    func testRecoveryButtonShowsForRetryStateWithoutUsage() {
         let view = UsageBarView(
             usage: nil,
             isLoading: false,
@@ -98,11 +97,65 @@ final class UsageBarViewTests: XCTestCase {
             isEnabled: true
         )
 
-        XCTAssertEqual(view.actionHint, "(tap to retry)")
-        XCTAssertTrue(view.shouldAllowTapAction)
+        XCTAssertTrue(view.shouldShowRecoveryButton)
     }
 
-    func testNoUsageReconnectStateRemainsTappableWithoutActionHint() {
+    func testRecoveryActionLabelMatchesRecoveryAction() {
+        func label(for action: ClaudeUsageRecoveryAction) -> String {
+            UsageBarView(
+                usage: nil,
+                isLoading: false,
+                error: nil,
+                statusMessage: nil,
+                isStale: false,
+                recoveryAction: action,
+                isEnabled: true
+            ).recoveryActionLabel
+        }
+
+        XCTAssertEqual(label(for: .retry), "Retry")
+        XCTAssertEqual(label(for: .reconnect), "Reconnect")
+        XCTAssertEqual(label(for: .waitForClaudeCode), "Open Claude Code")
+    }
+
+    func testRecoveryButtonHiddenWhenNoRecoveryAction() {
+        let view = UsageBarView(
+            usage: QuotaPeriod(utilization: 42, resetDate: Date(timeIntervalSince1970: 4_102_444_800)),
+            isLoading: false,
+            error: nil,
+            statusMessage: nil,
+            isStale: false,
+            recoveryAction: .none,
+            isEnabled: true
+        )
+
+        XCTAssertFalse(view.shouldShowRecoveryButton)
+    }
+
+    func testRetryRecoveryActionInvokesOnRetry() {
+        var retried = false
+        var connected = false
+        let view = UsageBarView(
+            usage: nil,
+            isLoading: false,
+            error: "Rate limited, retrying in 120s",
+            statusMessage: nil,
+            isStale: false,
+            recoveryAction: .retry,
+            isEnabled: true,
+            onConnect: { connected = true },
+            onRetry: { retried = true }
+        )
+
+        view.performRecoveryAction()
+
+        XCTAssertTrue(retried)
+        XCTAssertFalse(connected)
+    }
+
+    func testReconnectRecoveryActionInvokesOnConnect() {
+        var retried = false
+        var connected = false
         let view = UsageBarView(
             usage: nil,
             isLoading: false,
@@ -110,26 +163,15 @@ final class UsageBarViewTests: XCTestCase {
             statusMessage: nil,
             isStale: false,
             recoveryAction: .reconnect,
-            isEnabled: true
+            isEnabled: true,
+            onConnect: { connected = true },
+            onRetry: { retried = true }
         )
 
-        XCTAssertNil(view.actionHint)
-        XCTAssertTrue(view.shouldAllowTapAction)
-    }
+        view.performRecoveryAction()
 
-    func testNoUsageWaitForClaudeCodeStateRemainsTappableWithoutActionHint() {
-        let view = UsageBarView(
-            usage: nil,
-            isLoading: false,
-            error: "Start Claude Code to track usage",
-            statusMessage: nil,
-            isStale: false,
-            recoveryAction: .waitForClaudeCode,
-            isEnabled: true
-        )
-
-        XCTAssertNil(view.actionHint)
-        XCTAssertTrue(view.shouldAllowTapAction)
+        XCTAssertTrue(connected)
+        XCTAssertFalse(retried)
     }
 
     func testExtraUsageIndicatorOnlyShowsWhenActivelyUsingExtraUsage() {

--- a/notchi/Tests/UsageDisplayTests.swift
+++ b/notchi/Tests/UsageDisplayTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import notchi
+
+final class UsageDisplayTests: XCTestCase {
+    private let futureReset = Date(timeIntervalSince1970: 4_102_444_800)
+
+    func testPercentLeftIsComplementOfUsed() {
+        XCTAssertEqual(UsageMetrics.percentLeft(fromPercentUsed: 42), 58)
+        XCTAssertEqual(UsageMetrics.percentLeft(fromPercentUsed: 0), 100)
+        XCTAssertEqual(UsageMetrics.percentLeft(fromPercentUsed: 100), 0)
+    }
+
+    func testPercentLeftClampsBeyondBounds() {
+        XCTAssertEqual(UsageMetrics.percentLeft(fromPercentUsed: 125), 0)
+        XCTAssertEqual(UsageMetrics.percentLeft(fromPercentUsed: -10), 100)
+    }
+
+    func testPeriodDisplayReturnsNilWhenNoUsage() {
+        XCTAssertNil(UsageMetrics.periodDisplay(title: "Session", usage: nil))
+    }
+
+    func testPeriodDisplayIncludesResetTextWhenResetInFuture() {
+        let usage = QuotaPeriod(utilization: 58, resetDate: futureReset)
+
+        let display = UsageMetrics.periodDisplay(title: "Weekly", usage: usage)
+
+        XCTAssertEqual(display?.title, "Weekly")
+        XCTAssertEqual(display?.percentUsed, 58)
+        XCTAssertEqual(display?.resetText?.hasPrefix("Resets in "), true)
+    }
+
+    func testPeriodDisplayOmitsResetTextWhenExpired() {
+        let usage = QuotaPeriod(utilization: 90, resetDate: Date(timeIntervalSince1970: 1_000))
+
+        let display = UsageMetrics.periodDisplay(title: "Session", usage: usage)
+
+        XCTAssertEqual(display?.percentUsed, 90)
+        XCTAssertNil(display?.resetText)
+    }
+
+    func testPeriodDisplayClampsUtilizationAboveQuota() {
+        let usage = QuotaPeriod(utilization: 137, resetDate: futureReset)
+
+        XCTAssertEqual(UsageMetrics.periodDisplay(title: "Session", usage: usage)?.percentUsed, 100)
+    }
+
+    func testExtraUsageDisplayReturnsNilWhenDisabled() {
+        let extra = ExtraUsage(isEnabled: false, monthlyLimit: 20, usedCredits: 4.2, utilization: nil)
+        XCTAssertNil(UsageMetrics.extraUsageDisplay(extra))
+    }
+
+    func testExtraUsageDisplayReturnsNilWhenLimitMissing() {
+        let extra = ExtraUsage(isEnabled: true, monthlyLimit: nil, usedCredits: 4.2, utilization: nil)
+        XCTAssertNil(UsageMetrics.extraUsageDisplay(extra))
+    }
+
+    func testExtraUsageDisplayComputesPercentUsed() {
+        let extra = ExtraUsage(isEnabled: true, monthlyLimit: 20, usedCredits: 5, utilization: nil)
+
+        let display = UsageMetrics.extraUsageDisplay(extra)
+
+        XCTAssertEqual(display?.usedCredits, 5)
+        XCTAssertEqual(display?.monthlyLimit, 20)
+        XCTAssertEqual(display?.percentUsed, 25)
+    }
+
+    func testClaudeHasDataTrueWhenAnyPeriodOrExtraUsagePresent() {
+        let usage = QuotaPeriod(utilization: 10, resetDate: futureReset)
+        let extra = ExtraUsage(isEnabled: true, monthlyLimit: 20, usedCredits: 5, utilization: nil)
+
+        XCTAssertTrue(UsageMetrics.claudeHasData(usage: usage, weeklyUsage: nil, extraUsage: nil))
+        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: usage, extraUsage: nil))
+        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, extraUsage: extra))
+    }
+
+    func testClaudeHasDataFalseWhenNoUsableData() {
+        let disabledExtra = ExtraUsage(isEnabled: false, monthlyLimit: 20, usedCredits: 5, utilization: nil)
+        XCTAssertFalse(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, extraUsage: disabledExtra))
+    }
+
+    func testCodexHasDataReflectsPeriodPresence() {
+        let usage = QuotaPeriod(utilization: 10, resetDate: futureReset)
+        XCTAssertTrue(UsageMetrics.codexHasData(usage: usage, weeklyUsage: nil))
+        XCTAssertTrue(UsageMetrics.codexHasData(usage: nil, weeklyUsage: usage))
+        XCTAssertFalse(UsageMetrics.codexHasData(usage: nil, weeklyUsage: nil))
+    }
+
+    func testCurrencyFormatsWholeAndFractionalAmounts() {
+        XCTAssertEqual(ExtraUsageRowView.currency(20), "$20")
+        XCTAssertEqual(ExtraUsageRowView.currency(4.2), "$4.20")
+    }
+}

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -86,9 +86,51 @@ enum EmotionAnalysisModel: String, CaseIterable, Identifiable {
     }
 }
 
+enum NotchSlotContent: String, CaseIterable, Identifiable {
+    case latest
+    case ring
+    case claude
+    case codex
+    case nothing
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .latest: "Latest Session"
+        case .ring: "Usage"
+        case .claude: "Claude"
+        case .codex: "Codex"
+        case .nothing: "Nothing"
+        }
+    }
+
+    var spriteProvider: AgentProvider? {
+        switch self {
+        case .claude: .claude
+        case .codex: .codex
+        case .nothing, .ring, .latest: nil
+        }
+    }
+
+    var isSprite: Bool {
+        switch self {
+        case .latest, .claude, .codex: true
+        case .nothing, .ring: false
+        }
+    }
+
+    static func conflict(_ a: NotchSlotContent, _ b: NotchSlotContent) -> Bool {
+        guard a != .nothing, b != .nothing else { return false }
+        return a == b || (a.isSprite && b.isSprite && (a == .latest || b == .latest))
+    }
+}
+
 struct AppSettings {
     static let hideSpriteWhenIdleKey = "hideSpriteWhenIdle"
     static let panelToggleShortcutKey = "panelToggleShortcut"
+    static let notchLeftContentKey = "notchLeftContent"
+    static let notchRightContentKey = "notchRightContent"
 
     private static let notificationSoundKey = "notificationSound"
     private static let notificationSoundSelectionKey = "notificationSoundSelection"
@@ -123,6 +165,46 @@ struct AppSettings {
     static var isUsageEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: isUsageEnabledKey) }
         set { UserDefaults.standard.set(newValue, forKey: isUsageEnabledKey) }
+    }
+
+    static var notchLeftContent: NotchSlotContent {
+        get { NotchSlotContent(rawValue: UserDefaults.standard.string(forKey: notchLeftContentKey) ?? "") ?? .ring }
+        set {
+            writeNotchSlot(
+                newValue,
+                previous: notchLeftContent,
+                other: notchRightContent,
+                key: notchLeftContentKey,
+                otherKey: notchRightContentKey
+            )
+        }
+    }
+
+    static var notchRightContent: NotchSlotContent {
+        get { NotchSlotContent(rawValue: UserDefaults.standard.string(forKey: notchRightContentKey) ?? "") ?? .latest }
+        set {
+            writeNotchSlot(
+                newValue,
+                previous: notchRightContent,
+                other: notchLeftContent,
+                key: notchRightContentKey,
+                otherKey: notchLeftContentKey
+            )
+        }
+    }
+
+    private static func writeNotchSlot(
+        _ newValue: NotchSlotContent,
+        previous: NotchSlotContent,
+        other: NotchSlotContent,
+        key: String,
+        otherKey: String
+    ) {
+        UserDefaults.standard.set(newValue.rawValue, forKey: key)
+        if NotchSlotContent.conflict(newValue, other) {
+            let resolved: NotchSlotContent = other == newValue ? previous : .ring
+            UserDefaults.standard.set(resolved.rawValue, forKey: otherKey)
+        }
     }
 
     static var hideSpriteWhenIdle: Bool {

--- a/notchi/notchi/Models/UsageDisplay.swift
+++ b/notchi/notchi/Models/UsageDisplay.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+nonisolated struct UsagePeriodDisplay: Equatable {
+    let title: String
+    let percentUsed: Int
+    let resetText: String?
+}
+
+nonisolated struct ExtraUsageDisplay: Equatable {
+    let usedCredits: Double
+    let monthlyLimit: Double
+
+    var percentUsed: Int {
+        guard monthlyLimit > 0 else { return 0 }
+        return min(max(Int((usedCredits / monthlyLimit * 100).rounded()), 0), 100)
+    }
+}
+
+nonisolated enum UsageMetrics {
+    static func percentLeft(fromPercentUsed percentUsed: Int) -> Int {
+        min(max(100 - percentUsed, 0), 100)
+    }
+
+    /// Builds a row from a quota period. Returns nil when there is no usage data
+    /// at all; an expired or reset-less period still renders, just without the
+    /// trailing reset segment.
+    static func periodDisplay(title: String, usage: QuotaPeriod?) -> UsagePeriodDisplay? {
+        guard let usage else { return nil }
+        let resetText = usage.formattedResetTime.map { "Resets in \($0)" }
+        return UsagePeriodDisplay(
+            title: title,
+            percentUsed: min(max(usage.usagePercentage, 0), 100),
+            resetText: resetText
+        )
+    }
+
+    static func claudeHasData(usage: QuotaPeriod?, weeklyUsage: QuotaPeriod?, extraUsage: ExtraUsage?) -> Bool {
+        usage != nil || weeklyUsage != nil || extraUsageDisplay(extraUsage) != nil
+    }
+
+    static func codexHasData(usage: QuotaPeriod?, weeklyUsage: QuotaPeriod?) -> Bool {
+        usage != nil || weeklyUsage != nil
+    }
+
+    static func extraUsageDisplay(_ extraUsage: ExtraUsage?) -> ExtraUsageDisplay? {
+        guard let extraUsage,
+              extraUsage.isEnabled,
+              let monthlyLimit = extraUsage.monthlyLimit, monthlyLimit > 0,
+              let usedCredits = extraUsage.usedCredits else {
+            return nil
+        }
+        return ExtraUsageDisplay(usedCredits: usedCredits, monthlyLimit: monthlyLimit)
+    }
+}

--- a/notchi/notchi/Models/UsageQuota.swift
+++ b/notchi/notchi/Models/UsageQuota.swift
@@ -3,11 +3,13 @@ import Foundation
 nonisolated struct UsageResponse: Decodable {
     let fiveHour: QuotaPeriod?
     let sevenDay: QuotaPeriod?
+    let sevenDaySonnet: QuotaPeriod?
     let extraUsage: ExtraUsage?
 
     enum CodingKeys: String, CodingKey {
         case fiveHour = "five_hour"
         case sevenDay = "seven_day"
+        case sevenDaySonnet = "seven_day_sonnet"
         case extraUsage = "extra_usage"
     }
 }

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -93,6 +93,7 @@ struct NotchContentView: View {
     @AppStorage(AppSettings.notchRightContentKey) private var rightContentRaw = NotchSlotContent.latest.rawValue
     @State private var showingPanelSettings = false
     @State private var showingPanelSettingsDetail = false
+    @State private var showingUsageDetail = false
     @State private var showingSessionActivity = false
     @State private var isMuted = AppSettings.isMuted
     @State private var isActivityCollapsed = false
@@ -336,6 +337,7 @@ struct NotchContentView: View {
 
     private var shouldShowBackButton: Bool {
         showingPanelSettings ||
+        showingUsageDetail ||
         (sessionStore.activeSessionCount >= 2 && showingSessionActivity)
     }
 
@@ -460,6 +462,7 @@ struct NotchContentView: View {
                 showingPanelSettings = false
                 showingPanelSettingsDetail = false
                 showingSessionActivity = false
+                showingUsageDetail = false
                 hoveredSessionId = nil
             }
         }
@@ -485,6 +488,7 @@ struct NotchContentView: View {
                         showingSettings: $showingPanelSettings,
                         showingSettingsDetail: $showingPanelSettingsDetail,
                         showingSessionActivity: $showingSessionActivity,
+                        showingUsageDetail: $showingUsageDetail,
                         isActivityCollapsed: $isActivityCollapsed,
                         hoveredSessionId: $hoveredSessionId
                     )
@@ -568,6 +572,8 @@ struct NotchContentView: View {
             } else {
                 showingPanelSettings = false
             }
+        } else if showingUsageDetail {
+            showingUsageDetail = false
         } else if showingSessionActivity {
             showingSessionActivity = false
             sessionStore.clearSelectedSession()

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -38,6 +38,10 @@ private enum LaunchWaveTiming {
 }
 
 struct NotchContentView: View {
+    private enum NotchSide {
+        case left, right
+    }
+
     private struct SpriteHandoff {
         enum Direction {
             case expanding
@@ -85,6 +89,8 @@ struct NotchContentView: View {
     var haptics: HapticService = .shared
     @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @ObservedObject private var updateManager = UpdateManager.shared
+    @AppStorage(AppSettings.notchLeftContentKey) private var leftContentRaw = NotchSlotContent.ring.rawValue
+    @AppStorage(AppSettings.notchRightContentKey) private var rightContentRaw = NotchSlotContent.latest.rawValue
     @State private var showingPanelSettings = false
     @State private var showingPanelSettingsDetail = false
     @State private var showingSessionActivity = false
@@ -114,31 +120,21 @@ struct NotchContentView: View {
     private var isExpanded: Bool { panelManager.isExpanded }
     private var collapsedMode: NotchPanelManager.CollapsedMode { panelManager.collapsedMode }
     private var isCompactIdle: Bool { !isExpanded && collapsedMode == .compactIdle }
-    private var headerSpriteContent: HeaderSpriteContent? {
-        Self.resolveHeaderSpriteContent(
-            activeSessionState: activeSession?.state,
-            activeSessionId: activeSession?.id,
-            launchWave: launchWave,
-            isCompactIdle: isCompactIdle,
-            launchSpriteFamily: launchSpriteFamily
-        )
+    private var leftContent: NotchSlotContent {
+        NotchSlotContent(rawValue: leftContentRaw) ?? .ring
     }
 
-    static func resolveHeaderSpriteContent(
-        activeSessionState: NotchiState?,
-        activeSessionId: String? = nil,
-        launchWave: LaunchWave?,
-        isCompactIdle: Bool,
-        launchSpriteFamily: NotchiSpriteFamily
-    ) -> HeaderSpriteContent? {
-        if let activeSessionState {
-            return HeaderSpriteContent(
-                state: activeSessionState,
-                mirrorSeed: activeSessionId ?? "active-header-sprite"
-            )
-        }
+    private var rightContent: NotchSlotContent {
+        NotchSlotContent(rawValue: rightContentRaw) ?? .latest
+    }
 
-        if let launchWave {
+    private func spriteContent(for content: NotchSlotContent, side: NotchSide) -> HeaderSpriteContent? {
+        let excluded = (side == .left ? rightContent : leftContent).spriteProvider
+        if let session = sessionForSprite(content, excluding: excluded) {
+            return HeaderSpriteContent(state: session.state, mirrorSeed: session.id)
+        }
+        if let launchWave,
+           contentAcceptsSprite(content, spriteFamily: launchWave.state.spriteFamily, excluding: excluded) {
             return HeaderSpriteContent(
                 state: launchWave.state,
                 mirrorSeed: "launch-wave-\(launchWave.state.spriteFamily.rawValue)",
@@ -148,12 +144,29 @@ struct NotchContentView: View {
                 xOffset: LaunchWaveTiming.horizontalOffset
             )
         }
+        return nil
+    }
 
-        guard !isCompactIdle else { return nil }
-        return HeaderSpriteContent(
-            state: NotchiState(task: .idle, spriteFamily: launchSpriteFamily),
-            mirrorSeed: "fallback-\(launchSpriteFamily.rawValue)"
-        )
+    private func sessionForSprite(_ content: NotchSlotContent, excluding excluded: AgentProvider?) -> SessionData? {
+        switch content {
+        case .claude: sessionStore.latestSession(for: .claude)
+        case .codex: sessionStore.latestSession(for: .codex)
+        case .latest: sessionStore.latestSession(excluding: excluded)
+        case .nothing, .ring: nil
+        }
+    }
+
+    private func contentAcceptsSprite(
+        _ content: NotchSlotContent,
+        spriteFamily: NotchiSpriteFamily,
+        excluding excluded: AgentProvider?
+    ) -> Bool {
+        switch content {
+        case .claude: spriteFamily == AgentProvider.claude.spriteFamily
+        case .codex: spriteFamily == AgentProvider.codex.spriteFamily
+        case .latest: spriteFamily != excluded?.spriteFamily
+        case .nothing, .ring: false
+        }
     }
 
     static func shouldRenderGrassIsland(
@@ -249,10 +262,16 @@ struct NotchContentView: View {
         return baseOffset + 3
     }
 
-    private var collapsedUsageRingOffsetX: CGFloat {
-        let baseOffset = -(sideWidth / 4 + cornerRadiusInsets.closed.top)
-        guard !isExpanded && panelManager.isCollapsedHovered else { return baseOffset }
-        return baseOffset - 6
+    private func ringOffsetX(side: NotchSide) -> CGFloat {
+        var magnitude = sideWidth / 4 + cornerRadiusInsets.closed.top
+        if !isExpanded && panelManager.isCollapsedHovered {
+            magnitude += 6
+        }
+        return side == .left ? -magnitude : magnitude
+    }
+
+    private func spriteOffsetX(side: NotchSide) -> CGFloat {
+        side == .left ? -collapsedHeaderSpriteOffsetX : collapsedHeaderSpriteOffsetX
     }
 
     private var collapsedUsageRingOffsetY: CGFloat {
@@ -281,6 +300,7 @@ struct NotchContentView: View {
 
     private var usageRingPercentage: Int? {
         guard AppSettings.isUsageEnabled,
+              sessionStore.activeSessionCount > 0,
               let usage = usageService.currentUsage,
               !usage.isExpired else { return nil }
         return usage.usagePercentage
@@ -575,45 +595,61 @@ struct NotchContentView: View {
                 .frame(width: compactContentWidth)
         } else {
             HStack(spacing: 0) {
-                usageRing
-                    .frame(width: sideWidth)
-                    .scaleEffect(collapsedHeaderSpriteScale, anchor: .bottom)
-                    .offset(x: collapsedUsageRingOffsetX, y: collapsedUsageRingOffsetY)
+                slotView(leftContent, side: .left)
 
                 Color.clear
                     .frame(width: notchSize.width - cornerRadiusInsets.closed.top - sideWidth)
 
-                headerSprites
-                    .offset(x: collapsedHeaderSpriteOffsetX, y: collapsedHeaderSpriteOffsetY)
-                    .frame(width: sideWidth)
-                    .opacity(collapsedHeaderSpriteVisuals.opacity)
-                    .blur(radius: collapsedHeaderSpriteVisuals.blur)
-                    .animation(collapsedHeaderSpriteVisibilityAnimation, value: isExpanded)
+                slotView(rightContent, side: .right)
             }
         }
     }
 
     @ViewBuilder
-    private var usageRing: some View {
-        if let usageRingPercentage, !isLaunchWaveActive {
-            UsageRingView(percentage: usageRingPercentage)
-                .opacity(collapsedHeaderSpriteVisuals.opacity)
-                .animation(collapsedHeaderSpriteVisibilityAnimation, value: isExpanded)
+    private func slotView(_ content: NotchSlotContent, side: NotchSide) -> some View {
+        switch content {
+        case .nothing:
+            Color.clear.frame(width: sideWidth)
+        case .ring:
+            ringSlot(side: side)
+        case .latest, .claude, .codex:
+            spriteSlot(content: spriteContent(for: content, side: side), side: side)
         }
     }
 
     @ViewBuilder
-    private var headerSprites: some View {
-        if let headerSpriteContent {
+    private func ringSlot(side: NotchSide) -> some View {
+        if let usageRingPercentage, !isLaunchWaveActive {
+            UsageRingView(percentage: usageRingPercentage)
+                .opacity(collapsedHeaderSpriteVisuals.opacity)
+                .animation(collapsedHeaderSpriteVisibilityAnimation, value: isExpanded)
+                .frame(width: sideWidth)
+                .scaleEffect(collapsedHeaderSpriteScale, anchor: .bottom)
+                .offset(x: ringOffsetX(side: side), y: collapsedUsageRingOffsetY)
+        } else {
+            Color.clear.frame(width: sideWidth)
+        }
+    }
+
+    @ViewBuilder
+    private func spriteSlot(content: HeaderSpriteContent?, side: NotchSide) -> some View {
+        if let content {
             SessionSpriteView(
-                state: headerSpriteContent.state,
+                state: content.state,
                 isPrimarySprite: true,
-                mirrorSeed: headerSpriteContent.mirrorSeed,
-                animationStartDate: headerSpriteContent.startedAt,
-                repeatsAnimation: headerSpriteContent.repeatsAnimation
+                mirrorSeed: content.mirrorSeed,
+                animationStartDate: content.startedAt,
+                repeatsAnimation: content.repeatsAnimation
             )
-            .scaleEffect(collapsedHeaderSpriteScale * headerSpriteContent.scale, anchor: .bottom)
-            .offset(x: headerSpriteContent.xOffset)
+            .scaleEffect(collapsedHeaderSpriteScale * content.scale, anchor: .bottom)
+            .offset(x: content.xOffset)
+            .offset(x: spriteOffsetX(side: side), y: collapsedHeaderSpriteOffsetY)
+            .frame(width: sideWidth)
+            .opacity(collapsedHeaderSpriteVisuals.opacity)
+            .blur(radius: collapsedHeaderSpriteVisuals.blur)
+            .animation(collapsedHeaderSpriteVisibilityAnimation, value: isExpanded)
+        } else {
+            Color.clear.frame(width: sideWidth)
         }
     }
 

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -265,6 +265,13 @@ struct NotchContentView: View {
         max(0, notchSize.height - 12) + 24
     }
 
+    private var usageRingPercentage: Int? {
+        guard AppSettings.isUsageEnabled,
+              let usage = usageService.currentUsage,
+              !usage.isExpired else { return nil }
+        return usage.usagePercentage
+    }
+
     private var compactContentWidth: CGFloat {
         max(0, panelManager.compactNotchRect.width - (cornerRadiusInsets.closed.bottom * 2))
     }
@@ -554,8 +561,12 @@ struct NotchContentView: View {
                 .frame(width: compactContentWidth)
         } else {
             HStack(spacing: 0) {
+                usageRing
+                    .frame(width: sideWidth)
+                    .offset(x: -(sideWidth / 4 + cornerRadiusInsets.closed.top / 2))
+
                 Color.clear
-                    .frame(width: notchSize.width - cornerRadiusInsets.closed.top)
+                    .frame(width: notchSize.width - cornerRadiusInsets.closed.top - sideWidth)
 
                 headerSprites
                     .offset(x: collapsedHeaderSpriteOffsetX, y: collapsedHeaderSpriteOffsetY)
@@ -564,6 +575,15 @@ struct NotchContentView: View {
                     .blur(radius: collapsedHeaderSpriteVisuals.blur)
                     .animation(collapsedHeaderSpriteVisibilityAnimation, value: isExpanded)
             }
+        }
+    }
+
+    @ViewBuilder
+    private var usageRing: some View {
+        if let usageRingPercentage {
+            UsageRingView(percentage: usageRingPercentage)
+                .opacity(collapsedHeaderSpriteVisuals.opacity)
+                .animation(collapsedHeaderSpriteVisibilityAnimation, value: isExpanded)
         }
     }
 

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -249,6 +249,20 @@ struct NotchContentView: View {
         return baseOffset + 3
     }
 
+    private var collapsedUsageRingOffsetX: CGFloat {
+        let baseOffset = -(sideWidth / 4 + cornerRadiusInsets.closed.top)
+        guard !isExpanded && panelManager.isCollapsedHovered else { return baseOffset }
+        return baseOffset - 6
+    }
+
+    private var collapsedUsageRingOffsetY: CGFloat {
+        !isExpanded && panelManager.isCollapsedHovered ? 2 : -1
+    }
+
+    private var isLaunchWaveActive: Bool {
+        launchWave != nil || isLaunchWavePreparing
+    }
+
     private var collapsedHeaderSpriteVisuals: (opacity: Double, blur: CGFloat) {
         guard let activeSession, let spriteHandoff, spriteHandoff.sessionId == activeSession.id else {
             return (opacity: isExpanded ? 0 : 1, blur: 0)
@@ -563,7 +577,8 @@ struct NotchContentView: View {
             HStack(spacing: 0) {
                 usageRing
                     .frame(width: sideWidth)
-                    .offset(x: -(sideWidth / 4 + cornerRadiusInsets.closed.top / 2))
+                    .scaleEffect(collapsedHeaderSpriteScale, anchor: .bottom)
+                    .offset(x: collapsedUsageRingOffsetX, y: collapsedUsageRingOffsetY)
 
                 Color.clear
                     .frame(width: notchSize.width - cornerRadiusInsets.closed.top - sideWidth)
@@ -580,7 +595,7 @@ struct NotchContentView: View {
 
     @ViewBuilder
     private var usageRing: some View {
-        if let usageRingPercentage {
+        if let usageRingPercentage, !isLaunchWaveActive {
             UsageRingView(percentage: usageRingPercentage)
                 .opacity(collapsedHeaderSpriteVisuals.opacity)
                 .animation(collapsedHeaderSpriteVisibilityAnimation, value: isExpanded)

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -337,7 +337,7 @@ struct NotchContentView: View {
 
     private var shouldShowBackButton: Bool {
         showingPanelSettings ||
-        showingUsageDetail ||
+        (showingUsageDetail && !isActivityCollapsed) ||
         (sessionStore.activeSessionCount >= 2 && showingSessionActivity)
     }
 
@@ -581,6 +581,7 @@ struct NotchContentView: View {
     }
 
     private func selectGrassSession(_ sessionId: String) {
+        showingUsageDetail = false
         guard sessionStore.activeSessionCount >= 2 else { return }
 
         let shouldPlayHaptic = sessionStore.selectedSessionId != sessionId || !showingSessionActivity

--- a/notchi/notchi/Services/ClaudeUsageService.swift
+++ b/notchi/notchi/Services/ClaudeUsageService.swift
@@ -20,6 +20,7 @@ struct ClaudeUsageRecoverySnapshot: Codable, Equatable {
     let oauthHeadersFallbackProbeUntil: Date?
     let isHeadersFallbackActive: Bool
     let lastGoodUsage: QuotaPeriod?
+    let lastGoodWeeklyUsage: QuotaPeriod?
     let lastGoodExtraUsage: ExtraUsage?
     let lastObservedExtraUsageCredits: Double?
     let extraUsageResetMarker: String?
@@ -681,6 +682,7 @@ final class ClaudeUsageService {
     static let shared = ClaudeUsageService()
 
     var currentUsage: QuotaPeriod?
+    var currentWeeklyUsage: QuotaPeriod?
     var currentExtraUsage: ExtraUsage?
     var isUsingExtraUsage = false
     var isLoading = false
@@ -1231,6 +1233,7 @@ final class ClaudeUsageService {
             preferHeadersFallback = false
             clearTransientState()
             currentUsage = usageResponse.fiveHour
+            currentWeeklyUsage = usageResponse.sevenDay
             lastObservedAt = usageResponse.fiveHour == nil ? nil : dependencies.now()
             reconcileExtraUsageState(
                 with: usageResponse.extraUsage,
@@ -1322,6 +1325,7 @@ final class ClaudeUsageService {
             let usage = QuotaPeriod(utilization: (utilization * 100).rounded(), resetDate: resetDate)
             isConnected = true
             currentUsage = usage
+            currentWeeklyUsage = nil
             lastObservedAt = dependencies.now()
             reconcileExtraUsageStateForHeaders(using: usage)
 
@@ -1836,6 +1840,7 @@ final class ClaudeUsageService {
         let now = dependencies.now()
         guard isUsageStillValid(currentUsage, now: now) else {
             currentUsage = nil
+            currentWeeklyUsage = nil
             clearOAuthBackoffState()
             presentRetryableIssue(
                 noUsageMessage: "No rate limit headers, retrying in \(Int(pollInterval))s",
@@ -1867,6 +1872,7 @@ final class ClaudeUsageService {
         }
 
         currentUsage = isUsageStillValid(snapshot.lastGoodUsage, now: now) ? snapshot.lastGoodUsage : nil
+        currentWeeklyUsage = isUsageStillValid(snapshot.lastGoodWeeklyUsage, now: now) ? snapshot.lastGoodWeeklyUsage : nil
         lastObservedAt = currentUsage == nil ? nil : now
         currentExtraUsage = snapshot.lastGoodExtraUsage
         lastObservedExtraUsageCredits = snapshot.lastObservedExtraUsageCredits
@@ -1913,12 +1919,15 @@ final class ClaudeUsageService {
             return nil
         }
 
-        let usageToPersist = isUsageStillValid(currentUsage, now: dependencies.now()) ? currentUsage : nil
+        let now = dependencies.now()
+        let usageToPersist = isUsageStillValid(currentUsage, now: now) ? currentUsage : nil
+        let weeklyToPersist = isUsageStillValid(currentWeeklyUsage, now: now) ? currentWeeklyUsage : nil
         return ClaudeUsageRecoverySnapshot(
             oauthBackoffUntil: oauthBackoffUntil,
             oauthHeadersFallbackProbeUntil: oauthHeadersFallbackProbeUntil,
             isHeadersFallbackActive: isHeadersFallbackActive,
             lastGoodUsage: usageToPersist,
+            lastGoodWeeklyUsage: weeklyToPersist,
             lastGoodExtraUsage: currentExtraUsage,
             lastObservedExtraUsageCredits: lastObservedExtraUsageCredits,
             extraUsageResetMarker: extraUsageResetMarker,

--- a/notchi/notchi/Services/ClaudeUsageService.swift
+++ b/notchi/notchi/Services/ClaudeUsageService.swift
@@ -21,6 +21,7 @@ struct ClaudeUsageRecoverySnapshot: Codable, Equatable {
     let isHeadersFallbackActive: Bool
     let lastGoodUsage: QuotaPeriod?
     let lastGoodWeeklyUsage: QuotaPeriod?
+    let lastGoodSonnetUsage: QuotaPeriod?
     let lastGoodExtraUsage: ExtraUsage?
     let lastObservedExtraUsageCredits: Double?
     let extraUsageResetMarker: String?
@@ -683,6 +684,7 @@ final class ClaudeUsageService {
 
     var currentUsage: QuotaPeriod?
     var currentWeeklyUsage: QuotaPeriod?
+    var currentSonnetUsage: QuotaPeriod?
     var currentExtraUsage: ExtraUsage?
     var isUsingExtraUsage = false
     var isLoading = false
@@ -1234,6 +1236,7 @@ final class ClaudeUsageService {
             clearTransientState()
             currentUsage = usageResponse.fiveHour
             currentWeeklyUsage = usageResponse.sevenDay
+            currentSonnetUsage = usageResponse.sevenDaySonnet
             lastObservedAt = usageResponse.fiveHour == nil ? nil : dependencies.now()
             reconcileExtraUsageState(
                 with: usageResponse.extraUsage,
@@ -1326,6 +1329,7 @@ final class ClaudeUsageService {
             isConnected = true
             currentUsage = usage
             currentWeeklyUsage = nil
+            currentSonnetUsage = nil
             lastObservedAt = dependencies.now()
             reconcileExtraUsageStateForHeaders(using: usage)
 
@@ -1841,6 +1845,7 @@ final class ClaudeUsageService {
         guard isUsageStillValid(currentUsage, now: now) else {
             currentUsage = nil
             currentWeeklyUsage = nil
+            currentSonnetUsage = nil
             clearOAuthBackoffState()
             presentRetryableIssue(
                 noUsageMessage: "No rate limit headers, retrying in \(Int(pollInterval))s",
@@ -1873,6 +1878,7 @@ final class ClaudeUsageService {
 
         currentUsage = isUsageStillValid(snapshot.lastGoodUsage, now: now) ? snapshot.lastGoodUsage : nil
         currentWeeklyUsage = isUsageStillValid(snapshot.lastGoodWeeklyUsage, now: now) ? snapshot.lastGoodWeeklyUsage : nil
+        currentSonnetUsage = isUsageStillValid(snapshot.lastGoodSonnetUsage, now: now) ? snapshot.lastGoodSonnetUsage : nil
         lastObservedAt = currentUsage == nil ? nil : now
         currentExtraUsage = snapshot.lastGoodExtraUsage
         lastObservedExtraUsageCredits = snapshot.lastObservedExtraUsageCredits
@@ -1922,12 +1928,14 @@ final class ClaudeUsageService {
         let now = dependencies.now()
         let usageToPersist = isUsageStillValid(currentUsage, now: now) ? currentUsage : nil
         let weeklyToPersist = isUsageStillValid(currentWeeklyUsage, now: now) ? currentWeeklyUsage : nil
+        let sonnetToPersist = isUsageStillValid(currentSonnetUsage, now: now) ? currentSonnetUsage : nil
         return ClaudeUsageRecoverySnapshot(
             oauthBackoffUntil: oauthBackoffUntil,
             oauthHeadersFallbackProbeUntil: oauthHeadersFallbackProbeUntil,
             isHeadersFallbackActive: isHeadersFallbackActive,
             lastGoodUsage: usageToPersist,
             lastGoodWeeklyUsage: weeklyToPersist,
+            lastGoodSonnetUsage: sonnetToPersist,
             lastGoodExtraUsage: currentExtraUsage,
             lastObservedExtraUsageCredits: lastObservedExtraUsageCredits,
             extraUsageResetMarker: extraUsageResetMarker,

--- a/notchi/notchi/Services/ClaudeUsageService.swift
+++ b/notchi/notchi/Services/ClaudeUsageService.swift
@@ -738,7 +738,7 @@ final class ClaudeUsageService {
                 allowsCredentialRecovery: true,
                 prefersRecoveredCredentials: true
             ) else {
-                presentReconnectRequired(message: "Claude authentication needs attention. Tap to reconnect.")
+                presentReconnectRequired(message: "Claude authentication needs attention.")
                 AppSettings.isUsageEnabled = false
                 return
             }
@@ -793,7 +793,7 @@ final class ClaudeUsageService {
                 AppSettings.isUsageEnabled = false
                 clearOAuthBackoffState()
                 if currentUsage != nil {
-                    presentReconnectRequired(message: "Claude authentication needs attention. Tap to reconnect.")
+                    presentReconnectRequired(message: "Claude authentication needs attention.")
                 } else {
                     clearTransientState()
                 }
@@ -1110,7 +1110,7 @@ final class ClaudeUsageService {
             if allow403EmptyHeadersRecovery {
                 await recoverFromEmptyHeadersFallback(afterOAuth403With: accessToken, userInitiated: userInitiated)
             } else {
-                presentReconnectRequired(message: "Claude authentication needs attention. Tap to reconnect.")
+                presentReconnectRequired(message: "Claude authentication needs attention.")
                 stopPolling()
             }
         }
@@ -1439,7 +1439,7 @@ final class ClaudeUsageService {
         if usesCredentialMetadata,
            !credentials.scopes.isEmpty,
            !credentials.scopes.contains("user:profile") {
-            presentReconnectRequired(message: "Claude authentication needs attention. Tap to reconnect.")
+            presentReconnectRequired(message: "Claude authentication needs attention.")
             stopPolling()
             return .handled
         }
@@ -1476,11 +1476,11 @@ final class ClaudeUsageService {
 
     private func resolveAuthFailureResolution(after401With currentToken: String) -> ClaudeUsageAuthFailureResolution {
         guard let credentials = dependencies.getOAuthCredentials(false) else {
-            return .reconnect("Token expired. Tap to reconnect.")
+            return .reconnect("Token expired.")
         }
 
         if credentialsRequireReconnect(credentials) {
-            return .reconnect("Claude authentication needs attention. Tap to reconnect.")
+            return .reconnect("Claude authentication needs attention.")
         }
 
         let credentialToken = credentials.accessToken.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1512,7 +1512,7 @@ final class ClaudeUsageService {
             return
         }
 
-        presentReconnectRequired(message: "Claude authentication needs attention. Tap to reconnect.")
+        presentReconnectRequired(message: "Claude authentication needs attention.")
         stopPolling()
     }
 
@@ -1526,7 +1526,7 @@ final class ClaudeUsageService {
             logger.warning(
                 "OAuth 403 requires reconnect - errorType: \(errorTypeLog, privacy: .public), requestID: \(requestIDLog, privacy: .public), message: \(rawMessage, privacy: .public)"
             )
-            presentReconnectRequired(message: "Claude authentication needs attention. Tap to reconnect.")
+            presentReconnectRequired(message: "Claude authentication needs attention.")
             stopPolling()
             return .handled
 

--- a/notchi/notchi/Services/CodexUsageAPI.swift
+++ b/notchi/notchi/Services/CodexUsageAPI.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+nonisolated struct CodexAPIAuth: Equatable {
+    let accessToken: String
+    let accountId: String?
+
+    static func load(from data: Data) -> CodexAPIAuth? {
+        guard let root = try? JSONDecoder().decode(AuthFile.self, from: data),
+              let accessToken = root.tokens?.accessToken,
+              !accessToken.isEmpty else {
+            return nil
+        }
+        return CodexAPIAuth(accessToken: accessToken, accountId: root.tokens?.accountId)
+    }
+
+    private struct AuthFile: Decodable {
+        let tokens: Tokens?
+        struct Tokens: Decodable {
+            let accessToken: String?
+            let accountId: String?
+            enum CodingKeys: String, CodingKey {
+                case accessToken = "access_token"
+                case accountId = "account_id"
+            }
+        }
+    }
+}
+
+nonisolated struct CodexAPIUsage: Equatable {
+    let reviews: QuotaPeriod?
+    let creditsBalance: Double?
+}
+
+nonisolated enum CodexUsageAPI {
+    static let usageURL = URL(string: "https://chatgpt.com/backend-api/wham/usage")!
+
+    static let creditUSDRate = 0.04
+
+    static func authFileURL() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex/auth.json")
+    }
+
+    static func makeRequest(auth: CodexAPIAuth) -> URLRequest {
+        var request = URLRequest(url: usageURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(auth.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let accountId = auth.accountId {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+        request.timeoutInterval = 10
+        return request
+    }
+
+    static func accessTokenExpiry(_ token: String) -> Date? {
+        let segments = token.split(separator: ".")
+        guard segments.count >= 2,
+              let payload = base64URLDecode(String(segments[1])),
+              let json = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
+              let exp = json["exp"] as? Double else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: exp)
+    }
+
+    static func isAccessTokenExpired(_ token: String, now: Date) -> Bool {
+        guard let expiry = accessTokenExpiry(token) else { return false }
+        return expiry <= now
+    }
+
+    static func usage(from response: CodexUsageAPIResponse, now: Date) -> CodexAPIUsage {
+        let reviews = response.codeReviewRateLimit?.primaryWindow.flatMap { window -> QuotaPeriod? in
+            guard let usedPercent = window.usedPercent else { return nil }
+            return QuotaPeriod(
+                utilization: usedPercent.rounded(),
+                resetDate: window.resetDate(now: now)
+            )
+        }
+
+        let creditsBalance: Double?
+        if let balance = response.credits?.balance {
+            creditsBalance = balance
+        } else if response.credits?.hasCredits == false {
+            creditsBalance = 0
+        } else {
+            creditsBalance = nil
+        }
+
+        return CodexAPIUsage(reviews: reviews, creditsBalance: creditsBalance)
+    }
+
+    private static func base64URLDecode(_ value: String) -> Data? {
+        var base64 = value.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder > 0 {
+            base64.append(String(repeating: "=", count: 4 - remainder))
+        }
+        return Data(base64Encoded: base64)
+    }
+}
+
+nonisolated struct CodexUsageAPIResponse: Decodable {
+    let codeReviewRateLimit: RateLimit?
+    let credits: Credits?
+
+    enum CodingKeys: String, CodingKey {
+        case codeReviewRateLimit = "code_review_rate_limit"
+        case credits
+    }
+
+    struct RateLimit: Decodable {
+        let primaryWindow: Window?
+        enum CodingKeys: String, CodingKey {
+            case primaryWindow = "primary_window"
+        }
+    }
+
+    struct Window: Decodable {
+        let usedPercent: Double?
+        let resetAt: Double?
+        let resetAfterSeconds: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case usedPercent = "used_percent"
+            case resetAt = "reset_at"
+            case resetAfterSeconds = "reset_after_seconds"
+        }
+
+        func resetDate(now: Date) -> Date? {
+            if let resetAt { return Date(timeIntervalSince1970: resetAt) }
+            if let resetAfterSeconds { return now.addingTimeInterval(resetAfterSeconds) }
+            return nil
+        }
+    }
+
+    struct Credits: Decodable {
+        let balance: Double?
+        let hasCredits: Bool?
+
+        enum CodingKeys: String, CodingKey {
+            case balance
+            case hasCredits = "has_credits"
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            hasCredits = try container.decodeIfPresent(Bool.self, forKey: .hasCredits)
+            if let number = try? container.decodeIfPresent(Double.self, forKey: .balance) {
+                balance = number
+            } else if let string = try? container.decodeIfPresent(String.self, forKey: .balance) {
+                balance = Double(string)
+            } else {
+                balance = nil
+            }
+        }
+    }
+}

--- a/notchi/notchi/Services/CodexUsageService.swift
+++ b/notchi/notchi/Services/CodexUsageService.swift
@@ -2,6 +2,7 @@ import Foundation
 
 nonisolated struct CodexUsageSnapshot: Sendable, Equatable {
     let usage: QuotaPeriod
+    let weeklyUsage: QuotaPeriod?
     let observedAt: Date
 }
 
@@ -23,6 +24,7 @@ final class CodexUsageService {
     static let shared = CodexUsageService()
 
     var currentUsage: QuotaPeriod?
+    var currentWeeklyUsage: QuotaPeriod?
     var isUsageStale = false
     var statusMessage: String?
     var lastObservedAt: Date?
@@ -52,6 +54,7 @@ final class CodexUsageService {
 
     func clear() {
         currentUsage = nil
+        currentWeeklyUsage = nil
         isUsageStale = false
         statusMessage = nil
         lastObservedAt = nil
@@ -62,6 +65,7 @@ final class CodexUsageService {
 
         if let snapshot, isUsageStillValid(snapshot.usage, now: now) {
             currentUsage = snapshot.usage
+            currentWeeklyUsage = snapshot.weeklyUsage
             lastObservedAt = snapshot.observedAt
             isUsageStale = now.timeIntervalSince(snapshot.observedAt) > Self.staleObservationInterval
             statusMessage = nil
@@ -126,11 +130,19 @@ nonisolated enum CodexUsageSnapshotResolver {
                 continue
             }
 
+            let weeklyUsage = event.payload?.rateLimits?.secondary.map { secondary in
+                QuotaPeriod(
+                    utilization: secondary.usedPercent.rounded(),
+                    resetDate: Date(timeIntervalSince1970: secondary.resetsAt)
+                )
+            }
+
             let snapshot = CodexUsageSnapshot(
                 usage: QuotaPeriod(
                     utilization: primary.usedPercent.rounded(),
                     resetDate: Date(timeIntervalSince1970: primary.resetsAt)
                 ),
+                weeklyUsage: weeklyUsage,
                 observedAt: observedAt
             )
             if latestSnapshot.map({ observedAt > $0.observedAt }) ?? true {
@@ -194,6 +206,7 @@ private nonisolated struct CodexTokenCountEvent: Decodable {
 
     struct RateLimits: Decodable {
         let primary: Limit?
+        let secondary: Limit?
     }
 
     struct Limit: Decodable {

--- a/notchi/notchi/Services/CodexUsageService.swift
+++ b/notchi/notchi/Services/CodexUsageService.swift
@@ -8,14 +8,36 @@ nonisolated struct CodexUsageSnapshot: Sendable, Equatable {
 
 nonisolated struct CodexUsageServiceDependencies: Sendable {
     var resolveUsage: @Sendable ([String]) -> CodexUsageSnapshot?
+    var fetchAPIUsage: @Sendable () async -> CodexAPIUsage? = { nil }
     var now: @Sendable () -> Date
 
     static let live = CodexUsageServiceDependencies(
         resolveUsage: { transcriptPaths in
             CodexUsageSnapshotResolver.latestSnapshot(transcriptPaths: transcriptPaths)
         },
+        fetchAPIUsage: { await CodexUsageAPIClient.fetchLive() },
         now: { Date() }
     )
+}
+
+nonisolated enum CodexUsageAPIClient {
+    static func fetchLive() async -> CodexAPIUsage? {
+        guard let data = try? Data(contentsOf: CodexUsageAPI.authFileURL()),
+              let auth = CodexAPIAuth.load(from: data),
+              !CodexUsageAPI.isAccessTokenExpired(auth.accessToken, now: Date()) else {
+            return nil
+        }
+
+        let request = CodexUsageAPI.makeRequest(auth: auth)
+        guard let (body, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode),
+              let decoded = try? JSONDecoder().decode(CodexUsageAPIResponse.self, from: body) else {
+            return nil
+        }
+
+        return CodexUsageAPI.usage(from: decoded, now: Date())
+    }
 }
 
 @MainActor
@@ -25,11 +47,16 @@ final class CodexUsageService {
 
     var currentUsage: QuotaPeriod?
     var currentWeeklyUsage: QuotaPeriod?
+    var currentReviewsUsage: QuotaPeriod?
+    var currentExtraCreditsUSD: Double?
     var isUsageStale = false
     var statusMessage: String?
     var lastObservedAt: Date?
 
     private static let staleObservationInterval: TimeInterval = 15 * 60
+
+    private static let apiUsageRefreshInterval: TimeInterval = 60
+    private var lastAPIUsageFetchAt: Date?
 
     private let dependencies: CodexUsageServiceDependencies
 
@@ -50,11 +77,28 @@ final class CodexUsageService {
         }.value
 
         apply(snapshot)
+        await refreshAPIUsage()
+    }
+
+    private func refreshAPIUsage() async {
+        let now = dependencies.now()
+        if let last = lastAPIUsageFetchAt, now.timeIntervalSince(last) < Self.apiUsageRefreshInterval {
+            return
+        }
+        lastAPIUsageFetchAt = now
+
+        if let apiUsage = await dependencies.fetchAPIUsage() {
+            currentReviewsUsage = apiUsage.reviews
+            currentExtraCreditsUSD = apiUsage.creditsBalance.map { $0 * CodexUsageAPI.creditUSDRate }
+        }
     }
 
     func clear() {
         currentUsage = nil
         currentWeeklyUsage = nil
+        currentReviewsUsage = nil
+        currentExtraCreditsUSD = nil
+        lastAPIUsageFetchAt = nil
         isUsageStale = false
         statusMessage = nil
         lastObservedAt = nil

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -53,6 +53,14 @@ final class SessionStore {
         return sortedSessions.first
     }
 
+    func latestSession(for provider: AgentProvider) -> SessionData? {
+        sortedSessions.first { $0.provider == provider }
+    }
+
+    func latestSession(excluding provider: AgentProvider?) -> SessionData? {
+        sortedSessions.first { $0.provider != provider }
+    }
+
     func selectSession(_ sessionKey: ProviderSessionKey) {
         guard sessions[sessionKey] != nil else { return }
         selectedSessionKey = sessionKey

--- a/notchi/notchi/UI/TerminalColors.swift
+++ b/notchi/notchi/UI/TerminalColors.swift
@@ -17,6 +17,14 @@ struct TerminalColors {
     static let dimmedText = Color.white.opacity(0.3)
     static let subtleBackground = Color.white.opacity(0.04)
     static let hoverBackground = Color.white.opacity(0.08)
+
+    static func usageColor(forPercentUsed percentUsed: Int) -> Color {
+        switch percentUsed {
+        case ..<50: return green
+        case ..<80: return amber
+        default: return red
+        }
+    }
 }
 
 extension AgentProvider {

--- a/notchi/notchi/Views/Components/UsageRingView.swift
+++ b/notchi/notchi/Views/Components/UsageRingView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct UsageRingView: View {
+    let percentage: Int
+    var diameter: CGFloat = 15
+    var lineWidth: CGFloat = 3
+
+    private var clampedPercentage: Int {
+        min(max(percentage, 0), 100)
+    }
+
+    private var ringColor: Color {
+        switch clampedPercentage {
+        case ..<50: return TerminalColors.green
+        case ..<80: return TerminalColors.amber
+        default: return TerminalColors.red
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(ringColor.opacity(0.28), lineWidth: lineWidth)
+            UsageRingArc(fraction: Double(clampedPercentage) / 100)
+                .stroke(
+                    ringColor,
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                )
+        }
+        .frame(width: diameter, height: diameter)
+        .animation(.easeInOut(duration: 0.3), value: clampedPercentage)
+    }
+}
+
+private struct UsageRingArc: Shape {
+    var fraction: Double
+
+    var animatableData: Double {
+        get { fraction }
+        set { fraction = newValue }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius = min(rect.width, rect.height) / 2
+        path.addArc(
+            center: center,
+            radius: radius,
+            startAngle: .degrees(-90),
+            endAngle: .degrees(-90 + 360 * fraction),
+            clockwise: false
+        )
+        return path
+    }
+}
+
+#Preview {
+    HStack(spacing: 12) {
+        UsageRingView(percentage: 25)
+        UsageRingView(percentage: 65)
+        UsageRingView(percentage: 95)
+    }
+    .padding()
+    .background(Color.black)
+}

--- a/notchi/notchi/Views/Components/UsageRingView.swift
+++ b/notchi/notchi/Views/Components/UsageRingView.swift
@@ -5,6 +5,8 @@ struct UsageRingView: View {
     var diameter: CGFloat = 15
     var lineWidth: CGFloat = 3
 
+    @State private var drawProgress: CGFloat = 0
+
     private var clampedPercentage: Int {
         min(max(percentage, 0), 100)
     }
@@ -19,15 +21,21 @@ struct UsageRingView: View {
 
     var body: some View {
         ZStack {
-            Circle()
-                .stroke(ringColor.opacity(0.28), lineWidth: lineWidth)
-            UsageRingArc(fraction: Double(clampedPercentage) / 100)
+            UsageRingArc(fraction: Double(drawProgress))
+                .stroke(
+                    ringColor.opacity(0.28),
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .butt)
+                )
+            UsageRingArc(fraction: Double(clampedPercentage) / 100 * Double(drawProgress))
                 .stroke(
                     ringColor,
                     style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
                 )
         }
         .frame(width: diameter, height: diameter)
+        .onAppear {
+            withAnimation(.spring(response: 0.7, dampingFraction: 0.65)) { drawProgress = 1 }
+        }
         .animation(.easeInOut(duration: 0.3), value: clampedPercentage)
     }
 }

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -165,6 +165,7 @@ struct ExpandedPanelView: View {
     @Binding var showingSettings: Bool
     @Binding var showingSettingsDetail: Bool
     @Binding var showingSessionActivity: Bool
+    @Binding var showingUsageDetail: Bool
     @Binding var isActivityCollapsed: Bool
     @Binding var hoveredSessionId: String?
 
@@ -175,6 +176,7 @@ struct ExpandedPanelView: View {
         showingSettings: Binding<Bool>,
         showingSettingsDetail: Binding<Bool>,
         showingSessionActivity: Binding<Bool>,
+        showingUsageDetail: Binding<Bool>,
         isActivityCollapsed: Binding<Bool>,
         hoveredSessionId: Binding<String?>
     ) {
@@ -184,6 +186,7 @@ struct ExpandedPanelView: View {
         _showingSettings = showingSettings
         _showingSettingsDetail = showingSettingsDetail
         _showingSessionActivity = showingSessionActivity
+        _showingUsageDetail = showingUsageDetail
         _isActivityCollapsed = isActivityCollapsed
         _hoveredSessionId = hoveredSessionId
     }
@@ -199,6 +202,22 @@ struct ExpandedPanelView: View {
 
     private var usageContextSession: SessionData? {
         hoveredSession ?? effectiveSession
+    }
+
+    private var usageDetailDefaultProvider: AgentProvider {
+        usageContextSession?.provider ?? sharedUsageBarState?.provider ?? .claude
+    }
+
+    private var hasUsageDetailData: Bool {
+        UsageMetrics.claudeHasData(
+            usage: usageService.currentUsage,
+            weeklyUsage: usageService.currentWeeklyUsage,
+            extraUsage: usageService.currentExtraUsage
+        )
+            || UsageMetrics.codexHasData(
+                usage: codexUsageService.currentUsage,
+                weeklyUsage: codexUsageService.currentWeeklyUsage
+            )
     }
 
     private var state: NotchiState {
@@ -323,7 +342,10 @@ struct ExpandedPanelView: View {
                 if !showingSettings {
                     VStack(alignment: .leading, spacing: 0) {
                         ZStack {
-                            if shouldShowSessionPicker {
+                            if showingUsageDetail {
+                                usageDetailContent(geometry: geometry)
+                                    .transition(primaryContentTransition)
+                            } else if shouldShowSessionPicker {
                                 sessionPickerContent(geometry: geometry)
                                     .transition(primaryContentTransition)
                             } else {
@@ -333,9 +355,11 @@ struct ExpandedPanelView: View {
                         }
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
-                        sharedUsageBar
-                            .padding(.horizontal, 12)
-                            .padding(.bottom, 5)
+                        if !showingUsageDetail {
+                            sharedUsageBar
+                                .padding(.horizontal, 12)
+                                .padding(.bottom, 5)
+                        }
                     }
                 }
 
@@ -347,11 +371,15 @@ struct ExpandedPanelView: View {
             }
         }
         .animation(.easeInOut(duration: 0.25), value: showingSettings)
+        .animation(.easeInOut(duration: 0.25), value: showingUsageDetail)
         .animation(.easeInOut(duration: 0.25), value: shouldShowSessionPicker)
         .onChange(of: showingSettings) { _, isShowing in
             if !isShowing {
                 showingSettingsDetail = false
                 UpdateManager.shared.clearTransientStatus()
+            }
+            if isShowing {
+                showingUsageDetail = false
             }
         }
     }
@@ -394,6 +422,30 @@ struct ExpandedPanelView: View {
                 Spacer()
             }
             .padding(.horizontal, 12)
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    @ViewBuilder
+    private func usageDetailContent(geometry: GeometryProxy) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if isActivityCollapsed {
+                Spacer()
+                    .allowsHitTesting(false)
+            } else {
+                Spacer()
+                    .frame(height: geometry.size.height * 0.3)
+                    .allowsHitTesting(false)
+            }
+
+            UsageDetailView(
+                claudeUsage: usageService,
+                codexUsage: codexUsageService,
+                defaultProvider: usageDetailDefaultProvider
+            )
+            .padding(.horizontal, 12)
+
+            Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
     }
@@ -452,7 +504,8 @@ struct ExpandedPanelView: View {
                 compact: !shouldShowSessionPicker && isActivityCollapsed,
                 isEnabled: state.isProviderSpecific ? Self.sharedUsageBarIsEnabled(provider: state.provider) : true,
                 onConnect: state.provider == .claude && state.isProviderSpecific ? { usageService.connectAndStartPolling() } : nil,
-                onRetry: state.provider == .claude && state.isProviderSpecific ? { usageService.retryNow() } : nil
+                onRetry: state.provider == .claude && state.isProviderSpecific ? { usageService.retryNow() } : nil,
+                onOpenDetail: hasUsageDetailData ? { showingUsageDetail = true } : nil
             )
         }
     }

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -232,6 +232,10 @@ struct ExpandedPanelView: View {
         state.task == .working || state.task == .compacting || state.task == .waiting
     }
 
+    private var isShowingUsageDetail: Bool {
+        showingUsageDetail && !isActivityCollapsed
+    }
+
     private var hasActivity: Bool {
         guard let session = effectiveSession else { return false }
         return !session.recentEvents.isEmpty ||
@@ -342,7 +346,7 @@ struct ExpandedPanelView: View {
                 if !showingSettings {
                     VStack(alignment: .leading, spacing: 0) {
                         ZStack {
-                            if showingUsageDetail {
+                            if isShowingUsageDetail {
                                 usageDetailContent(geometry: geometry)
                                     .transition(primaryContentTransition)
                             } else if shouldShowSessionPicker {
@@ -355,7 +359,7 @@ struct ExpandedPanelView: View {
                         }
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
-                        if !showingUsageDetail {
+                        if !isShowingUsageDetail {
                             sharedUsageBar
                                 .padding(.horizontal, 12)
                                 .padding(.bottom, 5)
@@ -505,7 +509,12 @@ struct ExpandedPanelView: View {
                 isEnabled: state.isProviderSpecific ? Self.sharedUsageBarIsEnabled(provider: state.provider) : true,
                 onConnect: state.provider == .claude && state.isProviderSpecific ? { usageService.connectAndStartPolling() } : nil,
                 onRetry: state.provider == .claude && state.isProviderSpecific ? { usageService.retryNow() } : nil,
-                onOpenDetail: hasUsageDetailData ? { showingUsageDetail = true } : nil
+                onOpenDetail: hasUsageDetailData ? {
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                        isActivityCollapsed = false
+                        showingUsageDetail = true
+                    }
+                } : nil
             )
         }
     }

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -152,6 +152,8 @@ struct PanelSettingsView: View {
                 }
             }
             .buttonStyle(.plain)
+
+            NotchLayoutSettingsView()
         }
     }
 
@@ -990,6 +992,121 @@ private struct HorizontalShake: GeometryEffect {
                 y: 0
             )
         )
+    }
+}
+
+private struct NotchLayoutSettingsView: View {
+    private enum Side { case left, right }
+
+    @AppStorage(AppSettings.notchLeftContentKey) private var leftRaw = NotchSlotContent.ring.rawValue
+    @AppStorage(AppSettings.notchRightContentKey) private var rightRaw = NotchSlotContent.latest.rawValue
+    @State private var isLeftExpanded = false
+    @State private var isRightExpanded = false
+
+    private var left: NotchSlotContent { NotchSlotContent(rawValue: leftRaw) ?? .ring }
+    private var right: NotchSlotContent { NotchSlotContent(rawValue: rightRaw) ?? .latest }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
+            sideRow(.left, icon: "rectangle.lefthalf.filled", title: "Notch Left", isExpanded: $isLeftExpanded)
+            sideRow(.right, icon: "rectangle.righthalf.filled", title: "Notch Right", isExpanded: $isRightExpanded)
+        }
+        .animation(.spring(response: 0.3), value: isLeftExpanded)
+        .animation(.spring(response: 0.3), value: isRightExpanded)
+    }
+
+    @ViewBuilder
+    private func sideRow(_ side: Side, icon: String, title: String, isExpanded: Binding<Bool>) -> some View {
+        let selection = side == .left ? left : right
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: { isExpanded.wrappedValue.toggle() }) {
+                SettingsRowView(icon: icon, title: title) {
+                    HStack(spacing: 4) {
+                        Text(selection.displayName)
+                            .font(.system(size: 11))
+                            .foregroundColor(TerminalColors.secondaryText)
+                        Image(systemName: isExpanded.wrappedValue ? "chevron.up" : "chevron.down")
+                            .font(.system(size: 9))
+                            .foregroundColor(TerminalColors.dimmedText)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded.wrappedValue {
+                picker(side)
+            }
+        }
+    }
+
+    private func picker(_ side: Side) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(NotchSlotContent.allCases) { option in
+                    optionRow(side, option: option)
+                }
+            }
+            .padding(.vertical, SettingsLayout.pickerInset)
+        }
+        .frame(height: pickerHeight(optionCount: NotchSlotContent.allCases.count))
+        .background(TerminalColors.subtleBackground)
+        .cornerRadius(8)
+        .padding(.top, SettingsLayout.pickerInset)
+    }
+
+    private func optionRow(_ side: Side, option: NotchSlotContent) -> some View {
+        let selection = side == .left ? left : right
+        let other = side == .left ? right : left
+        let isSelected = selection == option
+        let hint = pickHint(option: option, isSelected: isSelected, other: other)
+        return Button(action: { select(option, for: side) }) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(isSelected ? TerminalColors.green : Color.clear)
+                    .frame(width: 6, height: 6)
+                Text(option.displayName)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(isSelected ? TerminalColors.primaryText : TerminalColors.secondaryText)
+                    .lineLimit(1)
+                Spacer()
+                if let hint {
+                    Text(hint)
+                        .font(.system(size: 9))
+                        .foregroundColor(TerminalColors.dimmedText)
+                }
+            }
+            .padding(.horizontal, SettingsLayout.pickerOptionHorizontalPadding)
+            .padding(.vertical, SettingsLayout.pickerOptionVerticalPadding)
+            .background(isSelected ? TerminalColors.hoverBackground : Color.clear)
+            .cornerRadius(4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func pickHint(option: NotchSlotContent, isSelected: Bool, other: NotchSlotContent) -> String? {
+        guard !isSelected else { return nil }
+        if option == other, other != .nothing { return "swap" }
+        if NotchSlotContent.conflict(option, other) { return "replace" }
+        return nil
+    }
+
+    private func select(_ option: NotchSlotContent, for side: Side) {
+        switch side {
+        case .left:
+            AppSettings.notchLeftContent = option
+            isLeftExpanded = false
+        case .right:
+            AppSettings.notchRightContent = option
+            isRightExpanded = false
+        }
+    }
+
+    private func pickerHeight(optionCount: Int) -> CGFloat {
+        let rowHeight: CGFloat = 28
+        let rowSpacing: CGFloat = 4
+        let visibleCount = min(optionCount, 6)
+        return CGFloat(visibleCount) * rowHeight + CGFloat(max(visibleCount - 1, 0)) * rowSpacing
     }
 }
 

--- a/notchi/notchi/Views/SessionSpriteView.swift
+++ b/notchi/notchi/Views/SessionSpriteView.swift
@@ -10,6 +10,7 @@ struct SessionSpriteView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var stateMirrorKey: String?
     @State private var stateMirrored = false
+    @State private var animatedVerticalOffset: CGFloat = 0
 
     private var bobAmplitude: CGFloat {
         guard !reduceMotion, state.bobAmplitude > 0 else { return 0 }
@@ -19,6 +20,13 @@ struct SessionSpriteView: View {
     private var trembleAmplitude: CGFloat {
         guard !reduceMotion, state.emotion == .sob else { return 0 }
         return Self.sobTrembleAmplitude
+    }
+
+    private var spriteVerticalOffset: CGFloat {
+        switch state.task {
+        case .idle, .sleeping, .compacting: -3
+        default: 0
+        }
     }
 
     private static let sobTrembleAmplitude: CGFloat = 0.2
@@ -41,9 +49,20 @@ struct SessionSpriteView: View {
                 x: trembleOffset(at: timeline.date, amplitude: trembleAmplitude),
                 y: bobOffset(at: timeline.date, duration: state.bobDuration, amplitude: bobAmplitude)
             )
+            .offset(y: animatedVerticalOffset)
         }
-        .onAppear(perform: updateStateMirroring)
+        .onAppear {
+            updateStateMirroring()
+            animatedVerticalOffset = spriteVerticalOffset
+        }
         .onChange(of: mirrorKey) { _, _ in updateStateMirroring() }
+        .onChange(of: spriteVerticalOffset) { _, newValue in
+            if reduceMotion {
+                animatedVerticalOffset = newValue
+            } else {
+                withAnimation(.easeInOut(duration: 0.2)) { animatedVerticalOffset = newValue }
+            }
+        }
     }
 
     private func spriteSheetPresentation(at date: Date) -> SpriteSheetPresentation {

--- a/notchi/notchi/Views/UsageBarView.swift
+++ b/notchi/notchi/Views/UsageBarView.swift
@@ -51,7 +51,12 @@ struct UsageBarView: View {
     }
 
     var shouldShowRecoveryButton: Bool {
-        recoveryAction != .none
+        switch recoveryAction {
+        case .retry, .reconnect:
+            return true
+        case .waitForClaudeCode, .none:
+            return false
+        }
     }
 
     var recoveryActionLabel: String {

--- a/notchi/notchi/Views/UsageBarView.swift
+++ b/notchi/notchi/Views/UsageBarView.swift
@@ -14,6 +14,7 @@ struct UsageBarView: View {
     var isEnabled: Bool = AppSettings.isUsageEnabled
     var onConnect: (() -> Void)?
     var onRetry: (() -> Void)?
+    var onOpenDetail: (() -> Void)?
 
     @State private var isPulsing = false
 
@@ -30,7 +31,8 @@ struct UsageBarView: View {
         compact: Bool = false,
         isEnabled: Bool = AppSettings.isUsageEnabled,
         onConnect: (() -> Void)? = nil,
-        onRetry: (() -> Void)? = nil
+        onRetry: (() -> Void)? = nil,
+        onOpenDetail: (() -> Void)? = nil
     ) {
         self.usage = usage
         self.isUsingExtraUsage = isUsingExtraUsage
@@ -45,6 +47,7 @@ struct UsageBarView: View {
         self.isEnabled = isEnabled
         self.onConnect = onConnect
         self.onRetry = onRetry
+        self.onOpenDetail = onOpenDetail
     }
 
     var shouldShowRecoveryButton: Bool {
@@ -194,6 +197,8 @@ struct UsageBarView: View {
             progressBar
         }
         .padding(.top, compact ? 0 : 5)
+        .contentShape(Rectangle())
+        .onTapGesture { onOpenDetail?() }
     }
 
     private var recoveryButton: some View {

--- a/notchi/notchi/Views/UsageBarView.swift
+++ b/notchi/notchi/Views/UsageBarView.swift
@@ -15,6 +15,8 @@ struct UsageBarView: View {
     var onConnect: (() -> Void)?
     var onRetry: (() -> Void)?
 
+    @State private var isPulsing = false
+
     init(
         usage: QuotaPeriod?,
         isUsingExtraUsage: Bool = false,
@@ -45,12 +47,31 @@ struct UsageBarView: View {
         self.onRetry = onRetry
     }
 
-    var actionHint: String? {
+    var shouldShowRecoveryButton: Bool {
+        recoveryAction != .none
+    }
+
+    var recoveryActionLabel: String {
         switch recoveryAction {
         case .retry:
-            return "(tap to retry)"
-        case .reconnect, .waitForClaudeCode, .none:
-            return nil
+            return "Retry"
+        case .reconnect:
+            return "Reconnect"
+        case .waitForClaudeCode:
+            return "Open Claude Code"
+        case .none:
+            return ""
+        }
+    }
+
+    func performRecoveryAction() {
+        switch recoveryAction {
+        case .retry:
+            onRetry?()
+        case .reconnect, .waitForClaudeCode:
+            onConnect?()
+        case .none:
+            break
         }
     }
 
@@ -87,17 +108,6 @@ struct UsageBarView: View {
             && recoveryAction == .none
     }
 
-    var shouldAllowTapAction: Bool {
-        switch recoveryAction {
-        case .reconnect, .waitForClaudeCode:
-            return true
-        case .retry:
-            return usage == nil
-        case .none:
-            return false
-        }
-    }
-
     func resetLabelText(for resetTime: String) -> String {
         if let resetLabelPrefix {
             return "\(resetLabelPrefix) resets in \(resetTime)"
@@ -130,16 +140,9 @@ struct UsageBarView: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
                 if let error, usage == nil {
-                    HStack(spacing: 4) {
-                        Text(error)
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundColor(TerminalColors.dimmedText)
-                        if let actionHint {
-                            Text(actionHint)
-                                .font(.system(size: 10))
-                                .foregroundColor(TerminalColors.dimmedText)
-                        }
-                    }
+                    Text(error)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(TerminalColors.red.opacity(0.7))
                 } else if let usage, let resetTime = usage.formattedResetTime {
                     HStack(alignment: .center, spacing: 4) {
                         Text(resetLabelText(for: resetTime))
@@ -167,7 +170,7 @@ struct UsageBarView: View {
                 if isLoading {
                     ProgressView()
                         .controlSize(.mini)
-                } else if usage != nil {
+                } else {
                     HStack(alignment: .center, spacing: 6) {
                         if shouldShowExtraUsageIndicator {
                             Text("Extra Usage")
@@ -175,9 +178,14 @@ struct UsageBarView: View {
                                 .foregroundColor(TerminalColors.red.opacity(0.85))
                                 .lineLimit(1)
                         }
-                        Text("\(effectivePercentage)%")
-                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                            .foregroundColor(usageColor)
+                        if usage != nil {
+                            Text("\(effectivePercentage)%")
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                                .foregroundColor(usageColor)
+                        }
+                        if shouldShowRecoveryButton {
+                            recoveryButton
+                        }
                     }
                     .padding(.bottom, 1)
                 }
@@ -185,19 +193,21 @@ struct UsageBarView: View {
 
             progressBar
         }
-        .contentShape(Rectangle())
-        .onTapGesture {
-            guard shouldAllowTapAction else { return }
-            switch recoveryAction {
-            case .retry:
-                onRetry?()
-            case .reconnect, .waitForClaudeCode:
-                onConnect?()
-            case .none:
-                break
-            }
-        }
         .padding(.top, compact ? 0 : 5)
+    }
+
+    private var recoveryButton: some View {
+        Button(action: performRecoveryAction) {
+            Image(systemName: "arrow.clockwise")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(TerminalColors.red.opacity(0.7))
+                .opacity(isPulsing ? 0.8 : 1.0)
+                .animation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true), value: isPulsing)
+        }
+        .buttonStyle(RecoveryButtonStyle())
+        .help(recoveryActionLabel)
+        .accessibilityLabel(recoveryActionLabel)
+        .onAppear { isPulsing = true }
     }
 
     private var progressBar: some View {
@@ -216,4 +226,17 @@ struct UsageBarView: View {
         .frame(height: 4)
     }
 
+}
+
+private struct RecoveryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.8 : 1.0)
+            .animation(.spring(response: 0.28, dampingFraction: 0.45), value: configuration.isPressed)
+            .onChange(of: configuration.isPressed) { _, pressed in
+                if pressed {
+                    NSHapticFeedbackManager.defaultPerformer.perform(.generic, performanceTime: .now)
+                }
+            }
+    }
 }

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -1,0 +1,205 @@
+import SwiftUI
+
+struct UsageDetailView: View {
+    let claudeUsage: ClaudeUsageService
+    let codexUsage: CodexUsageService
+    let defaultProvider: AgentProvider
+
+    @State private var selectedProvider: AgentProvider
+
+    init(
+        claudeUsage: ClaudeUsageService,
+        codexUsage: CodexUsageService,
+        defaultProvider: AgentProvider
+    ) {
+        self.claudeUsage = claudeUsage
+        self.codexUsage = codexUsage
+        self.defaultProvider = defaultProvider
+        _selectedProvider = State(initialValue: defaultProvider)
+    }
+
+    private var claudeHasData: Bool {
+        UsageMetrics.claudeHasData(
+            usage: claudeUsage.currentUsage,
+            weeklyUsage: claudeUsage.currentWeeklyUsage,
+            extraUsage: claudeUsage.currentExtraUsage
+        )
+    }
+
+    private var codexHasData: Bool {
+        UsageMetrics.codexHasData(
+            usage: codexUsage.currentUsage,
+            weeklyUsage: codexUsage.currentWeeklyUsage
+        )
+    }
+
+    private var showsToggle: Bool {
+        claudeHasData && codexHasData
+    }
+
+    private var resolvedProvider: AgentProvider {
+        switch selectedProvider {
+        case .claude where !claudeHasData && codexHasData: return .codex
+        case .codex where !codexHasData && claudeHasData: return .claude
+        default: return selectedProvider
+        }
+    }
+
+    private var periods: [UsagePeriodDisplay] {
+        switch resolvedProvider {
+        case .claude:
+            return [
+                UsageMetrics.periodDisplay(title: "Session", usage: claudeUsage.currentUsage),
+                UsageMetrics.periodDisplay(title: "Weekly", usage: claudeUsage.currentWeeklyUsage),
+            ].compactMap { $0 }
+        case .codex:
+            return [
+                UsageMetrics.periodDisplay(title: "Session", usage: codexUsage.currentUsage),
+                UsageMetrics.periodDisplay(title: "Weekly", usage: codexUsage.currentWeeklyUsage),
+            ].compactMap { $0 }
+        }
+    }
+
+    private var extraUsage: ExtraUsageDisplay? {
+        resolvedProvider == .claude
+            ? UsageMetrics.extraUsageDisplay(claudeUsage.currentExtraUsage)
+            : nil
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+
+            ForEach(periods, id: \.title) { period in
+                UsagePeriodRowView(display: period)
+            }
+
+            if let extraUsage {
+                ExtraUsageRowView(display: extraUsage)
+            }
+        }
+        .padding(.top, 8)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            if showsToggle {
+                providerToggle
+            } else {
+                Text(resolvedProvider.displayName)
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(TerminalColors.primaryText)
+            }
+
+            Spacer()
+        }
+    }
+
+    private var providerToggle: some View {
+        HStack(spacing: 4) {
+            ForEach([AgentProvider.claude, .codex], id: \.self) { provider in
+                Button(action: { selectedProvider = provider }) {
+                    Text(provider.displayName)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(
+                            resolvedProvider == provider
+                                ? TerminalColors.primaryText
+                                : TerminalColors.dimmedText
+                        )
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(resolvedProvider == provider ? TerminalColors.hoverBackground : .clear)
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+private struct UsageProgressBar: View {
+    let percentUsed: Int
+    let color: Color
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(TerminalColors.subtleBackground)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(color)
+                    .frame(width: geometry.size.width * Double(min(max(percentUsed, 0), 100)) / 100)
+            }
+        }
+        .frame(height: 6)
+    }
+}
+
+private struct StatusDot: View {
+    let color: Color
+    var body: some View {
+        Circle().fill(color).frame(width: 7, height: 7)
+    }
+}
+
+struct UsagePeriodRowView: View {
+    let display: UsagePeriodDisplay
+
+    var body: some View {
+        let color = TerminalColors.usageColor(forPercentUsed: display.percentUsed)
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 6) {
+                Text(display.title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(TerminalColors.primaryText)
+                StatusDot(color: color)
+            }
+            UsageProgressBar(percentUsed: display.percentUsed, color: color)
+            HStack {
+                Text("\(UsageMetrics.percentLeft(fromPercentUsed: display.percentUsed))% left")
+                    .foregroundColor(TerminalColors.secondaryText)
+                Spacer()
+                if let resetText = display.resetText {
+                    Text(resetText)
+                        .foregroundColor(TerminalColors.secondaryText)
+                }
+            }
+            .font(.system(size: 11))
+        }
+    }
+}
+
+struct ExtraUsageRowView: View {
+    let display: ExtraUsageDisplay
+
+    var body: some View {
+        let color = TerminalColors.usageColor(forPercentUsed: display.percentUsed)
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 6) {
+                Text("Extra usage")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(TerminalColors.primaryText)
+                StatusDot(color: color)
+            }
+            UsageProgressBar(percentUsed: display.percentUsed, color: color)
+            HStack {
+                Text("\(Self.currency(display.usedCredits)) used")
+                    .foregroundColor(TerminalColors.secondaryText)
+                Spacer()
+                Text("\(Self.currency(display.monthlyLimit)) limit")
+                    .foregroundColor(TerminalColors.secondaryText)
+            }
+            .font(.system(size: 11))
+        }
+    }
+
+    static func currency(_ value: Double) -> String {
+        if value == value.rounded() {
+            return "$\(Int(value))"
+        }
+        return String(format: "$%.2f", value)
+    }
+}

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -57,8 +57,13 @@ struct UsageDetailView: View {
             return [
                 UsageMetrics.periodDisplay(title: "Session", usage: codexUsage.currentUsage),
                 UsageMetrics.periodDisplay(title: "Weekly", usage: codexUsage.currentWeeklyUsage),
+                UsageMetrics.periodDisplay(title: "Reviews", usage: codexUsage.currentReviewsUsage),
             ].compactMap { $0 }
         }
+    }
+
+    private var codexCreditsUSD: Double? {
+        resolvedProvider == .codex ? codexUsage.currentExtraCreditsUSD : nil
     }
 
     private var extraUsage: ExtraUsageDisplay? {
@@ -77,6 +82,10 @@ struct UsageDetailView: View {
 
             if let extraUsage {
                 ExtraUsageRowView(display: extraUsage)
+            }
+
+            if let codexCreditsUSD {
+                CodexCreditsRowView(remainingUSD: codexCreditsUSD)
             }
         }
         .padding(.top, 8)
@@ -189,5 +198,23 @@ struct ExtraUsageRowView: View {
             return "$\(Int(value))"
         }
         return String(format: "$%.2f", value)
+    }
+}
+
+struct CodexCreditsRowView: View {
+    let remainingUSD: Double
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text("Extra usage")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(TerminalColors.primaryText)
+            HStack {
+                Text(String(format: "$%.2f remaining", remainingUSD))
+                    .foregroundColor(TerminalColors.secondaryText)
+                Spacer()
+            }
+            .font(.system(size: 11))
+        }
     }
 }

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -51,6 +51,7 @@ struct UsageDetailView: View {
             return [
                 UsageMetrics.periodDisplay(title: "Session", usage: claudeUsage.currentUsage),
                 UsageMetrics.periodDisplay(title: "Weekly", usage: claudeUsage.currentWeeklyUsage),
+                UsageMetrics.periodDisplay(title: "Sonnet", usage: claudeUsage.currentSonnetUsage),
             ].compactMap { $0 }
         case .codex:
             return [

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -138,25 +138,15 @@ private struct UsageProgressBar: View {
     }
 }
 
-private struct StatusDot: View {
-    let color: Color
-    var body: some View {
-        Circle().fill(color).frame(width: 7, height: 7)
-    }
-}
-
 struct UsagePeriodRowView: View {
     let display: UsagePeriodDisplay
 
     var body: some View {
         let color = TerminalColors.usageColor(forPercentUsed: display.percentUsed)
         VStack(alignment: .leading, spacing: 7) {
-            HStack(spacing: 6) {
-                Text(display.title)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(TerminalColors.primaryText)
-                StatusDot(color: color)
-            }
+            Text(display.title)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(TerminalColors.primaryText)
             UsageProgressBar(percentUsed: display.percentUsed, color: color)
             HStack {
                 Text("\(UsageMetrics.percentLeft(fromPercentUsed: display.percentUsed))% left")
@@ -178,12 +168,9 @@ struct ExtraUsageRowView: View {
     var body: some View {
         let color = TerminalColors.usageColor(forPercentUsed: display.percentUsed)
         VStack(alignment: .leading, spacing: 7) {
-            HStack(spacing: 6) {
-                Text("Extra usage")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(TerminalColors.primaryText)
-                StatusDot(color: color)
-            }
+            Text("Extra usage")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(TerminalColors.primaryText)
             UsageProgressBar(percentUsed: display.percentUsed, color: color)
             HStack {
                 Text("\(Self.currency(display.usedCredits)) used")


### PR DESCRIPTION
## Summary

Adds at-a-glance usage to the collapsed notch and a detailed, tappable usage breakdown for both Claude and Codex, plus some notch/sprite polish.

## Collapsed notch
- 5-hour usage ring on the collapsed notch, with an animated draw-in and sprite mirroring on hover
- Configurable collapsed notch sides
- Idle / sleeping / compacting sprites raise with an animated glide

## Usage detail view
- Tapping the usage bar opens a detailed per-period breakdown (the full-bar recovery tap was replaced by a dedicated, pulsing recovery icon, freeing the bar surface)
- Renders below the grass header; the standard back button dismisses it; compress/expand preserves the panel state
- **Claude:** Session, Weekly, Sonnet (`seven_day_sonnet`), and Extra usage (`extra_usage`, shown only when enabled)
- **Codex:** Session, Weekly (from rollout rate limits), plus Reviews and an Extra-usage credit balance fetched from `chatgpt.com/backend-api/wham/usage`

## Data notes
- Codex Reviews/credits reuse the token Codex CLI already stores in `~/.codex/auth.json`; the token is never refreshed by us (refresh tokens rotate and could invalidate Codex's session) — an expired token just skips the call. The networked fetch is throttled to 60s and retains last-good values on transient failure.

## Testing
- `./scripts/test.sh all` passes, including new coverage for usage display mappers, Claude weekly/Sonnet publishing, Codex weekly decoding, and the Codex API auth/parse/throttle paths.