### PR TITLE
fix(usage): harden usage ring visibility and polling resilience

### DIFF
--- a/notchi/Tests/ClaudeUsageServiceTests+HeadersFallback.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests+HeadersFallback.swift
@@ -329,7 +329,7 @@ extension ClaudeUsageServiceTests {
 
         XCTAssertEqual(requestURLs, ["/v1/messages"])
         XCTAssertNil(service.error)
-        XCTAssertEqual(service.statusMessage, "Updating soon")
+        XCTAssertEqual(service.statusMessage, "Stale data")
         XCTAssertTrue(service.isUsageStale)
         XCTAssertEqual(service.recoveryAction, .retry)
         XCTAssertEqual(service.currentUsage?.usagePercentage, 50)

--- a/notchi/Tests/ClaudeUsageServiceTests+TokenRecovery.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests+TokenRecovery.swift
@@ -3,6 +3,44 @@ import XCTest
 @testable import notchi
 
 extension ClaudeUsageServiceTests {
+    func testReconnectStateSchedulesSelfHealRetryThatResumesPolling() async throws {
+        let scheduler = PollSchedulerSpy()
+        var credentialsAvailable = false
+        var serveSuccess = false
+        let dependencies = makeDependencies(
+            scheduler: scheduler,
+            resolveUserAgent: { "claude-code/2.1.77" },
+            getCachedOAuthToken: { _ in nil },
+            getOAuthCredentials: { _ in
+                credentialsAvailable
+                    ? self.makeCredentials(accessToken: "fresh-token", scopes: ["user:profile"])
+                    : nil
+            },
+            fetchUsage: { _ in
+                serveSuccess
+                    ? (self.makeSuccessPayload(utilization: 30), self.makeResponse(statusCode: 200))
+                    : (Data(), self.makeResponse(statusCode: 401))
+            }
+        )
+
+        let service = ClaudeUsageService(dependencies: dependencies)
+        AppSettings.isUsageEnabled = true
+        service.currentUsage = makeQuotaPeriod(utilization: 18)
+
+        await service.performFetch(with: "old-token", consultCredentialMetadata: false)
+
+        XCTAssertEqual(service.recoveryAction, .reconnect)
+        XCTAssertTrue(scheduler.intervals.contains(300))
+
+        credentialsAvailable = true
+        serveSuccess = true
+        scheduler.fireLast()
+        for _ in 0..<6 { await Task.yield() }
+
+        XCTAssertEqual(service.currentUsage?.usagePercentage, 30)
+        XCTAssertEqual(service.recoveryAction, .none)
+    }
+
     func testConnectAndStartPollingUsesSilentStoredTokenRecovery() async throws {
         let scheduler = PollSchedulerSpy()
         var environmentTokenCalls = 0

--- a/notchi/Tests/CodexUsageAPITests.swift
+++ b/notchi/Tests/CodexUsageAPITests.swift
@@ -90,6 +90,46 @@ final class CodexUsageAPITests: XCTestCase {
         XCTAssertEqual(CodexUsageAPI.usage(from: response, now: Date()).creditsBalance, 1250)
     }
 
+    func testUsageParsesSessionAndWeeklyFromRateLimit() throws {
+        let data = Data("""
+        {
+          "rate_limit": {
+            "primary_window": { "used_percent": 27.0, "reset_at": 1777103326 },
+            "secondary_window": { "used_percent": 9.0, "reset_at": 1777621726 }
+          }
+        }
+        """.utf8)
+        let response = try JSONDecoder().decode(CodexUsageAPIResponse.self, from: data)
+
+        let usage = CodexUsageAPI.usage(from: response, now: Date(timeIntervalSince1970: 1_000))
+
+        XCTAssertEqual(usage.session?.usagePercentage, 27)
+        XCTAssertEqual(usage.weekly?.usagePercentage, 9)
+    }
+
+    @MainActor
+    func testRefreshFromAPIPopulatesSessionWeeklyAndCredits() async throws {
+        let service = CodexUsageService(dependencies: CodexUsageServiceDependencies(
+            resolveUsage: { _ in nil },
+            fetchAPIUsage: {
+                CodexAPIUsage(
+                    session: QuotaPeriod(utilization: 40, resetDate: Date(timeIntervalSince1970: 9_999_999_999)),
+                    weekly: QuotaPeriod(utilization: 12, resetDate: Date(timeIntervalSince1970: 9_999_999_999)),
+                    reviews: nil,
+                    creditsBalance: 100
+                )
+            },
+            now: { Date(timeIntervalSince1970: 1_000) }
+        ))
+
+        await service.refreshFromAPI()
+
+        XCTAssertEqual(service.currentUsage?.usagePercentage, 40)
+        XCTAssertEqual(service.currentWeeklyUsage?.usagePercentage, 12)
+        let credits = try XCTUnwrap(service.currentExtraCreditsUSD)
+        XCTAssertEqual(credits, 100 * CodexUsageAPI.creditUSDRate, accuracy: 0.0001)
+    }
+
     func testUsageTreatsHasCreditsFalseAsZeroBalance() throws {
         let data = Data(#"{ "credits": { "has_credits": false } }"#.utf8)
         let response = try JSONDecoder().decode(CodexUsageAPIResponse.self, from: data)
@@ -160,6 +200,43 @@ final class CodexUsageAPITests: XCTestCase {
         XCTAssertEqual(service.currentReviewsUsage?.usagePercentage, 30)
         let retainedCredits = try XCTUnwrap(service.currentExtraCreditsUSD)
         XCTAssertEqual(retainedCredits, 100 * CodexUsageAPI.creditUSDRate, accuracy: 0.0001)
+    }
+
+    @MainActor
+    func testIdleRefreshAppliesCachedSessionWeeklyWhenThrottled() async {
+        let counter = CallCounter()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let service = CodexUsageService(dependencies: CodexUsageServiceDependencies(
+            resolveUsage: { _ in
+                CodexUsageSnapshot(
+                    usage: QuotaPeriod(utilization: 5, resetDate: Date(timeIntervalSince1970: 9_999_999_999)),
+                    weeklyUsage: nil,
+                    observedAt: now
+                )
+            },
+            fetchAPIUsage: {
+                await counter.bump()
+                return CodexAPIUsage(
+                    session: QuotaPeriod(utilization: 73, resetDate: Date(timeIntervalSince1970: 9_999_999_999)),
+                    weekly: QuotaPeriod(utilization: 8, resetDate: Date(timeIntervalSince1970: 9_999_999_999)),
+                    reviews: nil,
+                    creditsBalance: nil
+                )
+            },
+            now: { now }
+        ))
+
+        // Active refresh: file drives session (5%), API fetched once (reviews/credits only).
+        await service.refresh(transcriptPaths: ["/tmp/rollout.jsonl"])
+        XCTAssertEqual(service.currentUsage?.usagePercentage, 5)
+
+        // Session ends within the throttle window: cached API session/weekly are applied without a new fetch.
+        await service.refreshFromAPI()
+
+        let fetchCount = await counter.count
+        XCTAssertEqual(fetchCount, 1)
+        XCTAssertEqual(service.currentUsage?.usagePercentage, 73)
+        XCTAssertEqual(service.currentWeeklyUsage?.usagePercentage, 8)
     }
 
     @MainActor

--- a/notchi/Tests/NotchiStateMachineTests.swift
+++ b/notchi/Tests/NotchiStateMachineTests.swift
@@ -383,11 +383,17 @@ final class NotchiStateMachineTests: XCTestCase {
         XCTAssertNil(SessionStore.shared.session(for: sessionKey))
     }
 
-    func testLastCodexSessionEndClearsCodexUsage() {
+    func testLastCodexSessionEndTriggersCodexUsageRefresh() {
         let stateMachine = NotchiStateMachine.shared
         stateMachine.setCodexThreadMetadataAutoRefreshEnabledForTesting(false)
-        let sessionId = "codex-end-clear-usage-\(UUID().uuidString)"
-        let transcriptPath = "/tmp/codex-end-clear-usage.jsonl"
+        var endedHookCalls = 0
+        stateMachine.onCodexSessionsEnded = { endedHookCalls += 1 }
+        defer {
+            stateMachine.resetTestingHooks()
+            CodexUsageService.shared.clear()
+        }
+        let sessionId = "codex-end-refresh-usage-\(UUID().uuidString)"
+        let transcriptPath = "/tmp/codex-end-refresh-usage.jsonl"
 
         stateMachine.handleEvent(makeEvent(
             sessionId: sessionId,
@@ -402,7 +408,6 @@ final class NotchiStateMachineTests: XCTestCase {
             utilization: 15,
             resetDate: Date(timeIntervalSinceNow: 300)
         )
-        CodexUsageService.shared.lastObservedAt = Date()
 
         stateMachine.handleEvent(makeEvent(
             sessionId: sessionId,
@@ -412,8 +417,8 @@ final class NotchiStateMachineTests: XCTestCase {
             status: "ended"
         ))
 
-        XCTAssertNil(CodexUsageService.shared.currentUsage)
-        XCTAssertNil(CodexUsageService.shared.lastObservedAt)
+        XCTAssertGreaterThan(endedHookCalls, 0)
+        XCTAssertEqual(CodexUsageService.shared.currentUsage?.usagePercentage, 15)
     }
 
     private func makeInteractiveSession(sessionId: String) -> SessionData {

--- a/notchi/Tests/UsageDisplayTests.swift
+++ b/notchi/Tests/UsageDisplayTests.swift
@@ -4,6 +4,21 @@ import XCTest
 final class UsageDisplayTests: XCTestCase {
     private let futureReset = Date(timeIntervalSince1970: 4_102_444_800)
 
+    func testFormattedResetTimeUsesMinutesUnderAnHour() {
+        let usage = QuotaPeriod(utilization: 10, resetDate: Date(timeIntervalSinceNow: 30 * 60 + 30))
+        XCTAssertEqual(usage.formattedResetTime, "30m")
+    }
+
+    func testFormattedResetTimeUsesHoursAndMinutesUnder48Hours() {
+        let usage = QuotaPeriod(utilization: 10, resetDate: Date(timeIntervalSinceNow: 5 * 3600 + 30 * 60 + 30))
+        XCTAssertEqual(usage.formattedResetTime, "5h 30m")
+    }
+
+    func testFormattedResetTimeUsesDaysAndHoursAtOrAbove48Hours() {
+        let usage = QuotaPeriod(utilization: 10, resetDate: Date(timeIntervalSinceNow: 50 * 3600 + 5 * 60))
+        XCTAssertEqual(usage.formattedResetTime, "2d 2h")
+    }
+
     func testPeriodDisplayReturnsNilWhenNoUsage() {
         XCTAssertNil(UsageMetrics.periodDisplay(title: "Session", usage: nil))
     }

--- a/notchi/Tests/UsageDisplayTests.swift
+++ b/notchi/Tests/UsageDisplayTests.swift
@@ -4,17 +4,6 @@ import XCTest
 final class UsageDisplayTests: XCTestCase {
     private let futureReset = Date(timeIntervalSince1970: 4_102_444_800)
 
-    func testPercentLeftIsComplementOfUsed() {
-        XCTAssertEqual(UsageMetrics.percentLeft(fromPercentUsed: 42), 58)
-        XCTAssertEqual(UsageMetrics.percentLeft(fromPercentUsed: 0), 100)
-        XCTAssertEqual(UsageMetrics.percentLeft(fromPercentUsed: 100), 0)
-    }
-
-    func testPercentLeftClampsBeyondBounds() {
-        XCTAssertEqual(UsageMetrics.percentLeft(fromPercentUsed: 125), 0)
-        XCTAssertEqual(UsageMetrics.percentLeft(fromPercentUsed: -10), 100)
-    }
-
     func testPeriodDisplayReturnsNilWhenNoUsage() {
         XCTAssertNil(UsageMetrics.periodDisplay(title: "Session", usage: nil))
     }
@@ -26,7 +15,7 @@ final class UsageDisplayTests: XCTestCase {
 
         XCTAssertEqual(display?.title, "Weekly")
         XCTAssertEqual(display?.percentUsed, 58)
-        XCTAssertEqual(display?.resetText?.hasPrefix("Resets in "), true)
+        XCTAssertEqual(display?.resetText?.hasPrefix("resets in "), true)
     }
 
     func testPeriodDisplayOmitsResetTextWhenExpired() {
@@ -42,6 +31,13 @@ final class UsageDisplayTests: XCTestCase {
         let usage = QuotaPeriod(utilization: 137, resetDate: futureReset)
 
         XCTAssertEqual(UsageMetrics.periodDisplay(title: "Session", usage: usage)?.percentUsed, 100)
+    }
+
+    func testPeriodDisplayDefaultsToFreshAndCarriesStaleFlag() {
+        let usage = QuotaPeriod(utilization: 20, resetDate: futureReset)
+
+        XCTAssertEqual(UsageMetrics.periodDisplay(title: "Weekly", usage: usage)?.isStale, false)
+        XCTAssertEqual(UsageMetrics.periodDisplay(title: "Weekly", usage: usage, isStale: true)?.isStale, true)
     }
 
     func testExtraUsageDisplayReturnsNilWhenDisabled() {
@@ -68,14 +64,19 @@ final class UsageDisplayTests: XCTestCase {
         let usage = QuotaPeriod(utilization: 10, resetDate: futureReset)
         let extra = ExtraUsage(isEnabled: true, monthlyLimit: 20, usedCredits: 5, utilization: nil)
 
-        XCTAssertTrue(UsageMetrics.claudeHasData(usage: usage, weeklyUsage: nil, extraUsage: nil))
-        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: usage, extraUsage: nil))
-        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, extraUsage: extra))
+        XCTAssertTrue(UsageMetrics.claudeHasData(usage: usage, weeklyUsage: nil, sonnetUsage: nil, extraUsage: nil))
+        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: usage, sonnetUsage: nil, extraUsage: nil))
+        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, sonnetUsage: nil, extraUsage: extra))
+    }
+
+    func testClaudeHasDataTrueForSonnetOnlyData() {
+        let sonnet = QuotaPeriod(utilization: 0, resetDate: nil)
+        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, sonnetUsage: sonnet, extraUsage: nil))
     }
 
     func testClaudeHasDataFalseWhenNoUsableData() {
         let disabledExtra = ExtraUsage(isEnabled: false, monthlyLimit: 20, usedCredits: 5, utilization: nil)
-        XCTAssertFalse(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, extraUsage: disabledExtra))
+        XCTAssertFalse(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, sonnetUsage: nil, extraUsage: disabledExtra))
     }
 
     func testCodexHasDataReflectsPeriodPresence() {

--- a/notchi/notchi/AppDelegate.swift
+++ b/notchi/notchi/AppDelegate.swift
@@ -62,6 +62,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
                 NotchiStateMachine.shared.handleEvent(event)
             }
             await ClaudeUsageService.shared.startPolling()
+            await CodexUsageService.shared.refreshFromAPI()
         }
     }
 
@@ -157,6 +158,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
     @objc private func handleSystemWake() {
         MainActor.assumeIsolated {
             ClaudeUsageService.shared.startPolling(afterSystemWake: true)
+            Task { await CodexUsageService.shared.refreshFromAPI() }
         }
     }
 

--- a/notchi/notchi/Models/UsageDisplay.swift
+++ b/notchi/notchi/Models/UsageDisplay.swift
@@ -4,6 +4,7 @@ nonisolated struct UsagePeriodDisplay: Equatable {
     let title: String
     let percentUsed: Int
     let resetText: String?
+    var isStale: Bool = false
 }
 
 nonisolated struct ExtraUsageDisplay: Equatable {
@@ -17,25 +18,19 @@ nonisolated struct ExtraUsageDisplay: Equatable {
 }
 
 nonisolated enum UsageMetrics {
-    static func percentLeft(fromPercentUsed percentUsed: Int) -> Int {
-        min(max(100 - percentUsed, 0), 100)
-    }
-
-    /// Builds a row from a quota period. Returns nil when there is no usage data
-    /// at all; an expired or reset-less period still renders, just without the
-    /// trailing reset segment.
-    static func periodDisplay(title: String, usage: QuotaPeriod?) -> UsagePeriodDisplay? {
+    static func periodDisplay(title: String, usage: QuotaPeriod?, isStale: Bool = false) -> UsagePeriodDisplay? {
         guard let usage else { return nil }
-        let resetText = usage.formattedResetTime.map { "Resets in \($0)" }
+        let resetText = usage.formattedResetTime.map { "resets in \($0)" }
         return UsagePeriodDisplay(
             title: title,
             percentUsed: min(max(usage.usagePercentage, 0), 100),
-            resetText: resetText
+            resetText: resetText,
+            isStale: isStale
         )
     }
 
-    static func claudeHasData(usage: QuotaPeriod?, weeklyUsage: QuotaPeriod?, extraUsage: ExtraUsage?) -> Bool {
-        usage != nil || weeklyUsage != nil || extraUsageDisplay(extraUsage) != nil
+    static func claudeHasData(usage: QuotaPeriod?, weeklyUsage: QuotaPeriod?, sonnetUsage: QuotaPeriod?, extraUsage: ExtraUsage?) -> Bool {
+        usage != nil || weeklyUsage != nil || sonnetUsage != nil || extraUsageDisplay(extraUsage) != nil
     }
 
     static func codexHasData(usage: QuotaPeriod?, weeklyUsage: QuotaPeriod?) -> Bool {

--- a/notchi/notchi/Models/UsageQuota.swift
+++ b/notchi/notchi/Models/UsageQuota.swift
@@ -67,7 +67,9 @@ nonisolated struct QuotaPeriod: Codable, Equatable, Sendable {
         let hours = Int(interval) / 3600
         let minutes = (Int(interval) % 3600) / 60
 
-        if hours > 0 {
+        if hours >= 48 {
+            return "\(hours / 24)d \(hours % 24)h"
+        } else if hours > 0 {
             return "\(hours)h \(minutes)m"
         } else {
             return "\(minutes)m"

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import OSLog
 
 enum NotchConstants {
     static let expandedPanelSize = CGSize(width: 450, height: 450)
@@ -301,7 +302,6 @@ struct NotchContentView: View {
 
     private var usageRingPercentage: Int? {
         guard AppSettings.isUsageEnabled,
-              sessionStore.activeSessionCount > 0,
               let usage = usageService.currentUsage else { return nil }
         return usage.usagePercentage
     }
@@ -623,8 +623,21 @@ struct NotchContentView: View {
         }
     }
 
+    private static let ringDebugLogger = Logger(subsystem: "com.ruban.notchi", category: "ring-debug")
+    private static var lastRingDebugLine: String?
+
+    private func logRingState(side: NotchSide) {
+        guard side == .left else { return }
+        let hidden = usageRingPercentage == nil || isLaunchWaveActive
+        let line = "hidden=\(hidden) pct=\(String(describing: usageRingPercentage)) launchWave=\(isLaunchWaveActive) enabled=\(AppSettings.isUsageEnabled) sessions=\(sessionStore.activeSessionCount) claudeUsage=\(usageService.currentUsage != nil) stale=\(usageService.isUsageStale) connected=\(usageService.isConnected) fallback=\(usageService.isUsingHeadersFallback)"
+        guard line != Self.lastRingDebugLine else { return }
+        Self.lastRingDebugLine = line
+        Self.ringDebugLogger.error("RING-DEBUG \(line, privacy: .public)")
+    }
+
     @ViewBuilder
     private func ringSlot(side: NotchSide) -> some View {
+        let _ = logRingState(side: side)
         if let usageRingPercentage, !isLaunchWaveActive {
             UsageRingView(percentage: usageRingPercentage, isStale: usageService.isUsageStale)
                 .opacity(collapsedHeaderSpriteVisuals.opacity)

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -302,8 +302,7 @@ struct NotchContentView: View {
     private var usageRingPercentage: Int? {
         guard AppSettings.isUsageEnabled,
               sessionStore.activeSessionCount > 0,
-              let usage = usageService.currentUsage,
-              !usage.isExpired else { return nil }
+              let usage = usageService.currentUsage else { return nil }
         return usage.usagePercentage
     }
 
@@ -627,7 +626,7 @@ struct NotchContentView: View {
     @ViewBuilder
     private func ringSlot(side: NotchSide) -> some View {
         if let usageRingPercentage, !isLaunchWaveActive {
-            UsageRingView(percentage: usageRingPercentage)
+            UsageRingView(percentage: usageRingPercentage, isStale: usageService.isUsageStale)
                 .opacity(collapsedHeaderSpriteVisuals.opacity)
                 .animation(collapsedHeaderSpriteVisibilityAnimation, value: isExpanded)
                 .frame(width: sideWidth)

--- a/notchi/notchi/Services/ClaudeUsageService.swift
+++ b/notchi/notchi/Services/ClaudeUsageService.swift
@@ -702,11 +702,13 @@ final class ClaudeUsageService {
     private static let headersFallbackOAuthProbeInterval: TimeInterval = 600
     private static let headersFallbackRefreshInterval: TimeInterval = 60
     private static let resumeReconnectDelay: TimeInterval = 2
+    private static let selfHealRetryInterval: TimeInterval = 300
 
     private let dependencies: ClaudeUsageServiceDependencies
     private var resolvedUserAgent: String?
     private var pollTimer: (any ClaudeUsagePollTimer)?
     private var pendingResumeReconnectTimer: (any ClaudeUsagePollTimer)?
+    private var selfHealRetryTimer: (any ClaudeUsagePollTimer)?
     private let pollInterval: TimeInterval = 60
     private var pollScheduleGeneration: UInt64 = 0
     private var consecutiveRateLimits = 0
@@ -937,9 +939,45 @@ final class ClaudeUsageService {
         pollTimer = nil
         pollScheduleGeneration &+= 1
         clearPendingResumeReconnect()
+
+        if recoveryAction == .reconnect {
+            scheduleSelfHealRetry()
+        }
+    }
+
+    private func scheduleSelfHealRetry() {
+        guard AppSettings.isUsageEnabled else { return }
+        selfHealRetryTimer?.invalidate()
+        selfHealRetryTimer = dependencies.schedulePoll(Self.selfHealRetryInterval) { [weak self] in
+            Task { @MainActor [weak self] in
+                await self?.attemptSelfHeal()
+            }
+        }
+    }
+
+    private func attemptSelfHeal() async {
+        selfHealRetryTimer = nil
+        guard AppSettings.isUsageEnabled, pollTimer == nil, !isLoading else { return }
+
+        guard let resolution = resolveStoredAccessToken(
+            allowsCredentialRecovery: true,
+            prefersRecoveredCredentials: true
+        ) else {
+            scheduleSelfHealRetry()
+            return
+        }
+
+        cachedToken = resolution.token
+        await performFetch(
+            with: resolution.token,
+            consultCredentialMetadata: resolution.source == .recoveredFromCredentials,
+            cachedCredentials: resolution.credentials
+        )
     }
 
     private func schedulePollTimer(interval: TimeInterval? = nil, minimumInterval: TimeInterval? = nil) {
+        selfHealRetryTimer?.invalidate()
+        selfHealRetryTimer = nil
         pollTimer?.invalidate()
         let baseInterval = interval ?? pollInterval
         let jitter = dependencies.pollJitter()

--- a/notchi/notchi/Services/ClaudeUsageService.swift
+++ b/notchi/notchi/Services/ClaudeUsageService.swift
@@ -692,6 +692,7 @@ final class ClaudeUsageService {
     var statusMessage: String?
     var isConnected = false
     var isUsageStale = false
+    var isUsingHeadersFallback: Bool { isHeadersFallbackActive }
     var lastObservedAt: Date?
     var recoveryAction: ClaudeUsageRecoveryAction = .none
 
@@ -1366,8 +1367,6 @@ final class ClaudeUsageService {
             let usage = QuotaPeriod(utilization: (utilization * 100).rounded(), resetDate: resetDate)
             isConnected = true
             currentUsage = usage
-            currentWeeklyUsage = nil
-            currentSonnetUsage = nil
             lastObservedAt = dependencies.now()
             reconcileExtraUsageStateForHeaders(using: usage)
 

--- a/notchi/notchi/Services/ClaudeUsageService.swift
+++ b/notchi/notchi/Services/ClaudeUsageService.swift
@@ -1177,7 +1177,7 @@ final class ClaudeUsageService {
             guard let httpResponse = response as? HTTPURLResponse else {
                 presentRetryableIssue(
                     noUsageMessage: "Invalid response, retrying in \(Int(pollInterval))s",
-                    staleMessage: "Updating soon"
+                    staleMessage: "Stale data"
                 )
                 schedulePollTimer()
                 return .handled
@@ -1259,7 +1259,7 @@ final class ClaudeUsageService {
                 clearOAuthBackoffState()
                 presentRetryableIssue(
                     noUsageMessage: "HTTP \(httpResponse.statusCode), retrying in \(Int(pollInterval))s",
-                    staleMessage: "Updating soon"
+                    staleMessage: "Stale data"
                 )
                 schedulePollTimer()
                 logger.warning("API error: HTTP \(httpResponse.statusCode)")
@@ -1286,7 +1286,7 @@ final class ClaudeUsageService {
         } catch {
             presentRetryableIssue(
                 noUsageMessage: "Network error, retrying in \(Int(pollInterval))s",
-                staleMessage: "Updating soon"
+                staleMessage: "Stale data"
             )
             logger.error("OAuth fetch failed: \(error.localizedDescription)")
             schedulePollTimer()
@@ -1331,7 +1331,7 @@ final class ClaudeUsageService {
                 case .normalRetrying, .normalNoRetry:
                     presentRetryableIssue(
                         noUsageMessage: "Invalid response, retrying in \(Int(pollInterval))s",
-                        staleMessage: "Updating soon"
+                        staleMessage: "Stale data"
                     )
                     schedulePollTimer()
                     return .handled
@@ -1355,7 +1355,7 @@ final class ClaudeUsageService {
                 case .normalRetrying:
                     presentRetryableIssue(
                         noUsageMessage: "No rate limit headers, retrying in \(Int(pollInterval))s",
-                        staleMessage: "Updating soon"
+                        staleMessage: "Stale data"
                     )
                     schedulePollTimer()
                     return .noHeadersFallback
@@ -1400,7 +1400,7 @@ final class ClaudeUsageService {
             case .normalRetrying, .normalNoRetry:
                 presentRetryableIssue(
                     noUsageMessage: "Network error, retrying in \(Int(pollInterval))s",
-                    staleMessage: "Updating soon"
+                    staleMessage: "Stale data"
                 )
                 logger.error("Headers fetch failed: \(error.localizedDescription)")
                 schedulePollTimer()
@@ -1887,7 +1887,7 @@ final class ClaudeUsageService {
             clearOAuthBackoffState()
             presentRetryableIssue(
                 noUsageMessage: "No rate limit headers, retrying in \(Int(pollInterval))s",
-                staleMessage: "Updating soon"
+                staleMessage: "Stale data"
             )
             schedulePollTimer()
             return .handled

--- a/notchi/notchi/Services/CodexUsageAPI.swift
+++ b/notchi/notchi/Services/CodexUsageAPI.swift
@@ -27,8 +27,10 @@ nonisolated struct CodexAPIAuth: Equatable {
 }
 
 nonisolated struct CodexAPIUsage: Equatable {
-    let reviews: QuotaPeriod?
-    let creditsBalance: Double?
+    var session: QuotaPeriod? = nil
+    var weekly: QuotaPeriod? = nil
+    var reviews: QuotaPeriod? = nil
+    var creditsBalance: Double? = nil
 }
 
 nonisolated enum CodexUsageAPI {
@@ -70,12 +72,9 @@ nonisolated enum CodexUsageAPI {
     }
 
     static func usage(from response: CodexUsageAPIResponse, now: Date) -> CodexAPIUsage {
-        let reviews = response.codeReviewRateLimit?.primaryWindow.flatMap { window -> QuotaPeriod? in
-            guard let usedPercent = window.usedPercent else { return nil }
-            return QuotaPeriod(
-                utilization: usedPercent.rounded(),
-                resetDate: window.resetDate(now: now)
-            )
+        func period(_ window: CodexUsageAPIResponse.Window?) -> QuotaPeriod? {
+            guard let window, let usedPercent = window.usedPercent else { return nil }
+            return QuotaPeriod(utilization: usedPercent.rounded(), resetDate: window.resetDate(now: now))
         }
 
         let creditsBalance: Double?
@@ -87,7 +86,12 @@ nonisolated enum CodexUsageAPI {
             creditsBalance = nil
         }
 
-        return CodexAPIUsage(reviews: reviews, creditsBalance: creditsBalance)
+        return CodexAPIUsage(
+            session: period(response.rateLimit?.primaryWindow),
+            weekly: period(response.rateLimit?.secondaryWindow),
+            reviews: period(response.codeReviewRateLimit?.primaryWindow),
+            creditsBalance: creditsBalance
+        )
     }
 
     private static func base64URLDecode(_ value: String) -> Data? {
@@ -102,18 +106,22 @@ nonisolated enum CodexUsageAPI {
 }
 
 nonisolated struct CodexUsageAPIResponse: Decodable {
+    let rateLimit: RateLimit?
     let codeReviewRateLimit: RateLimit?
     let credits: Credits?
 
     enum CodingKeys: String, CodingKey {
+        case rateLimit = "rate_limit"
         case codeReviewRateLimit = "code_review_rate_limit"
         case credits
     }
 
     struct RateLimit: Decodable {
         let primaryWindow: Window?
+        let secondaryWindow: Window?
         enum CodingKeys: String, CodingKey {
             case primaryWindow = "primary_window"
+            case secondaryWindow = "secondary_window"
         }
     }
 

--- a/notchi/notchi/Services/CodexUsageService.swift
+++ b/notchi/notchi/Services/CodexUsageService.swift
@@ -57,6 +57,7 @@ final class CodexUsageService {
 
     private static let apiUsageRefreshInterval: TimeInterval = 60
     private var lastAPIUsageFetchAt: Date?
+    private var lastFetchedAPIUsage: CodexAPIUsage?
 
     private let dependencies: CodexUsageServiceDependencies
 
@@ -77,19 +78,35 @@ final class CodexUsageService {
         }.value
 
         apply(snapshot)
-        await refreshAPIUsage()
+        await fetchAndApplyAPIUsage(includeSessionWeekly: false)
     }
 
-    private func refreshAPIUsage() async {
-        let now = dependencies.now()
-        if let last = lastAPIUsageFetchAt, now.timeIntervalSince(last) < Self.apiUsageRefreshInterval {
-            return
-        }
-        lastAPIUsageFetchAt = now
+    func refreshFromAPI() async {
+        await fetchAndApplyAPIUsage(includeSessionWeekly: true)
+    }
 
-        if let apiUsage = await dependencies.fetchAPIUsage() {
-            currentReviewsUsage = apiUsage.reviews
-            currentExtraCreditsUSD = apiUsage.creditsBalance.map { $0 * CodexUsageAPI.creditUSDRate }
+    private func fetchAndApplyAPIUsage(includeSessionWeekly: Bool) async {
+        let now = dependencies.now()
+        let apiUsage: CodexAPIUsage?
+        if let last = lastAPIUsageFetchAt, now.timeIntervalSince(last) < Self.apiUsageRefreshInterval {
+            apiUsage = lastFetchedAPIUsage
+        } else {
+            lastAPIUsageFetchAt = now
+            let fetched = await dependencies.fetchAPIUsage()
+            if fetched != nil { lastFetchedAPIUsage = fetched }
+            apiUsage = fetched
+        }
+
+        guard let apiUsage else { return }
+        currentReviewsUsage = apiUsage.reviews
+        currentExtraCreditsUSD = apiUsage.creditsBalance.map { $0 * CodexUsageAPI.creditUSDRate }
+
+        if includeSessionWeekly, let session = apiUsage.session {
+            currentUsage = session
+            currentWeeklyUsage = apiUsage.weekly
+            lastObservedAt = now
+            isUsageStale = false
+            statusMessage = nil
         }
     }
 
@@ -99,6 +116,7 @@ final class CodexUsageService {
         currentReviewsUsage = nil
         currentExtraCreditsUSD = nil
         lastAPIUsageFetchAt = nil
+        lastFetchedAPIUsage = nil
         isUsageStale = false
         statusMessage = nil
         lastObservedAt = nil

--- a/notchi/notchi/Services/NotchiStateMachine.swift
+++ b/notchi/notchi/Services/NotchiStateMachine.swift
@@ -28,8 +28,8 @@ final class NotchiStateMachine {
         ClaudeUsageService.shared.handleClaudeResumeTrigger(trigger)
     }
     var isCodexProcessAlive: (Int) -> Bool
-    var clearCodexUsage: () -> Void = {
-        CodexUsageService.shared.clear()
+    var onCodexSessionsEnded: () -> Void = {
+        Task { await CodexUsageService.shared.refreshFromAPI() }
     }
 
     private static let syncDebounce: Duration = .milliseconds(100)
@@ -440,7 +440,7 @@ final class NotchiStateMachine {
             codexThreadMetadataRefreshTask = nil
             cancelCodexCompactionSignalRefresh()
             codexThreadMetadataImmediateRefreshKeys.removeAll()
-            clearCodexUsage()
+            onCodexSessionsEnded()
         }
     }
 
@@ -549,8 +549,8 @@ final class NotchiStateMachine {
             ClaudeUsageService.shared.handleClaudeResumeTrigger(trigger)
         }
         isCodexProcessAlive = Self.defaultCodexProcessAlive
-        clearCodexUsage = {
-            CodexUsageService.shared.clear()
+        onCodexSessionsEnded = {
+            Task { await CodexUsageService.shared.refreshFromAPI() }
         }
         codexProcessMonitorTask?.cancel()
         codexProcessMonitorTask = nil

--- a/notchi/notchi/Views/Components/UsageRingView.swift
+++ b/notchi/notchi/Views/Components/UsageRingView.swift
@@ -4,6 +4,7 @@ struct UsageRingView: View {
     let percentage: Int
     var diameter: CGFloat = 15
     var lineWidth: CGFloat = 3
+    var isStale: Bool = false
 
     @State private var drawProgress: CGFloat = 0
 
@@ -12,11 +13,13 @@ struct UsageRingView: View {
     }
 
     private var ringColor: Color {
+        let base: Color
         switch clampedPercentage {
-        case ..<50: return TerminalColors.green
-        case ..<80: return TerminalColors.amber
-        default: return TerminalColors.red
+        case ..<50: base = TerminalColors.green
+        case ..<80: base = TerminalColors.amber
+        default: base = TerminalColors.red
         }
+        return isStale ? base.opacity(0.5) : base
     }
 
     var body: some View {

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -212,6 +212,7 @@ struct ExpandedPanelView: View {
         UsageMetrics.claudeHasData(
             usage: usageService.currentUsage,
             weeklyUsage: usageService.currentWeeklyUsage,
+            sonnetUsage: usageService.currentSonnetUsage,
             extraUsage: usageService.currentExtraUsage
         )
             || UsageMetrics.codexHasData(

--- a/notchi/notchi/Views/UsageBarView.swift
+++ b/notchi/notchi/Views/UsageBarView.swift
@@ -150,7 +150,7 @@ struct UsageBarView: View {
                 if let error, usage == nil {
                     Text(error)
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(TerminalColors.red.opacity(0.7))
+                        .foregroundColor(TerminalColors.red.opacity(0.8))
                 } else if let usage, let resetTime = usage.formattedResetTime {
                     HStack(alignment: .center, spacing: 4) {
                         Text(resetLabelText(for: resetTime))
@@ -159,8 +159,8 @@ struct UsageBarView: View {
                             .lineLimit(1)
                         if let statusMessage {
                             Text("• \(statusMessage)")
-                                .font(.system(size: 9))
-                                .foregroundColor(TerminalColors.dimmedText)
+                                .font(.system(size: 10))
+                                .foregroundColor(Color.white.opacity(0.35))
                                 .lineLimit(1)
                                 .truncationMode(.tail)
                         }
@@ -210,8 +210,9 @@ struct UsageBarView: View {
         Button(action: performRecoveryAction) {
             Image(systemName: "arrow.clockwise")
                 .font(.system(size: 11, weight: .semibold))
-                .foregroundColor(TerminalColors.red.opacity(0.7))
+                .foregroundColor(isStale ? TerminalColors.secondaryText : TerminalColors.red.opacity(0.8))
                 .opacity(isPulsing ? 0.8 : 1.0)
+                .offset(y: -1)
                 .animation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true), value: isPulsing)
         }
         .buttonStyle(RecoveryButtonStyle())

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -22,6 +22,7 @@ struct UsageDetailView: View {
         UsageMetrics.claudeHasData(
             usage: claudeUsage.currentUsage,
             weeklyUsage: claudeUsage.currentWeeklyUsage,
+            sonnetUsage: claudeUsage.currentSonnetUsage,
             extraUsage: claudeUsage.currentExtraUsage
         )
     }
@@ -48,16 +49,19 @@ struct UsageDetailView: View {
     private var periods: [UsagePeriodDisplay] {
         switch resolvedProvider {
         case .claude:
+            let stale = claudeUsage.isUsageStale
+            let heldOver = stale || claudeUsage.isUsingHeadersFallback
             return [
-                UsageMetrics.periodDisplay(title: "Session", usage: claudeUsage.currentUsage),
-                UsageMetrics.periodDisplay(title: "Weekly", usage: claudeUsage.currentWeeklyUsage),
-                UsageMetrics.periodDisplay(title: "Sonnet", usage: claudeUsage.currentSonnetUsage),
+                UsageMetrics.periodDisplay(title: "Session", usage: claudeUsage.currentUsage, isStale: stale),
+                UsageMetrics.periodDisplay(title: "Weekly", usage: claudeUsage.currentWeeklyUsage, isStale: heldOver),
+                UsageMetrics.periodDisplay(title: "Sonnet", usage: claudeUsage.currentSonnetUsage, isStale: heldOver),
             ].compactMap { $0 }
         case .codex:
+            let stale = codexUsage.isUsageStale
             return [
-                UsageMetrics.periodDisplay(title: "Session", usage: codexUsage.currentUsage),
-                UsageMetrics.periodDisplay(title: "Weekly", usage: codexUsage.currentWeeklyUsage),
-                UsageMetrics.periodDisplay(title: "Reviews", usage: codexUsage.currentReviewsUsage),
+                UsageMetrics.periodDisplay(title: "Session", usage: codexUsage.currentUsage, isStale: stale),
+                UsageMetrics.periodDisplay(title: "Weekly", usage: codexUsage.currentWeeklyUsage, isStale: stale),
+                UsageMetrics.periodDisplay(title: "Reviews", usage: codexUsage.currentReviewsUsage, isStale: stale),
             ].compactMap { $0 }
         }
     }
@@ -152,22 +156,29 @@ struct UsagePeriodRowView: View {
     let display: UsagePeriodDisplay
 
     var body: some View {
-        let color = TerminalColors.usageColor(forPercentUsed: display.percentUsed)
+        let color = display.isStale
+            ? TerminalColors.dimmedText
+            : TerminalColors.usageColor(forPercentUsed: display.percentUsed)
         VStack(alignment: .leading, spacing: 7) {
-            Text(display.title)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(TerminalColors.primaryText)
-            UsageProgressBar(percentUsed: display.percentUsed, color: color)
-            HStack {
-                Text("\(UsageMetrics.percentLeft(fromPercentUsed: display.percentUsed))% left")
-                    .foregroundColor(TerminalColors.secondaryText)
-                Spacer()
-                if let resetText = display.resetText {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(display.title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(TerminalColors.primaryText)
+                if display.isStale {
+                    Text("stale data")
+                        .font(.system(size: 11))
+                        .foregroundColor(TerminalColors.secondaryText)
+                } else if let resetText = display.resetText {
                     Text(resetText)
+                        .font(.system(size: 11))
                         .foregroundColor(TerminalColors.secondaryText)
                 }
+                Spacer()
+                Text("\(display.percentUsed)%")
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundColor(color)
             }
-            .font(.system(size: 11))
+            UsageProgressBar(percentUsed: display.percentUsed, color: color)
         }
     }
 }


### PR DESCRIPTION
## Summary
Reliability and presentation fixes for the usage indicator (notch ring +
expanded usage detail), plus Codex idle persistence.

## Changes
- Keep the notch ring visible and self-heal stalled polling
- Refine stale/error states in the usage bar
- Persist Codex usage when idle via an API snapshot
- Redesign usage detail rows and harden ring visibility
- Show reset time in days + hours past the 48h mark

## Testing
- `./scripts/test.sh focused`