### PR TITLE
fix(usage): omit "0h" from reset time at exact day boundaries

### DIFF
--- a/notchi/Tests/UsageDisplayTests.swift
+++ b/notchi/Tests/UsageDisplayTests.swift
@@ -19,6 +19,11 @@ final class UsageDisplayTests: XCTestCase {
         XCTAssertEqual(usage.formattedResetTime, "2d 2h")
     }
 
+    func testFormattedResetTimeOmitsHoursAtExactDayBoundary() {
+        let usage = QuotaPeriod(utilization: 10, resetDate: Date(timeIntervalSinceNow: 72 * 3600 + 5 * 60))
+        XCTAssertEqual(usage.formattedResetTime, "3d")
+    }
+
     func testPeriodDisplayReturnsNilWhenNoUsage() {
         XCTAssertNil(UsageMetrics.periodDisplay(title: "Session", usage: nil))
     }

--- a/notchi/notchi/Models/UsageQuota.swift
+++ b/notchi/notchi/Models/UsageQuota.swift
@@ -68,7 +68,8 @@ nonisolated struct QuotaPeriod: Codable, Equatable, Sendable {
         let minutes = (Int(interval) % 3600) / 60
 
         if hours >= 48 {
-            return "\(hours / 24)d \(hours % 24)h"
+            let remainingHours = hours % 24
+            return remainingHours > 0 ? "\(hours / 24)d \(remainingHours)h" : "\(hours / 24)d"
         } else if hours > 0 {
             return "\(hours)h \(minutes)m"
         } else {


### PR DESCRIPTION
## Summary
Addresses a Greptile finding from #76: `QuotaPeriod.formattedResetTime` rendered "3d 0h" when a reset landed on a whole number of days. It now shows "3d", while keeping "Xd Yh" for non-zero remainders (and the existing "Xh Ym" / "Xm" formats under 48h).

## Testing
- New `testFormattedResetTimeOmitsHoursAtExactDayBoundary` (72h → "3d").
- `./scripts/test.sh` passes.