### PR TITLE
fix(usage): keep usage enabled across sleep/wake

### DIFF
--- a/notchi/Tests/ClaudeUsageServiceTests+TokenRecovery.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests+TokenRecovery.swift
@@ -184,6 +184,7 @@ extension ClaudeUsageServiceTests {
         await Task.yield()
 
         XCTAssertTrue(AppSettings.isUsageEnabled)
+        XCTAssertTrue(service.isConnected)
         XCTAssertEqual(service.currentUsage?.usagePercentage, 42)
     }
 

--- a/notchi/Tests/ClaudeUsageServiceTests+TokenRecovery.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests+TokenRecovery.swift
@@ -157,6 +157,36 @@ extension ClaudeUsageServiceTests {
         XCTAssertFalse(AppSettings.isUsageEnabled)
     }
 
+    func testSystemWakeKeepsUsageEnabledWhenKeychainBrieflyUnavailable() async throws {
+        let scheduler = PollSchedulerSpy()
+        var keychainAvailable = true
+        let dependencies = makeDependencies(
+            scheduler: scheduler,
+            resolveUserAgent: { "claude-code/2.1.77" },
+            getCachedOAuthToken: { _ in keychainAvailable ? "token" : nil },
+            getOAuthCredentials: { _ in nil },
+            fetchUsage: { _ in
+                (self.makeSuccessPayload(utilization: 42), self.makeResponse(statusCode: 200))
+            }
+        )
+
+        let service = ClaudeUsageService(dependencies: dependencies)
+        AppSettings.isUsageEnabled = true
+
+        service.startPolling()
+        await Task.yield()
+        await Task.yield()
+        XCTAssertEqual(service.currentUsage?.usagePercentage, 42)
+
+        keychainAvailable = false
+        service.startPolling(afterSystemWake: true)
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertTrue(AppSettings.isUsageEnabled)
+        XCTAssertEqual(service.currentUsage?.usagePercentage, 42)
+    }
+
     func testStartPollingDisablesUsageWhenNoCachedTokenExists() async throws {
         let scheduler = PollSchedulerSpy()
         var getCachedTokenCalls: [Bool] = []
@@ -206,14 +236,14 @@ extension ClaudeUsageServiceTests {
         await Task.yield()
         await Task.yield()
 
-        XCTAssertFalse(AppSettings.isUsageEnabled)
+        XCTAssertTrue(AppSettings.isUsageEnabled)
         XCTAssertFalse(service.isConnected)
         XCTAssertNil(service.error)
         XCTAssertEqual(service.statusMessage, "Claude authentication needs attention.")
         XCTAssertTrue(service.isUsageStale)
         XCTAssertEqual(service.recoveryAction, .reconnect)
         XCTAssertEqual(service.currentUsage?.usagePercentage, 42)
-        XCTAssertTrue(scheduler.intervals.isEmpty)
+        XCTAssertTrue(scheduler.intervals.contains(300))
     }
 
     func testStartPollingRecoversFreshCredentialsWhenNoCachedTokenExists() async throws {

--- a/notchi/notchi/Services/ClaudeUsageService.swift
+++ b/notchi/notchi/Services/ClaudeUsageService.swift
@@ -787,21 +787,24 @@ final class ClaudeUsageService {
         stopPolling()
 
         Task {
-            if afterSystemWake,
-               isHeadersFallbackActive,
-               let accessToken = cachedToken {
-                resetHeadersFallbackProbeWindowFromWake()
-                await refreshActiveHeadersFallback(with: accessToken)
+            if afterSystemWake, let accessToken = cachedToken {
+                if isHeadersFallbackActive {
+                    resetHeadersFallbackProbeWindowFromWake()
+                    await refreshActiveHeadersFallback(with: accessToken)
+                } else {
+                    await performFetch(with: accessToken, consultCredentialMetadata: false)
+                }
                 return
             }
 
             guard let resolution = resolveStoredAccessToken(allowsCredentialRecovery: true) else {
                 isConnected = false
-                AppSettings.isUsageEnabled = false
                 clearOAuthBackoffState()
                 if currentUsage != nil {
                     presentReconnectRequired(message: "Claude authentication needs attention.")
+                    scheduleSelfHealRetry()
                 } else {
+                    AppSettings.isUsageEnabled = false
                     clearTransientState()
                 }
                 return


### PR DESCRIPTION
## Summary
Fixes the notch usage ring vanishing after sleep/wake.

On wake, `startPolling(afterSystemWake:)` re-read the OAuth token from the keychain, which can be briefly unavailable right after wake. The nil resolution set `isUsageEnabled = false`, hiding the ring until the next trigger — even though cached usage and the network were fine moments later. Confirmed from device logs (`enabled=false` with `claudeUsage=true connected=true`, alongside a transient `-1009` offline error on the OAuth fetch).

## Changes
- On wake, reuse the in-memory `cachedToken` (it survives sleep) instead of re-resolving from the keychain.
- On any transient token-resolution failure, only disable usage when there's no cached usage to show; otherwise keep it enabled, present the reconnect affordance, and schedule a self-heal retry.

## Testing
- New regression test `testSystemWakeKeepsUsageEnabledWhenKeychainBrieflyUnavailable`.
- Updated `testStartPollingWithoutTokenKeepsReconnectAffordanceWhenUsageIsVisible` to assert usage stays enabled + a self-heal retry is scheduled.
- `./scripts/test.sh` passes.