### PR TITLE
feat(cost): Claude cost & token history dashboard

### DIFF
--- a/notchi/Tests/ClaudeCostScannerTests.swift
+++ b/notchi/Tests/ClaudeCostScannerTests.swift
@@ -82,4 +82,20 @@ final class ClaudeCostScannerTests: XCTestCase {
                        "truncated file must trigger a clean full rescan, not double-count")
         XCTAssertEqual(second.buckets["2026-06-24"]?["claude-opus-4"]?.requestCount, 1)
     }
+
+    func testMessagesWithoutIdsAreNotDeduped() throws {
+        let noId = """
+        {"type":"assistant","timestamp":"2026-06-24T12:00:00.000Z",\
+        "message":{"model":"claude-opus-4-20250101",\
+        "usage":{"input_tokens":40,"output_tokens":0,\
+        "cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+        """
+        let url = try writeFile([noId, noId])
+        let s = scanner(root: url.deletingLastPathComponent().deletingLastPathComponent())
+        let out = s.scan(cache: CostUsageCache(version: CostUsageCache.currentVersion, files: [:], buckets: [:]),
+                         now: ISO8601DateFormatter().date(from: "2026-06-24T12:00:00Z")!)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["claude-opus-4"]?.input, 80,
+                       "messages without ids cannot be deduped and must each count")
+        XCTAssertEqual(out.buckets["2026-06-24"]?["claude-opus-4"]?.requestCount, 2)
+    }
 }

--- a/notchi/Tests/ClaudeCostScannerTests.swift
+++ b/notchi/Tests/ClaudeCostScannerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class ClaudeCostScannerTests: XCTestCase {
     private struct FlatPrice: ClaudePricingProviding {
-        func pricing(model: String, on date: Date) -> ClaudeModelPricing? {
+        nonisolated func pricing(model: String, on date: Date) -> ClaudeModelPricing? {
             ClaudeModelPricing(inputPerToken: 1e-6, outputPerToken: 1e-6,
                 cacheCreationPerToken: 0, cacheReadPerToken: 0, cacheCreation1hPerToken: nil,
                 thresholdTokens: nil, inputPerTokenAboveThreshold: nil,
@@ -40,12 +40,12 @@ final class ClaudeCostScannerTests: XCTestCase {
     func testDuplicateMessageRequestPairCountedOnce() throws {
         let url = try writeFile([
             line(msgId: "m1", reqId: "r1", input: 100, output: 0),
-            line(msgId: "m1", reqId: "r1", input: 100, output: 0),  // exact dup
+            line(msgId: "m1", reqId: "r1", input: 100, output: 0),
         ])
         let s = scanner(root: url.deletingLastPathComponent().deletingLastPathComponent())
         let out = s.scan(cache: CostUsageCache(version: CostUsageCache.currentVersion, files: [:], buckets: [:]),
                          now: ISO8601DateFormatter().date(from: "2026-06-24T12:00:00Z")!)
-        XCTAssertEqual(out.buckets["2026-06-24"]?["claude-opus-4"]?.input, 100)  // not 200
+        XCTAssertEqual(out.buckets["2026-06-24"]?["claude-opus-4"]?.input, 100)
         XCTAssertEqual(out.buckets["2026-06-24"]?["claude-opus-4"]?.requestCount, 1)
     }
 
@@ -57,12 +57,11 @@ final class ClaudeCostScannerTests: XCTestCase {
         let first = s.scan(cache: CostUsageCache(version: CostUsageCache.currentVersion, files: [:], buckets: [:]), now: now)
         XCTAssertEqual(first.buckets["2026-06-24"]?["claude-opus-4"]?.input, 100)
 
-        // append a new line, rescan with the prior cache
         let fh = try FileHandle(forWritingTo: url); fh.seekToEndOfFile()
         fh.write((line(msgId: "m2", reqId: "r2", input: 50, output: 0) + "\n").data(using: .utf8)!)
         try fh.close()
         let second = s.scan(cache: first, now: now)
-        XCTAssertEqual(second.buckets["2026-06-24"]?["claude-opus-4"]?.input, 150)  // 100 + 50, no re-count
+        XCTAssertEqual(second.buckets["2026-06-24"]?["claude-opus-4"]?.input, 150)
         XCTAssertEqual(second.buckets["2026-06-24"]?["claude-opus-4"]?.requestCount, 2)
     }
 }

--- a/notchi/Tests/ClaudeCostScannerTests.swift
+++ b/notchi/Tests/ClaudeCostScannerTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import notchi
+
+final class ClaudeCostScannerTests: XCTestCase {
+    private struct FlatPrice: ClaudePricingProviding {
+        func pricing(model: String, on date: Date) -> ClaudeModelPricing? {
+            ClaudeModelPricing(inputPerToken: 1e-6, outputPerToken: 1e-6,
+                cacheCreationPerToken: 0, cacheReadPerToken: 0, cacheCreation1hPerToken: nil,
+                thresholdTokens: nil, inputPerTokenAboveThreshold: nil,
+                outputPerTokenAboveThreshold: nil, cacheCreationPerTokenAboveThreshold: nil,
+                cacheReadPerTokenAboveThreshold: nil)
+        }
+    }
+
+    private func line(msgId: String, reqId: String, input: Int, output: Int,
+                      day: String = "2026-06-24") -> String {
+        """
+        {"type":"assistant","timestamp":"\(day)T12:00:00.000Z","requestId":"\(reqId)",\
+        "message":{"id":"\(msgId)","model":"claude-opus-4-20250101",\
+        "usage":{"input_tokens":\(input),"output_tokens":\(output),\
+        "cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+        """
+    }
+
+    private func writeFile(_ lines: [String]) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("p").appendingPathComponent("c.jsonl")
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try (lines.joined(separator: "\n") + "\n").data(using: .utf8)!.write(to: url)
+        return url
+    }
+
+    private func scanner(root: URL) -> ClaudeCostScanner {
+        var cal = Calendar(identifier: .gregorian); cal.timeZone = TimeZone(identifier: "UTC")!
+        return ClaudeCostScanner(projectsRoots: [root], pricing: FlatPrice(),
+                                 windowDays: 30, calendar: cal)
+    }
+
+    func testDuplicateMessageRequestPairCountedOnce() throws {
+        let url = try writeFile([
+            line(msgId: "m1", reqId: "r1", input: 100, output: 0),
+            line(msgId: "m1", reqId: "r1", input: 100, output: 0),  // exact dup
+        ])
+        let s = scanner(root: url.deletingLastPathComponent().deletingLastPathComponent())
+        let out = s.scan(cache: CostUsageCache(version: CostUsageCache.currentVersion, files: [:], buckets: [:]),
+                         now: ISO8601DateFormatter().date(from: "2026-06-24T12:00:00Z")!)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["claude-opus-4"]?.input, 100)  // not 200
+        XCTAssertEqual(out.buckets["2026-06-24"]?["claude-opus-4"]?.requestCount, 1)
+    }
+
+    func testAppendedLinesAddWithoutRecountingViaOffset() throws {
+        let url = try writeFile([line(msgId: "m1", reqId: "r1", input: 100, output: 0)])
+        let root = url.deletingLastPathComponent().deletingLastPathComponent()
+        let s = scanner(root: root)
+        let now = ISO8601DateFormatter().date(from: "2026-06-24T12:00:00Z")!
+        let first = s.scan(cache: CostUsageCache(version: CostUsageCache.currentVersion, files: [:], buckets: [:]), now: now)
+        XCTAssertEqual(first.buckets["2026-06-24"]?["claude-opus-4"]?.input, 100)
+
+        // append a new line, rescan with the prior cache
+        let fh = try FileHandle(forWritingTo: url); fh.seekToEndOfFile()
+        fh.write((line(msgId: "m2", reqId: "r2", input: 50, output: 0) + "\n").data(using: .utf8)!)
+        try fh.close()
+        let second = s.scan(cache: first, now: now)
+        XCTAssertEqual(second.buckets["2026-06-24"]?["claude-opus-4"]?.input, 150)  // 100 + 50, no re-count
+        XCTAssertEqual(second.buckets["2026-06-24"]?["claude-opus-4"]?.requestCount, 2)
+    }
+}

--- a/notchi/Tests/ClaudeCostScannerTests.swift
+++ b/notchi/Tests/ClaudeCostScannerTests.swift
@@ -64,4 +64,22 @@ final class ClaudeCostScannerTests: XCTestCase {
         XCTAssertEqual(second.buckets["2026-06-24"]?["claude-opus-4"]?.input, 150)
         XCTAssertEqual(second.buckets["2026-06-24"]?["claude-opus-4"]?.requestCount, 2)
     }
+
+    func testTruncatedFileFullyRescansWithoutDoubleCounting() throws {
+        let url = try writeFile([
+            line(msgId: "m1", reqId: "r1", input: 100, output: 0),
+            line(msgId: "m2", reqId: "r2", input: 50, output: 0),
+        ])
+        let root = url.deletingLastPathComponent().deletingLastPathComponent()
+        let s = scanner(root: root)
+        let now = ISO8601DateFormatter().date(from: "2026-06-24T12:00:00Z")!
+        let first = s.scan(cache: CostUsageCache(version: CostUsageCache.currentVersion, files: [:], buckets: [:]), now: now)
+        XCTAssertEqual(first.buckets["2026-06-24"]?["claude-opus-4"]?.input, 150)
+
+        try (line(msgId: "m1", reqId: "r1", input: 100, output: 0) + "\n").data(using: .utf8)!.write(to: url)
+        let second = s.scan(cache: first, now: now)
+        XCTAssertEqual(second.buckets["2026-06-24"]?["claude-opus-4"]?.input, 100,
+                       "truncated file must trigger a clean full rescan, not double-count")
+        XCTAssertEqual(second.buckets["2026-06-24"]?["claude-opus-4"]?.requestCount, 1)
+    }
 }

--- a/notchi/Tests/ClaudeModelPricingTests.swift
+++ b/notchi/Tests/ClaudeModelPricingTests.swift
@@ -52,7 +52,7 @@ final class ClaudeModelPricingTests: XCTestCase {
 
     func testCatalogFallsBackToEmbeddedSnapshotForKnownModel() {
         let catalog = PricingCatalog(fallbackBundle: .main)
-        let p = catalog.pricing(model: "claude-sonnet-4", on: Date())
+        let p = catalog.pricing(model: "claude-sonnet-4-6", on: Date())
         XCTAssertNotNil(p, "embedded fallback must price the current Sonnet model")
         XCTAssertGreaterThan(p!.outputPerToken, p!.inputPerToken)
     }
@@ -60,6 +60,78 @@ final class ClaudeModelPricingTests: XCTestCase {
     func testCatalogReturnsNilForUnknownModel() {
         let catalog = PricingCatalog(fallbackBundle: .main)
         XCTAssertNil(catalog.pricing(model: "totally-made-up-model", on: Date()))
+    }
+
+    // MARK: - T1: signature() is deterministic
+
+    func testSignatureIsDeterministicAcrossCallsAndNotSwiftHasher() {
+        let catalog = PricingCatalog(fallbackBundle: .main)
+        let sig1 = catalog.signature()
+        let sig2 = catalog.signature()
+        XCTAssertEqual(sig1, sig2)
+        XCTAssertFalse(sig1.isEmpty)
+    }
+
+    // MARK: - T2: signature() changes when a price changes
+
+    func testSignatureChangesWhenPriceChanges() {
+        let p1 = ClaudeModelPricing(inputPerToken: 0.000003, outputPerToken: 0.000015,
+            cacheCreationPerToken: 0.00000375, cacheReadPerToken: 0.0000003,
+            cacheCreation1hPerToken: nil, thresholdTokens: nil,
+            inputPerTokenAboveThreshold: nil, outputPerTokenAboveThreshold: nil,
+            cacheCreationPerTokenAboveThreshold: nil, cacheReadPerTokenAboveThreshold: nil)
+        let p2 = ClaudeModelPricing(inputPerToken: 0.000006, outputPerToken: 0.000015,
+            cacheCreationPerToken: 0.00000375, cacheReadPerToken: 0.0000003,
+            cacheCreation1hPerToken: nil, thresholdTokens: nil,
+            inputPerTokenAboveThreshold: nil, outputPerTokenAboveThreshold: nil,
+            cacheCreationPerTokenAboveThreshold: nil, cacheReadPerTokenAboveThreshold: nil)
+        let cat1 = PricingCatalog(table: ["claude-sonnet-4": p1])
+        let cat2 = PricingCatalog(table: ["claude-sonnet-4": p2])
+        XCTAssertNotEqual(cat1.signature(), cat2.signature())
+    }
+
+    // MARK: - T3: disk snapshot round-trips and overlays fallback
+
+    func testSnapshotPersistsAndOverlaysFallback() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let snapURL = dir.appendingPathComponent("models-dev.json")
+
+        let snapJSON = """
+        {"version":1,"models":{"claude-test-9000":{"inputPerToken":0.001,"outputPerToken":0.002,
+        "cacheCreationPerToken":0.0015,"cacheReadPerToken":0.0001,
+        "thresholdTokens":null,"inputPerTokenAboveThreshold":null,
+        "outputPerTokenAboveThreshold":null,"cacheCreationPerTokenAboveThreshold":null,
+        "cacheReadPerTokenAboveThreshold":null}}}
+        """
+        try snapJSON.data(using: .utf8)!.write(to: snapURL)
+
+        let catalog = PricingCatalog(fallbackBundle: .main, snapshotURL: snapURL)
+        let p = catalog.pricing(model: "claude-test-9000", on: Date())
+        XCTAssertNotNil(p)
+        XCTAssertEqual(p!.inputPerToken, 0.001, accuracy: 1e-12)
+        XCTAssertNotNil(catalog.pricing(model: "claude-sonnet-4-6", on: Date()))
+    }
+
+    // MARK: - T4: cache with stale pricingSignature is reset
+
+    func testCacheWithStalePricingSignatureIsReset() {
+        let staleSig = "old-sig"
+        let currentSig = "new-sig"
+        let cache = CostUsageCache(version: CostUsageCache.currentVersion,
+                                    files: ["f": .init(size: 100, mtime: 1, offset: 100)],
+                                    buckets: ["2026-06-24": ["m": .init(input: 10, costNanos: 50)]],
+                                    pricingSignature: staleSig)
+
+        let reset = cache.reconciled(withPricingSignature: currentSig)
+        XCTAssertTrue(reset.files.isEmpty, "stale signature must discard file state")
+        XCTAssertTrue(reset.buckets.isEmpty, "stale signature must discard cached costs")
+        XCTAssertEqual(reset.pricingSignature, currentSig)
+
+        let kept = cache.reconciled(withPricingSignature: staleSig)
+        XCTAssertEqual(kept.files.count, 1, "matching signature must keep the cache")
+        XCTAssertEqual(kept.buckets.count, 1)
+        XCTAssertEqual(kept.pricingSignature, staleSig)
     }
 
     func testPlausibilityGuardAcceptsBothAnchorsAndRejectsPartial() {

--- a/notchi/Tests/ClaudeModelPricingTests.swift
+++ b/notchi/Tests/ClaudeModelPricingTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import notchi
+
+final class ClaudeModelPricingTests: XCTestCase {
+    // Named constants = independent expectations (per-MILLION → per-token)
+    private let sonnetInput = 3.0 / 1_000_000
+    private let sonnetOutput = 15.0 / 1_000_000
+    private let sonnetCacheRead = 0.30 / 1_000_000
+    private let sonnetCacheWrite = 3.75 / 1_000_000
+
+    private func pricing() -> ClaudeModelPricing {
+        ClaudeModelPricing(
+            inputPerToken: sonnetInput, outputPerToken: sonnetOutput,
+            cacheCreationPerToken: sonnetCacheWrite, cacheReadPerToken: sonnetCacheRead,
+            cacheCreation1hPerToken: nil,
+            thresholdTokens: 200_000,
+            inputPerTokenAboveThreshold: 6.0 / 1_000_000,
+            outputPerTokenAboveThreshold: 22.5 / 1_000_000,
+            cacheCreationPerTokenAboveThreshold: 7.5 / 1_000_000,
+            cacheReadPerTokenAboveThreshold: 0.60 / 1_000_000)
+    }
+
+    func testNormalizesProviderPrefixedModelNames() {
+        XCTAssertEqual(CostPricing.normalizeClaudeModel("claude-sonnet-4-20250514"), "claude-sonnet-4")
+        XCTAssertEqual(CostPricing.normalizeClaudeModel("anthropic/claude-opus-4-1"), "claude-opus-4-1")
+    }
+
+    func testCostBelowThresholdSumsEachTokenClass() {
+        let cost = CostPricing.claudeCostUSD(
+            model: "claude-sonnet-4", input: 1_000, cacheRead: 2_000,
+            cacheCreation: 500, cacheCreation1h: 0, output: 800, pricing: pricing())
+        let inputCost: Double = 1_000 * sonnetInput
+        let readCost: Double = 2_000 * sonnetCacheRead
+        let writeCost: Double = 500 * sonnetCacheWrite
+        let outputCost: Double = 800 * sonnetOutput
+        let expected: Double = inputCost + readCost + writeCost + outputCost
+        XCTAssertEqual(cost!, expected, accuracy: 1e-12)
+    }
+
+    func testWholeRequestRepricedWhenContextExceedsThreshold() {
+        // input context = input + cacheRead + cacheCreation = 250_000 > 200_000 → above-threshold rates apply to ALL classes
+        let cost = CostPricing.claudeCostUSD(
+            model: "claude-sonnet-4", input: 50_000, cacheRead: 150_000,
+            cacheCreation: 50_000, cacheCreation1h: 0, output: 1_000, pricing: pricing())
+        let inputCost: Double = 50_000 * (6.0 / 1_000_000)
+        let readCost: Double = 150_000 * (0.60 / 1_000_000)
+        let writeCost: Double = 50_000 * (7.5 / 1_000_000)
+        let outputCost: Double = 1_000 * (22.5 / 1_000_000)
+        let expected: Double = inputCost + readCost + writeCost + outputCost
+        XCTAssertEqual(cost!, expected, accuracy: 1e-9)
+    }
+}

--- a/notchi/Tests/ClaudeModelPricingTests.swift
+++ b/notchi/Tests/ClaudeModelPricingTests.swift
@@ -61,4 +61,22 @@ final class ClaudeModelPricingTests: XCTestCase {
         let catalog = PricingCatalog(fallbackBundle: .main)
         XCTAssertNil(catalog.pricing(model: "totally-made-up-model", on: Date()))
     }
+
+    func testPlausibilityGuardAcceptsBothAnchorsAndRejectsPartial() {
+        let anyPricing = ClaudeModelPricing(
+            inputPerToken: sonnetInput, outputPerToken: sonnetOutput,
+            cacheCreationPerToken: sonnetCacheWrite, cacheReadPerToken: sonnetCacheRead,
+            cacheCreation1hPerToken: nil, thresholdTokens: nil,
+            inputPerTokenAboveThreshold: nil, outputPerTokenAboveThreshold: nil,
+            cacheCreationPerTokenAboveThreshold: nil, cacheReadPerTokenAboveThreshold: nil)
+
+        // Versioned anchor keys must still pass (prefix match, not exact key).
+        let bothAnchors = ["claude-sonnet-4-5": anyPricing, "claude-opus-4-1": anyPricing]
+        XCTAssertTrue(PricingCatalog.isPlausibleRefresh(bothAnchors))
+
+        let sonnetOnly = ["claude-sonnet-4": anyPricing]
+        XCTAssertFalse(PricingCatalog.isPlausibleRefresh(sonnetOnly))
+
+        XCTAssertFalse(PricingCatalog.isPlausibleRefresh([:]))
+    }
 }

--- a/notchi/Tests/ClaudeModelPricingTests.swift
+++ b/notchi/Tests/ClaudeModelPricingTests.swift
@@ -90,6 +90,22 @@ final class ClaudeModelPricingTests: XCTestCase {
         XCTAssertNotEqual(cat1.signature(), cat2.signature())
     }
 
+    func testSignatureToleratesSubUlpFloatDifferences() {
+        func mk(_ v: Double) -> ClaudeModelPricing {
+            ClaudeModelPricing(inputPerToken: v, outputPerToken: 0.000025,
+                cacheCreationPerToken: 0.00000625, cacheReadPerToken: 0.0000005,
+                cacheCreation1hPerToken: nil, thresholdTokens: nil,
+                inputPerTokenAboveThreshold: nil, outputPerTokenAboveThreshold: nil,
+                cacheCreationPerTokenAboveThreshold: nil, cacheReadPerTokenAboveThreshold: nil)
+        }
+        let base = 5e-6
+        let nudged = base.nextUp.nextUp
+        XCTAssertNotEqual(base, nudged)
+        let a = PricingCatalog(table: ["claude-opus-4-8": mk(base)]).signature()
+        let b = PricingCatalog(table: ["claude-opus-4-8": mk(nudged)]).signature()
+        XCTAssertEqual(a, b, "sub-12-sig-fig float differences must not change the signature")
+    }
+
     // MARK: - T3: disk snapshot round-trips and overlays fallback
 
     func testSnapshotPersistsAndOverlaysFallback() throws {

--- a/notchi/Tests/ClaudeModelPricingTests.swift
+++ b/notchi/Tests/ClaudeModelPricingTests.swift
@@ -49,4 +49,16 @@ final class ClaudeModelPricingTests: XCTestCase {
         let expected: Double = inputCost + readCost + writeCost + outputCost
         XCTAssertEqual(cost!, expected, accuracy: 1e-9)
     }
+
+    func testCatalogFallsBackToEmbeddedSnapshotForKnownModel() {
+        let catalog = PricingCatalog(fallbackBundle: .main)
+        let p = catalog.pricing(model: "claude-sonnet-4", on: Date())
+        XCTAssertNotNil(p, "embedded fallback must price the current Sonnet model")
+        XCTAssertGreaterThan(p!.outputPerToken, p!.inputPerToken)
+    }
+
+    func testCatalogReturnsNilForUnknownModel() {
+        let catalog = PricingCatalog(fallbackBundle: .main)
+        XCTAssertNil(catalog.pricing(model: "totally-made-up-model", on: Date()))
+    }
 }

--- a/notchi/Tests/CostUsageCacheTests.swift
+++ b/notchi/Tests/CostUsageCacheTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import notchi
+
+final class CostUsageCacheTests: XCTestCase {
+    func testLoadDiscardsCacheWithStaleVersion() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("cache.json")
+        var stale = CostUsageCache(version: CostUsageCache.currentVersion - 1, files: [:], buckets: [:])
+        stale.buckets["2026-06-24"] = ["claude-opus-4": ModelTokenTotals(input: 1)]
+        try JSONEncoder().encode(stale).write(to: url)
+
+        let loaded = CostUsageCacheStore.load(url: url)
+        XCTAssertEqual(loaded.version, CostUsageCache.currentVersion)
+        XCTAssertTrue(loaded.buckets.isEmpty, "stale-version cache must be discarded")
+    }
+
+    func testSaveThenLoadRoundTrips() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("cache.json")
+        var cache = CostUsageCache(version: CostUsageCache.currentVersion, files: [:], buckets: [:])
+        cache.buckets["2026-06-24"] = ["claude-opus-4": ModelTokenTotals(input: 5, output: 7, costNanos: 12)]
+        CostUsageCacheStore.save(cache, to: url)
+        let loaded = CostUsageCacheStore.load(url: url)
+        XCTAssertEqual(loaded.buckets["2026-06-24"]?["claude-opus-4"]?.input, 5)
+    }
+}

--- a/notchi/Tests/DailyCostReportTests.swift
+++ b/notchi/Tests/DailyCostReportTests.swift
@@ -38,8 +38,7 @@ final class DailyCostReportTests: XCTestCase {
         cal.timeZone = TimeZone(identifier: "UTC")!
         let report = DailyCostReport.make(
             provider: .claude, buckets: buckets,
-            window: DateInterval(start: day("2026-06-20"), end: day("2026-06-24")),
-            today: day("2026-06-24"), calendar: cal)
+            windowStart: day("2026-06-20"), today: day("2026-06-24"), calendar: cal)
 
         // window 06-20..06-24 → gap-filled ascending indices: 0=20, 1=21, 2=22, 3=23, 4=24
         XCTAssertEqual(report.entries.count, 5)

--- a/notchi/Tests/DailyCostReportTests.swift
+++ b/notchi/Tests/DailyCostReportTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import notchi
+
+final class DailyCostReportTests: XCTestCase {
+    private func day(_ s: String) -> Date {
+        let f = DateFormatter(); f.calendar = Calendar(identifier: .gregorian)
+        f.timeZone = TimeZone(identifier: "UTC"); f.dateFormat = "yyyy-MM-dd"
+        return f.date(from: s)!
+    }
+
+    func testReportDerivesHeadlineStatsAndGapFills() {
+        var buckets: DayModelBuckets = [:]
+        buckets["2026-06-22"] = ["claude-sonnet-4": ModelTokenTotals(
+            input: 100, output: 50, costNanos: 2_000_000_000, requestCount: 1, pricedCount: 1)]
+        buckets["2026-06-24"] = [
+            "claude-opus-4": ModelTokenTotals(
+                input: 300, output: 100, costNanos: 9_000_000_000, requestCount: 2, pricedCount: 2),
+            "claude-sonnet-4": ModelTokenTotals(
+                input: 200, output: 20, costNanos: 1_000_000_000, requestCount: 1, pricedCount: 1)]
+
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let report = DailyCostReport.make(
+            provider: .claude, buckets: buckets,
+            window: DateInterval(start: day("2026-06-20"), end: day("2026-06-24")),
+            today: day("2026-06-24"), calendar: cal)
+
+        // window 06-20..06-24 → gap-filled ascending indices: 0=20, 1=21, 2=22, 3=23, 4=24
+        XCTAssertEqual(report.entries.count, 5)
+        XCTAssertEqual(report.entries[1].costUSD, 0, accuracy: 1e-9)   // 21st: no activity
+        XCTAssertEqual(report.entries[2].costUSD, 2.0, accuracy: 1e-9) // 22nd: $2
+        XCTAssertEqual(report.windowCostUSD, 12.0, accuracy: 1e-9)     // 2 + 9 + 1
+        XCTAssertEqual(report.windowTokens, 100 + 50 + 300 + 100 + 200 + 20)
+        XCTAssertEqual(report.todayCostUSD, 10.0, accuracy: 1e-9)      // 24th: 9 + 1
+        XCTAssertEqual(report.latestTokens, 300 + 100 + 200 + 20)      // most recent active day = 24th
+        XCTAssertEqual(report.topModel, "claude-opus-4")              // highest cost across window
+    }
+}

--- a/notchi/Tests/DailyCostReportTests.swift
+++ b/notchi/Tests/DailyCostReportTests.swift
@@ -1,6 +1,22 @@
 import XCTest
 @testable import notchi
 
+final class CostHistoryStoreTests: XCTestCase {
+    @MainActor
+    func testStorePublishesReportFromInjectedScan() async {
+        var buckets: DayModelBuckets = [:]
+        buckets[DailyCostReport.dayKey(Date(), calendar: .current)] =
+            ["claude-opus-4": ModelTokenTotals(input: 10, output: 5, costNanos: 3_000_000_000,
+                                               requestCount: 1, pricedCount: 1)]
+        let store = CostHistoryStore(windowDays: 30, calendar: .current,
+            scanProvider: { _ in buckets })
+        await store.refresh()
+        XCTAssertEqual(store.report?.todayCostUSD ?? 0, 3.0, accuracy: 1e-9)
+        XCTAssertEqual(store.report?.topModel, "claude-opus-4")
+        XCTAssertFalse(store.isScanning)
+    }
+}
+
 final class DailyCostReportTests: XCTestCase {
     private func day(_ s: String) -> Date {
         let f = DateFormatter(); f.calendar = Calendar(identifier: .gregorian)

--- a/notchi/Tests/UsageDisplayTests.swift
+++ b/notchi/Tests/UsageDisplayTests.swift
@@ -110,4 +110,15 @@ final class UsageDisplayTests: XCTestCase {
         XCTAssertEqual(ExtraUsageRowView.currency(20), "$20")
         XCTAssertEqual(ExtraUsageRowView.currency(4.2), "$4.20")
     }
+
+    func testTokenFormatterUsesCompactSuffixes() {
+        XCTAssertEqual(CostStatFormatter.tokens(4_300_000_000), "4.3B")
+        XCTAssertEqual(CostStatFormatter.tokens(221_000_000), "221M")
+        XCTAssertEqual(CostStatFormatter.tokens(950), "950")
+    }
+
+    func testUsdFormatterTwoDecimalsWithThousands() {
+        XCTAssertEqual(CostStatFormatter.usd(3638.66), "$3,638.66")
+        XCTAssertEqual(CostStatFormatter.usd(174.41), "$174.41")
+    }
 }

--- a/notchi/notchi/AppDelegate.swift
+++ b/notchi/notchi/AppDelegate.swift
@@ -63,6 +63,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
             }
             await ClaudeUsageService.shared.startPolling()
             await CodexUsageService.shared.refreshFromAPI()
+            await CostHistoryStore.shared.start()
         }
     }
 

--- a/notchi/notchi/Models/CostUsageModels.swift
+++ b/notchi/notchi/Models/CostUsageModels.swift
@@ -57,10 +57,10 @@ nonisolated struct DailyCostReport: Equatable, Sendable {
 
     static func make(
         provider: CostProvider, buckets: DayModelBuckets,
-        window: DateInterval, today: Date, calendar: Calendar) -> DailyCostReport
+        windowStart: Date, today: Date, calendar: Calendar) -> DailyCostReport
     {
         var entries: [DayEntry] = []
-        var cursor = calendar.startOfDay(for: window.start)
+        var cursor = calendar.startOfDay(for: windowStart)
         let last = calendar.startOfDay(for: today)
         var modelCostNanos: [String: Int] = [:]
         while cursor <= last {

--- a/notchi/notchi/Models/CostUsageModels.swift
+++ b/notchi/notchi/Models/CostUsageModels.swift
@@ -1,17 +1,17 @@
 import Foundation
 
-enum CostProvider: String, Codable, Sendable, CaseIterable {
+nonisolated enum CostProvider: String, Codable, Sendable, CaseIterable {
     case claude
     case codex
 }
 
-struct ModelTokenTotals: Equatable, Sendable, Codable {
+nonisolated struct ModelTokenTotals: Equatable, Sendable, Codable {
     var input: Int = 0
     var cacheRead: Int = 0
     var cacheCreation: Int = 0
     var cacheCreation1h: Int = 0
     var output: Int = 0
-    var costNanos: Int = 0           // USD × 1_000_000_000 (integer to avoid float drift)
+    var costNanos: Int = 0
     var requestCount: Int = 0
     var pricedCount: Int = 0
 
@@ -28,21 +28,21 @@ struct ModelTokenTotals: Equatable, Sendable, Codable {
     }
 }
 
-typealias DayModelBuckets = [String: [String: ModelTokenTotals]]  // [dayKey: [model: totals]]
+typealias DayModelBuckets = [String: [String: ModelTokenTotals]]
 
-struct DailyCostReport: Equatable, Sendable {
-    struct DayEntry: Equatable, Sendable, Identifiable {
-        let day: String          // "yyyy-MM-dd"
+nonisolated struct DailyCostReport: Equatable, Sendable {
+    nonisolated struct DayEntry: Equatable, Sendable, Identifiable {
+        let day: String
         let date: Date
         let costUSD: Double
         let totalTokens: Int
         let requestCount: Int
-        let pricedFraction: Double   // 0...1; 1 = every request priced
+        let pricedFraction: Double
         var id: String { day }
     }
 
     let provider: CostProvider
-    let entries: [DayEntry]      // ascending by date, gap-filled across window
+    let entries: [DayEntry]
     let topModel: String?
 
     var windowCostUSD: Double { entries.reduce(0) { $0 + $1.costUSD } }
@@ -59,7 +59,6 @@ struct DailyCostReport: Equatable, Sendable {
         provider: CostProvider, buckets: DayModelBuckets,
         window: DateInterval, today: Date, calendar: Calendar) -> DailyCostReport
     {
-        // 1) gap-filled ascending day list across [window.start, today]
         var entries: [DayEntry] = []
         var cursor = calendar.startOfDay(for: window.start)
         let last = calendar.startOfDay(for: today)

--- a/notchi/notchi/Models/CostUsageModels.swift
+++ b/notchi/notchi/Models/CostUsageModels.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+enum CostProvider: String, Codable, Sendable, CaseIterable {
+    case claude
+    case codex
+}
+
+struct ModelTokenTotals: Equatable, Sendable, Codable {
+    var input: Int = 0
+    var cacheRead: Int = 0
+    var cacheCreation: Int = 0
+    var cacheCreation1h: Int = 0
+    var output: Int = 0
+    var costNanos: Int = 0           // USD × 1_000_000_000 (integer to avoid float drift)
+    var requestCount: Int = 0
+    var pricedCount: Int = 0
+
+    var totalTokens: Int { input + cacheRead + cacheCreation + output }
+    var costUSD: Double { Double(costNanos) / 1_000_000_000 }
+
+    static func + (l: ModelTokenTotals, r: ModelTokenTotals) -> ModelTokenTotals {
+        ModelTokenTotals(
+            input: l.input + r.input, cacheRead: l.cacheRead + r.cacheRead,
+            cacheCreation: l.cacheCreation + r.cacheCreation,
+            cacheCreation1h: l.cacheCreation1h + r.cacheCreation1h,
+            output: l.output + r.output, costNanos: l.costNanos + r.costNanos,
+            requestCount: l.requestCount + r.requestCount, pricedCount: l.pricedCount + r.pricedCount)
+    }
+}
+
+typealias DayModelBuckets = [String: [String: ModelTokenTotals]]  // [dayKey: [model: totals]]
+
+struct DailyCostReport: Equatable, Sendable {
+    struct DayEntry: Equatable, Sendable, Identifiable {
+        let day: String          // "yyyy-MM-dd"
+        let date: Date
+        let costUSD: Double
+        let totalTokens: Int
+        let requestCount: Int
+        let pricedFraction: Double   // 0...1; 1 = every request priced
+        var id: String { day }
+    }
+
+    let provider: CostProvider
+    let entries: [DayEntry]      // ascending by date, gap-filled across window
+    let topModel: String?
+
+    var windowCostUSD: Double { entries.reduce(0) { $0 + $1.costUSD } }
+    var windowTokens: Int { entries.reduce(0) { $0 + $1.totalTokens } }
+    var todayCostUSD: Double { entries.last?.costUSD ?? 0 }
+    var latestTokens: Int { entries.last(where: { $0.totalTokens > 0 })?.totalTokens ?? 0 }
+
+    static func dayKey(_ date: Date, calendar: Calendar) -> String {
+        let c = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", c.year ?? 0, c.month ?? 0, c.day ?? 0)
+    }
+
+    static func make(
+        provider: CostProvider, buckets: DayModelBuckets,
+        window: DateInterval, today: Date, calendar: Calendar) -> DailyCostReport
+    {
+        // 1) gap-filled ascending day list across [window.start, today]
+        var entries: [DayEntry] = []
+        var cursor = calendar.startOfDay(for: window.start)
+        let last = calendar.startOfDay(for: today)
+        var modelCostNanos: [String: Int] = [:]
+        while cursor <= last {
+            let key = dayKey(cursor, calendar: calendar)
+            let models = buckets[key] ?? [:]
+            var totals = ModelTokenTotals()
+            for (m, t) in models {
+                totals = totals + t
+                modelCostNanos[m, default: 0] += t.costNanos
+            }
+            let priced = totals.requestCount == 0 ? 1 : Double(totals.pricedCount) / Double(totals.requestCount)
+            entries.append(DayEntry(
+                day: key, date: cursor, costUSD: totals.costUSD,
+                totalTokens: totals.totalTokens, requestCount: totals.requestCount,
+                pricedFraction: priced))
+            cursor = calendar.date(byAdding: .day, value: 1, to: cursor)!
+        }
+        let topModel = modelCostNanos.max(by: { $0.value < $1.value })?.key
+        return DailyCostReport(provider: provider, entries: entries, topModel: topModel)
+    }
+}

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -461,7 +461,6 @@ struct NotchContentView: View {
                 showingPanelSettings = false
                 showingPanelSettingsDetail = false
                 showingSessionActivity = false
-                showingUsageDetail = false
                 hoveredSessionId = nil
             }
         }

--- a/notchi/notchi/Resources/claude-pricing-fallback.json
+++ b/notchi/notchi/Resources/claude-pricing-fallback.json
@@ -1,23 +1,6 @@
 {
   "version": 1,
   "models": {
-    "claude-sonnet-4": {
-      "inputPerToken": 0.000003,
-      "outputPerToken": 0.000015,
-      "cacheCreationPerToken": 0.00000375,
-      "cacheReadPerToken": 0.0000003,
-      "thresholdTokens": 200000,
-      "inputPerTokenAboveThreshold": 0.000006,
-      "outputPerTokenAboveThreshold": 0.0000225,
-      "cacheCreationPerTokenAboveThreshold": 0.0000075,
-      "cacheReadPerTokenAboveThreshold": 0.0000006
-    },
-    "claude-sonnet-4-5": {
-      "inputPerToken": 0.000003,
-      "outputPerToken": 0.000015,
-      "cacheCreationPerToken": 0.00000375,
-      "cacheReadPerToken": 0.0000003
-    },
     "claude-sonnet-4-6": {
       "inputPerToken": 0.000003,
       "outputPerToken": 0.000015,
@@ -28,24 +11,6 @@
       "outputPerTokenAboveThreshold": 0.0000225,
       "cacheCreationPerTokenAboveThreshold": 0.0000075,
       "cacheReadPerTokenAboveThreshold": 0.0000006
-    },
-    "claude-3-7-sonnet": {
-      "inputPerToken": 0.000003,
-      "outputPerToken": 0.000015,
-      "cacheCreationPerToken": 0.00000375,
-      "cacheReadPerToken": 0.0000003
-    },
-    "claude-opus-4": {
-      "inputPerToken": 0.000015,
-      "outputPerToken": 0.000075,
-      "cacheCreationPerToken": 0.00001875,
-      "cacheReadPerToken": 0.0000015
-    },
-    "claude-opus-4-1": {
-      "inputPerToken": 0.000015,
-      "outputPerToken": 0.000075,
-      "cacheCreationPerToken": 0.00001875,
-      "cacheReadPerToken": 0.0000015
     },
     "claude-opus-4-5": {
       "inputPerToken": 0.000005,

--- a/notchi/notchi/Resources/claude-pricing-fallback.json
+++ b/notchi/notchi/Resources/claude-pricing-fallback.json
@@ -64,6 +64,24 @@
       "cacheCreationPerTokenAboveThreshold": 0.0000125,
       "cacheReadPerTokenAboveThreshold": 0.000001
     },
+    "claude-opus-4-7": {
+      "inputPerToken": 0.000005,
+      "outputPerToken": 0.000025,
+      "cacheCreationPerToken": 0.00000625,
+      "cacheReadPerToken": 0.0000005
+    },
+    "claude-opus-4-8": {
+      "inputPerToken": 0.000005,
+      "outputPerToken": 0.000025,
+      "cacheCreationPerToken": 0.00000625,
+      "cacheReadPerToken": 0.0000005
+    },
+    "claude-fable-5": {
+      "inputPerToken": 0.00001,
+      "outputPerToken": 0.00005,
+      "cacheCreationPerToken": 0.0000125,
+      "cacheReadPerToken": 0.000001
+    },
     "claude-haiku-4-5": {
       "inputPerToken": 0.000001,
       "outputPerToken": 0.000005,

--- a/notchi/notchi/Resources/claude-pricing-fallback.json
+++ b/notchi/notchi/Resources/claude-pricing-fallback.json
@@ -1,0 +1,74 @@
+{
+  "version": 1,
+  "models": {
+    "claude-sonnet-4": {
+      "inputPerToken": 0.000003,
+      "outputPerToken": 0.000015,
+      "cacheCreationPerToken": 0.00000375,
+      "cacheReadPerToken": 0.0000003,
+      "thresholdTokens": 200000,
+      "inputPerTokenAboveThreshold": 0.000006,
+      "outputPerTokenAboveThreshold": 0.0000225,
+      "cacheCreationPerTokenAboveThreshold": 0.0000075,
+      "cacheReadPerTokenAboveThreshold": 0.0000006
+    },
+    "claude-sonnet-4-5": {
+      "inputPerToken": 0.000003,
+      "outputPerToken": 0.000015,
+      "cacheCreationPerToken": 0.00000375,
+      "cacheReadPerToken": 0.0000003
+    },
+    "claude-sonnet-4-6": {
+      "inputPerToken": 0.000003,
+      "outputPerToken": 0.000015,
+      "cacheCreationPerToken": 0.00000375,
+      "cacheReadPerToken": 0.0000003,
+      "thresholdTokens": 200000,
+      "inputPerTokenAboveThreshold": 0.000006,
+      "outputPerTokenAboveThreshold": 0.0000225,
+      "cacheCreationPerTokenAboveThreshold": 0.0000075,
+      "cacheReadPerTokenAboveThreshold": 0.0000006
+    },
+    "claude-3-7-sonnet": {
+      "inputPerToken": 0.000003,
+      "outputPerToken": 0.000015,
+      "cacheCreationPerToken": 0.00000375,
+      "cacheReadPerToken": 0.0000003
+    },
+    "claude-opus-4": {
+      "inputPerToken": 0.000015,
+      "outputPerToken": 0.000075,
+      "cacheCreationPerToken": 0.00001875,
+      "cacheReadPerToken": 0.0000015
+    },
+    "claude-opus-4-1": {
+      "inputPerToken": 0.000015,
+      "outputPerToken": 0.000075,
+      "cacheCreationPerToken": 0.00001875,
+      "cacheReadPerToken": 0.0000015
+    },
+    "claude-opus-4-5": {
+      "inputPerToken": 0.000005,
+      "outputPerToken": 0.000025,
+      "cacheCreationPerToken": 0.00000625,
+      "cacheReadPerToken": 0.0000005
+    },
+    "claude-opus-4-6": {
+      "inputPerToken": 0.000005,
+      "outputPerToken": 0.000025,
+      "cacheCreationPerToken": 0.00000625,
+      "cacheReadPerToken": 0.0000005,
+      "thresholdTokens": 200000,
+      "inputPerTokenAboveThreshold": 0.00001,
+      "outputPerTokenAboveThreshold": 0.0000375,
+      "cacheCreationPerTokenAboveThreshold": 0.0000125,
+      "cacheReadPerTokenAboveThreshold": 0.000001
+    },
+    "claude-haiku-4-5": {
+      "inputPerToken": 0.000001,
+      "outputPerToken": 0.000005,
+      "cacheCreationPerToken": 0.00000125,
+      "cacheReadPerToken": 0.0000001
+    }
+  }
+}

--- a/notchi/notchi/Services/Cost/ClaudeCostScanner.swift
+++ b/notchi/notchi/Services/Cost/ClaudeCostScanner.swift
@@ -110,7 +110,7 @@ final class ClaudeCostScanner {
         let msgId = message["id"] as? String ?? ""
         let reqId = obj["requestId"] as? String ?? ""
         let dedupKey = msgId + "|" + reqId
-        if !dedupKey.isEmpty, !seen.insert(dedupKey).inserted { return }
+        if !(msgId.isEmpty && reqId.isEmpty), !seen.insert(dedupKey).inserted { return }
 
         let cost = pricing.pricing(model: model, on: date).map {
             CostPricing.claudeCostUSD(model: model, input: input, cacheRead: cacheRead,

--- a/notchi/notchi/Services/Cost/ClaudeCostScanner.swift
+++ b/notchi/notchi/Services/Cost/ClaudeCostScanner.swift
@@ -1,13 +1,11 @@
 import Foundation
 
-// nonisolated: scanner runs from detached tasks; must not inherit @MainActor default isolation.
 final class ClaudeCostScanner {
     let projectsRoots: [URL]
     let pricing: any ClaudePricingProviding
     let windowDays: Int
     let calendar: Calendar
 
-    // seen is mutated only within scan(), which callers must invoke serially.
     nonisolated(unsafe) private var seen = Set<String>()
 
     nonisolated init(projectsRoots: [URL], pricing: any ClaudePricingProviding, windowDays: Int, calendar: Calendar) {
@@ -35,8 +33,8 @@ final class ClaudeCostScanner {
                 let size = (attrs?[.size] as? NSNumber)?.int64Value ?? 0
                 let mtime = ((attrs?[.modificationDate] as? Date)?.timeIntervalSince1970) ?? 0
                 var state = cache.files[path] ?? .init(size: 0, mtime: 0, offset: 0)
-                if state.size == size, state.mtime == mtime { continue }  // unchanged → skip
-                let startOffset = (size >= state.size) ? state.offset : 0  // truncated/rotated → full reparse
+                if state.size == size, state.mtime == mtime { continue }
+                let startOffset = (size >= state.size) ? state.offset : 0
 
                 state.offset = parseFile(url: url, startOffset: startOffset, sinceKey: sinceKey, into: &cache.buckets)
                 state.size = size
@@ -48,7 +46,6 @@ final class ClaudeCostScanner {
         return cache
     }
 
-    /// Returns new byte offset (end of fully-consumed lines).
     nonisolated private func parseFile(url: URL, startOffset: Int64, sinceKey: String,
                                        into buckets: inout DayModelBuckets) -> Int64 {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return startOffset }
@@ -69,11 +66,10 @@ final class ClaudeCostScanner {
             }
             i = data.index(after: i)
         }
-        return consumed  // trailing partial line (no newline) left for next scan
+        return consumed
     }
 
     nonisolated private func handleLine(_ lineData: Data, sinceKey: String, into buckets: inout DayModelBuckets) {
-        // Fast byte prefilter before JSON parse.
         guard lineData.range(of: Data(#""type":"assistant""#.utf8)) != nil,
               lineData.range(of: Data(#""usage""#.utf8)) != nil else { return }
         guard let obj = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any],

--- a/notchi/notchi/Services/Cost/ClaudeCostScanner.swift
+++ b/notchi/notchi/Services/Cost/ClaudeCostScanner.swift
@@ -8,6 +8,13 @@ final class ClaudeCostScanner {
 
     nonisolated(unsafe) private var seen = Set<String>()
 
+    nonisolated(unsafe) private let isoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    nonisolated(unsafe) private let isoPlain = ISO8601DateFormatter()
+
     nonisolated init(projectsRoots: [URL], pricing: any ClaudePricingProviding, windowDays: Int, calendar: Calendar) {
         self.projectsRoots = projectsRoots
         self.pricing = pricing
@@ -121,8 +128,6 @@ final class ClaudeCostScanner {
     nonisolated private func intval(_ v: Any?) -> Int { (v as? NSNumber)?.intValue ?? 0 }
 
     nonisolated private func parseTimestamp(_ s: String) -> Date? {
-        let iso = ISO8601DateFormatter()
-        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return iso.date(from: s) ?? ISO8601DateFormatter().date(from: s)
+        isoFractional.date(from: s) ?? isoPlain.date(from: s)
     }
 }

--- a/notchi/notchi/Services/Cost/ClaudeCostScanner.swift
+++ b/notchi/notchi/Services/Cost/ClaudeCostScanner.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+// nonisolated: scanner runs from detached tasks; must not inherit @MainActor default isolation.
+final class ClaudeCostScanner {
+    let projectsRoots: [URL]
+    let pricing: any ClaudePricingProviding
+    let windowDays: Int
+    let calendar: Calendar
+
+    // seen is mutated only within scan(), which callers must invoke serially.
+    nonisolated(unsafe) private var seen = Set<String>()
+
+    nonisolated init(projectsRoots: [URL], pricing: any ClaudePricingProviding, windowDays: Int, calendar: Calendar) {
+        self.projectsRoots = projectsRoots
+        self.pricing = pricing
+        self.windowDays = windowDays
+        self.calendar = calendar
+    }
+
+    nonisolated deinit {}
+
+    nonisolated func scan(cache input: CostUsageCache, now: Date) -> CostUsageCache {
+        seen.removeAll()
+        var cache = input
+        let windowStart = calendar.date(byAdding: .day, value: -(windowDays - 1),
+                                        to: calendar.startOfDay(for: now))!
+        let sinceKey = DailyCostReport.dayKey(windowStart, calendar: calendar)
+
+        for root in projectsRoots {
+            guard let en = FileManager.default.enumerator(
+                at: root, includingPropertiesForKeys: [.fileSizeKey, .contentModificationDateKey]) else { continue }
+            for case let url as URL in en where url.pathExtension == "jsonl" {
+                let path = url.path
+                let attrs = try? FileManager.default.attributesOfItem(atPath: path)
+                let size = (attrs?[.size] as? NSNumber)?.int64Value ?? 0
+                let mtime = ((attrs?[.modificationDate] as? Date)?.timeIntervalSince1970) ?? 0
+                var state = cache.files[path] ?? .init(size: 0, mtime: 0, offset: 0)
+                if state.size == size, state.mtime == mtime { continue }  // unchanged → skip
+                let startOffset = (size >= state.size) ? state.offset : 0  // truncated/rotated → full reparse
+
+                state.offset = parseFile(url: url, startOffset: startOffset, sinceKey: sinceKey, into: &cache.buckets)
+                state.size = size
+                state.mtime = mtime
+                cache.files[path] = state
+            }
+        }
+        cache.buckets = cache.buckets.filter { $0.key >= sinceKey }
+        return cache
+    }
+
+    /// Returns new byte offset (end of fully-consumed lines).
+    nonisolated private func parseFile(url: URL, startOffset: Int64, sinceKey: String,
+                                       into buckets: inout DayModelBuckets) -> Int64 {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return startOffset }
+        defer { try? handle.close() }
+        if startOffset > 0 { try? handle.seek(toOffset: UInt64(startOffset)) }
+        guard let data = try? handle.readToEnd(), !data.isEmpty else { return startOffset }
+
+        var consumed = startOffset
+        var lineStart = data.startIndex
+        let newline = UInt8(ascii: "\n")
+        var i = data.startIndex
+        while i < data.endIndex {
+            if data[i] == newline {
+                let lineData = data[lineStart..<i]
+                consumed += Int64(lineData.count) + 1
+                handleLine(lineData, sinceKey: sinceKey, into: &buckets)
+                lineStart = data.index(after: i)
+            }
+            i = data.index(after: i)
+        }
+        return consumed  // trailing partial line (no newline) left for next scan
+    }
+
+    nonisolated private func handleLine(_ lineData: Data, sinceKey: String, into buckets: inout DayModelBuckets) {
+        // Fast byte prefilter before JSON parse.
+        guard lineData.range(of: Data(#""type":"assistant""#.utf8)) != nil,
+              lineData.range(of: Data(#""usage""#.utf8)) != nil else { return }
+        guard let obj = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any],
+              obj["type"] as? String == "assistant",
+              let ts = obj["timestamp"] as? String,
+              let date = parseTimestamp(ts) else { return }
+        let dayKey = DailyCostReport.dayKey(date, calendar: calendar)
+        guard dayKey >= sinceKey else { return }
+        guard let message = obj["message"] as? [String: Any],
+              let model = message["model"] as? String,
+              let usage = message["usage"] as? [String: Any] else { return }
+
+        let input = intval(usage["input_tokens"])
+        let output = intval(usage["output_tokens"])
+        let cacheCreate = intval(usage["cache_creation_input_tokens"])
+        let cacheRead = intval(usage["cache_read_input_tokens"])
+        if input == 0, output == 0, cacheCreate == 0, cacheRead == 0 { return }
+
+        let msgId = message["id"] as? String ?? ""
+        let reqId = obj["requestId"] as? String ?? ""
+        let dedupKey = msgId + "|" + reqId
+        if !dedupKey.isEmpty, !seen.insert(dedupKey).inserted { return }
+
+        let cost = pricing.pricing(model: model, on: date).map {
+            CostPricing.claudeCostUSD(model: model, input: input, cacheRead: cacheRead,
+                cacheCreation: cacheCreate, cacheCreation1h: 0, output: output, pricing: $0)
+        } ?? nil
+        let nanos = cost.map { Int(($0 * 1_000_000_000).rounded()) } ?? 0
+        let key = CostPricing.normalizeClaudeModel(model)
+        var dayModels = buckets[dayKey] ?? [:]
+        dayModels[key] = (dayModels[key] ?? ModelTokenTotals()) + ModelTokenTotals(
+            input: input, cacheRead: cacheRead, cacheCreation: cacheCreate, cacheCreation1h: 0,
+            output: output, costNanos: nanos, requestCount: 1, pricedCount: cost == nil ? 0 : 1)
+        buckets[dayKey] = dayModels
+    }
+
+    nonisolated private func intval(_ v: Any?) -> Int { (v as? NSNumber)?.intValue ?? 0 }
+
+    nonisolated private func parseTimestamp(_ s: String) -> Date? {
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return iso.date(from: s) ?? ISO8601DateFormatter().date(from: s)
+    }
+}

--- a/notchi/notchi/Services/Cost/ClaudeCostScanner.swift
+++ b/notchi/notchi/Services/Cost/ClaudeCostScanner.swift
@@ -20,6 +20,10 @@ final class ClaudeCostScanner {
     nonisolated func scan(cache input: CostUsageCache, now: Date) -> CostUsageCache {
         seen.removeAll()
         var cache = input
+        if anyTrackedFileShrank(cache.files) {
+            cache.files = [:]
+            cache.buckets = [:]
+        }
         let windowStart = calendar.date(byAdding: .day, value: -(windowDays - 1),
                                         to: calendar.startOfDay(for: now))!
         let sinceKey = DailyCostReport.dayKey(windowStart, calendar: calendar)
@@ -44,6 +48,14 @@ final class ClaudeCostScanner {
         }
         cache.buckets = cache.buckets.filter { $0.key >= sinceKey }
         return cache
+    }
+
+    nonisolated private func anyTrackedFileShrank(_ files: [String: CostUsageCache.FileState]) -> Bool {
+        for (path, state) in files {
+            let size = ((try? FileManager.default.attributesOfItem(atPath: path))?[.size] as? NSNumber)?.int64Value ?? 0
+            if size < state.size { return true }
+        }
+        return false
     }
 
     nonisolated private func parseFile(url: URL, startOffset: Int64, sinceKey: String,

--- a/notchi/notchi/Services/Cost/ClaudeModelPricing.swift
+++ b/notchi/notchi/Services/Cost/ClaudeModelPricing.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+struct ClaudeModelPricing: Equatable, Sendable {
+    let inputPerToken: Double
+    let outputPerToken: Double
+    let cacheCreationPerToken: Double
+    let cacheReadPerToken: Double
+    let cacheCreation1hPerToken: Double?
+    let thresholdTokens: Int?
+    let inputPerTokenAboveThreshold: Double?
+    let outputPerTokenAboveThreshold: Double?
+    let cacheCreationPerTokenAboveThreshold: Double?
+    let cacheReadPerTokenAboveThreshold: Double?
+}
+
+protocol ClaudePricingProviding: Sendable {
+    func pricing(model: String, on date: Date) -> ClaudeModelPricing?
+}
+
+enum CostPricing {
+    /// Strips date suffix and provider prefix: "anthropic/claude-sonnet-4-20250514" → "claude-sonnet-4".
+    static func normalizeClaudeModel(_ raw: String) -> String {
+        var s = raw
+        if let slash = s.lastIndex(of: "/") { s = String(s[s.index(after: slash)...]) }
+        // drop a trailing -YYYYMMDD date stamp
+        if let r = s.range(of: #"-\d{8}$"#, options: .regularExpression) { s.removeSubrange(r) }
+        return s
+    }
+
+    static func claudeCostUSD(
+        model: String, input: Int, cacheRead: Int, cacheCreation: Int,
+        cacheCreation1h: Int, output: Int, pricing: ClaudeModelPricing) -> Double?
+    {
+        let contextTokens = input + cacheRead + cacheCreation
+        let useAbove = (pricing.thresholdTokens.map { contextTokens > $0 } ?? false)
+            && pricing.inputPerTokenAboveThreshold != nil
+
+        let inP = useAbove ? (pricing.inputPerTokenAboveThreshold ?? pricing.inputPerToken) : pricing.inputPerToken
+        let outP = useAbove ? (pricing.outputPerTokenAboveThreshold ?? pricing.outputPerToken) : pricing.outputPerToken
+        let crP = useAbove ? (pricing.cacheCreationPerTokenAboveThreshold ?? pricing.cacheCreationPerToken) : pricing.cacheCreationPerToken
+        let rdP = useAbove ? (pricing.cacheReadPerTokenAboveThreshold ?? pricing.cacheReadPerToken) : pricing.cacheReadPerToken
+
+        // cacheCreation1h is a subset of cacheCreation priced at a separate rate when available.
+        let standardCreate = max(0, cacheCreation - cacheCreation1h)
+        let create1hCost = Double(cacheCreation1h) * (pricing.cacheCreation1hPerToken ?? crP)
+
+        return Double(input) * inP
+            + Double(output) * outP
+            + Double(standardCreate) * crP
+            + create1hCost
+            + Double(cacheRead) * rdP
+    }
+}

--- a/notchi/notchi/Services/Cost/ClaudeModelPricing.swift
+++ b/notchi/notchi/Services/Cost/ClaudeModelPricing.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ClaudeModelPricing: Equatable, Sendable {
+nonisolated struct ClaudeModelPricing: Equatable, Sendable {
     let inputPerToken: Double
     let outputPerToken: Double
     let cacheCreationPerToken: Double
@@ -14,15 +14,13 @@ struct ClaudeModelPricing: Equatable, Sendable {
 }
 
 protocol ClaudePricingProviding: Sendable {
-    func pricing(model: String, on date: Date) -> ClaudeModelPricing?
+    nonisolated func pricing(model: String, on date: Date) -> ClaudeModelPricing?
 }
 
-enum CostPricing {
-    /// Strips date suffix and provider prefix: "anthropic/claude-sonnet-4-20250514" → "claude-sonnet-4".
+nonisolated enum CostPricing {
     static func normalizeClaudeModel(_ raw: String) -> String {
         var s = raw
         if let slash = s.lastIndex(of: "/") { s = String(s[s.index(after: slash)...]) }
-        // drop a trailing -YYYYMMDD date stamp
         if let r = s.range(of: #"-\d{8}$"#, options: .regularExpression) { s.removeSubrange(r) }
         return s
     }
@@ -40,7 +38,6 @@ enum CostPricing {
         let crP = useAbove ? (pricing.cacheCreationPerTokenAboveThreshold ?? pricing.cacheCreationPerToken) : pricing.cacheCreationPerToken
         let rdP = useAbove ? (pricing.cacheReadPerTokenAboveThreshold ?? pricing.cacheReadPerToken) : pricing.cacheReadPerToken
 
-        // cacheCreation1h is a subset of cacheCreation priced at a separate rate when available.
         let standardCreate = max(0, cacheCreation - cacheCreation1h)
         let create1hCost = Double(cacheCreation1h) * (pricing.cacheCreation1hPerToken ?? crP)
 

--- a/notchi/notchi/Services/Cost/CostHistoryStore.swift
+++ b/notchi/notchi/Services/Cost/CostHistoryStore.swift
@@ -74,8 +74,7 @@ final class CostHistoryStore {
                                         to: calendar.startOfDay(for: now))!
         report = DailyCostReport.make(
             provider: .claude, buckets: buckets,
-            window: DateInterval(start: windowStart, end: now),
-            today: now, calendar: calendar)
+            windowStart: windowStart, today: now, calendar: calendar)
         lastScan = now
     }
 }

--- a/notchi/notchi/Services/Cost/CostHistoryStore.swift
+++ b/notchi/notchi/Services/Cost/CostHistoryStore.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class CostHistoryStore {
+    private(set) var report: DailyCostReport?
+    private(set) var isScanning = false
+    private(set) var lastScan: Date?
+
+    private let windowDays: Int
+    private let calendar: Calendar
+    private let scanProvider: @Sendable (Date) async -> DayModelBuckets
+    private var timer: Timer?
+    private let refreshInterval: TimeInterval = 90
+
+    init(windowDays: Int = 30, calendar: Calendar = .current,
+         scanProvider: @escaping @Sendable (Date) async -> DayModelBuckets) {
+        self.windowDays = windowDays
+        self.calendar = calendar
+        self.scanProvider = scanProvider
+    }
+
+    /// Production initializer — builds scanProvider from real scanner + cache.
+    convenience init(windowDays: Int = 30, calendar: Calendar = .current,
+                     pricing: any ClaudePricingProviding,
+                     projectsRoots: [URL],
+                     cacheURL: URL) {
+        // Construct scanner once; closure captures it and calls scan() serially (one at a time via isScanning guard).
+        let scanner = ClaudeCostScanner(
+            projectsRoots: projectsRoots,
+            pricing: pricing,
+            windowDays: windowDays,
+            calendar: calendar)
+
+        self.init(windowDays: windowDays, calendar: calendar) { now in
+            await Task.detached(priority: .utility) {
+                let cache = CostUsageCacheStore.load(url: cacheURL)
+                let updated = scanner.scan(cache: cache, now: now)
+                CostUsageCacheStore.save(updated, to: cacheURL)
+                return updated.buckets
+            }.value
+        }
+    }
+
+    func start() {
+        Task { await refresh() }
+        timer = Timer.scheduledTimer(withTimeInterval: refreshInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in await self?.refresh() }
+        }
+    }
+
+    func refresh() async {
+        if isScanning { return }
+        isScanning = true
+        let now = Date()
+        let buckets = await scanProvider(now)
+        let windowStart = calendar.date(byAdding: .day, value: -(windowDays - 1),
+                                        to: calendar.startOfDay(for: now))!
+        report = DailyCostReport.make(
+            provider: .claude, buckets: buckets,
+            window: DateInterval(start: windowStart, end: now),
+            today: now, calendar: calendar)
+        lastScan = now
+        isScanning = false
+    }
+}

--- a/notchi/notchi/Services/Cost/CostHistoryStore.swift
+++ b/notchi/notchi/Services/Cost/CostHistoryStore.swift
@@ -23,12 +23,10 @@ final class CostHistoryStore {
         self.pricingCatalog = nil
     }
 
-    /// Production initializer — builds scanProvider from real scanner + cache.
     convenience init(windowDays: Int = 30, calendar: Calendar = .current,
                      pricing: PricingCatalog,
                      projectsRoots: [URL],
                      cacheURL: URL) {
-        // Construct scanner once; closure captures it and calls scan() serially (one at a time via isScanning guard).
         let scanner = ClaudeCostScanner(
             projectsRoots: projectsRoots,
             pricing: pricing,
@@ -37,8 +35,10 @@ final class CostHistoryStore {
 
         self.init(windowDays: windowDays, calendar: calendar, pricingCatalog: pricing) { now in
             await Task.detached(priority: .utility) {
-                let cache = CostUsageCacheStore.load(url: cacheURL)
-                let updated = scanner.scan(cache: cache, now: now)
+                let sig = pricing.signature()
+                let cache = CostUsageCacheStore.load(url: cacheURL).reconciled(withPricingSignature: sig)
+                var updated = scanner.scan(cache: cache, now: now)
+                updated.pricingSignature = sig
                 CostUsageCacheStore.save(updated, to: cacheURL)
                 return updated.buckets
             }.value
@@ -84,7 +84,8 @@ final class CostHistoryStore {
 
 extension CostHistoryStore {
     static let shared: CostHistoryStore = {
-        let pricing = PricingCatalog(fallbackBundle: .main)
+        let pricing = PricingCatalog(fallbackBundle: .main,
+                                     snapshotURL: PricingCatalog.defaultSnapshotURL())
         let projectsRoot = URL(fileURLWithPath: NSHomeDirectory())
             .appendingPathComponent(".claude/projects", isDirectory: true)
         let cacheURL: URL

--- a/notchi/notchi/Services/Cost/CostHistoryStore.swift
+++ b/notchi/notchi/Services/Cost/CostHistoryStore.swift
@@ -13,17 +13,19 @@ final class CostHistoryStore {
     private let scanProvider: @Sendable (Date) async -> DayModelBuckets
     private var timer: Timer?
     private let refreshInterval: TimeInterval = 90
+    private let pricingCatalog: PricingCatalog?
 
     init(windowDays: Int = 30, calendar: Calendar = .current,
          scanProvider: @escaping @Sendable (Date) async -> DayModelBuckets) {
         self.windowDays = windowDays
         self.calendar = calendar
         self.scanProvider = scanProvider
+        self.pricingCatalog = nil
     }
 
     /// Production initializer — builds scanProvider from real scanner + cache.
     convenience init(windowDays: Int = 30, calendar: Calendar = .current,
-                     pricing: any ClaudePricingProviding,
+                     pricing: PricingCatalog,
                      projectsRoots: [URL],
                      cacheURL: URL) {
         // Construct scanner once; closure captures it and calls scan() serially (one at a time via isScanning guard).
@@ -33,7 +35,7 @@ final class CostHistoryStore {
             windowDays: windowDays,
             calendar: calendar)
 
-        self.init(windowDays: windowDays, calendar: calendar) { now in
+        self.init(windowDays: windowDays, calendar: calendar, pricingCatalog: pricing) { now in
             await Task.detached(priority: .utility) {
                 let cache = CostUsageCacheStore.load(url: cacheURL)
                 let updated = scanner.scan(cache: cache, now: now)
@@ -43,7 +45,19 @@ final class CostHistoryStore {
         }
     }
 
+    private init(windowDays: Int, calendar: Calendar, pricingCatalog: PricingCatalog,
+                 scanProvider: @escaping @Sendable (Date) async -> DayModelBuckets) {
+        self.windowDays = windowDays
+        self.calendar = calendar
+        self.scanProvider = scanProvider
+        self.pricingCatalog = pricingCatalog
+    }
+
     func start() {
+        guard timer == nil else { return }
+        if let catalog = pricingCatalog {
+            Task.detached(priority: .utility) { await catalog.refreshFromNetwork() }
+        }
         Task { await refresh() }
         timer = Timer.scheduledTimer(withTimeInterval: refreshInterval, repeats: true) { [weak self] _ in
             Task { @MainActor in await self?.refresh() }
@@ -64,4 +78,22 @@ final class CostHistoryStore {
         lastScan = now
         isScanning = false
     }
+}
+
+// MARK: - Shared singleton
+
+extension CostHistoryStore {
+    static let shared: CostHistoryStore = {
+        let pricing = PricingCatalog(fallbackBundle: .main)
+        let projectsRoot = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".claude/projects", isDirectory: true)
+        let cacheURL: URL
+        if let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
+            cacheURL = cachesDir.appendingPathComponent("CostUsage/claude.json")
+        } else {
+            cacheURL = URL(fileURLWithPath: NSHomeDirectory())
+                .appendingPathComponent(".notchi/CostUsage/claude.json")
+        }
+        return CostHistoryStore(pricing: pricing, projectsRoots: [projectsRoot], cacheURL: cacheURL)
+    }()
 }

--- a/notchi/notchi/Services/Cost/CostHistoryStore.swift
+++ b/notchi/notchi/Services/Cost/CostHistoryStore.swift
@@ -67,6 +67,7 @@ final class CostHistoryStore {
     func refresh() async {
         if isScanning { return }
         isScanning = true
+        defer { isScanning = false }
         let now = Date()
         let buckets = await scanProvider(now)
         let windowStart = calendar.date(byAdding: .day, value: -(windowDays - 1),
@@ -76,7 +77,6 @@ final class CostHistoryStore {
             window: DateInterval(start: windowStart, end: now),
             today: now, calendar: calendar)
         lastScan = now
-        isScanning = false
     }
 }
 

--- a/notchi/notchi/Services/Cost/CostUsageCache.swift
+++ b/notchi/notchi/Services/Cost/CostUsageCache.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-struct CostUsageCache: Codable, Equatable {
-    struct FileState: Codable, Equatable {
+nonisolated struct CostUsageCache: Codable, Equatable {
+    nonisolated struct FileState: Codable, Equatable {
         var size: Int64
         var mtime: Double
         var offset: Int64
@@ -9,16 +9,23 @@ struct CostUsageCache: Codable, Equatable {
 
     static let currentVersion = 1
     var version: Int
-    var files: [String: FileState]   // [filePath: state]
+    var files: [String: FileState]
     var buckets: DayModelBuckets
+    var pricingSignature: String? = nil
+
+    func reconciled(withPricingSignature signature: String) -> CostUsageCache {
+        pricingSignature == signature
+            ? self
+            : CostUsageCache(version: Self.currentVersion, files: [:], buckets: [:], pricingSignature: signature)
+    }
 }
 
-enum CostUsageCacheStore {
+nonisolated enum CostUsageCacheStore {
     static func load(url: URL) -> CostUsageCache {
         guard let data = try? Data(contentsOf: url),
               let decoded = try? JSONDecoder().decode(CostUsageCache.self, from: data),
               decoded.version == CostUsageCache.currentVersion
-        else { return CostUsageCache(version: CostUsageCache.currentVersion, files: [:], buckets: [:]) }
+        else { return CostUsageCache(version: CostUsageCache.currentVersion, files: [:], buckets: [:], pricingSignature: nil) }
         return decoded
     }
 

--- a/notchi/notchi/Services/Cost/CostUsageCache.swift
+++ b/notchi/notchi/Services/Cost/CostUsageCache.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+struct CostUsageCache: Codable, Equatable {
+    struct FileState: Codable, Equatable {
+        var size: Int64
+        var mtime: Double
+        var offset: Int64
+    }
+
+    static let currentVersion = 1
+    var version: Int
+    var files: [String: FileState]   // [filePath: state]
+    var buckets: DayModelBuckets
+}
+
+enum CostUsageCacheStore {
+    static func load(url: URL) -> CostUsageCache {
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode(CostUsageCache.self, from: data),
+              decoded.version == CostUsageCache.currentVersion
+        else { return CostUsageCache(version: CostUsageCache.currentVersion, files: [:], buckets: [:]) }
+        return decoded
+    }
+
+    static func save(_ cache: CostUsageCache, to url: URL) {
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let tmp = url.deletingLastPathComponent().appendingPathComponent(".tmp-\(UUID().uuidString)")
+        guard let data = try? JSONEncoder().encode(cache), (try? data.write(to: tmp, options: .atomic)) != nil
+        else { return }
+        _ = try? FileManager.default.replaceItemAt(url, withItemAt: tmp)
+    }
+}

--- a/notchi/notchi/Services/Cost/PricingCatalog.swift
+++ b/notchi/notchi/Services/Cost/PricingCatalog.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
-    private struct Snapshot: Decodable {
+nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
+    private struct Snapshot: Codable {
         let version: Int
         let models: [String: ClaudeModelPricingDTO]
     }
 
-    private struct ClaudeModelPricingDTO: Decodable {
+    private struct ClaudeModelPricingDTO: Codable {
         let inputPerToken: Double
         let outputPerToken: Double
         let cacheCreationPerToken: Double
@@ -17,6 +17,19 @@ final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
         let outputPerTokenAboveThreshold: Double?
         let cacheCreationPerTokenAboveThreshold: Double?
         let cacheReadPerTokenAboveThreshold: Double?
+
+        init(from pricing: ClaudeModelPricing) {
+            inputPerToken = pricing.inputPerToken
+            outputPerToken = pricing.outputPerToken
+            cacheCreationPerToken = pricing.cacheCreationPerToken
+            cacheReadPerToken = pricing.cacheReadPerToken
+            cacheCreation1hPerToken = pricing.cacheCreation1hPerToken
+            thresholdTokens = pricing.thresholdTokens
+            inputPerTokenAboveThreshold = pricing.inputPerTokenAboveThreshold
+            outputPerTokenAboveThreshold = pricing.outputPerTokenAboveThreshold
+            cacheCreationPerTokenAboveThreshold = pricing.cacheCreationPerTokenAboveThreshold
+            cacheReadPerTokenAboveThreshold = pricing.cacheReadPerTokenAboveThreshold
+        }
 
         func toPricing() -> ClaudeModelPricing {
             ClaudeModelPricing(
@@ -33,7 +46,6 @@ final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
         }
     }
 
-    // models.dev /api.json shape — only the fields we need
     private struct ModelsDev: Decodable {
         let anthropic: ModelsDev.Provider?
 
@@ -69,9 +81,19 @@ final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
 
     private let lock = NSLock()
     private var table: [String: ClaudeModelPricing]
+    private let snapshotURL: URL?
 
-    init(fallbackBundle: Bundle) {
+    init(fallbackBundle: Bundle, snapshotURL: URL? = nil) {
         table = Self.loadFallback(bundle: fallbackBundle)
+        if let url = snapshotURL, let overlay = Self.loadSnapshot(url: url) {
+            table.merge(overlay) { _, new in new }
+        }
+        self.snapshotURL = snapshotURL
+    }
+
+    init(table: [String: ClaudeModelPricing]) {
+        self.table = table
+        self.snapshotURL = nil
     }
 
     private static func loadFallback(bundle: Bundle) -> [String: ClaudeModelPricing] {
@@ -80,6 +102,18 @@ final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
               let snap = try? JSONDecoder().decode(Snapshot.self, from: data)
         else { return [:] }
         return snap.models.mapValues { $0.toPricing() }
+    }
+
+    private static func loadSnapshot(url: URL) -> [String: ClaudeModelPricing]? {
+        guard let data = try? Data(contentsOf: url),
+              let snap = try? JSONDecoder().decode(Snapshot.self, from: data)
+        else { return nil }
+        return snap.models.mapValues { $0.toPricing() }
+    }
+
+    static func defaultSnapshotURL() -> URL? {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("CostUsage/models-dev.json")
     }
 
     func pricing(model: String, on date: Date) -> ClaudeModelPricing? {
@@ -101,7 +135,6 @@ final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
             guard let cost = entry.cost else { continue }
             let key = CostPricing.normalizeClaudeModel(rawId)
 
-            // Extract tier pricing when the first tier is a context-size threshold
             let firstTier = cost.tiers?.first(where: { $0.tier?.type == "context" })
             let thresholdTokens = firstTier?.tier?.size
 
@@ -120,6 +153,7 @@ final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
 
         guard Self.isPlausibleRefresh(updated) else { return }
         replaceTable(updated)
+        persistSnapshot(updated)
     }
 
     private func replaceTable(_ updated: [String: ClaudeModelPricing]) {
@@ -127,8 +161,37 @@ final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
         table = updated
     }
 
-    // Symmetric prefix checks: models.dev may key Sonnet/Opus with version suffixes
-    // (e.g. claude-sonnet-4-5), so an exact-key match would silently reject every refresh.
+    private func persistSnapshot(_ updated: [String: ClaudeModelPricing]) {
+        guard let url = snapshotURL else { return }
+        let dtos = updated.mapValues { ClaudeModelPricingDTO(from: $0) }
+        let snap = Snapshot(version: 1, models: dtos)
+        guard let data = try? JSONEncoder().encode(snap) else { return }
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let tmp = url.deletingLastPathComponent().appendingPathComponent(".tmp-\(UUID().uuidString)")
+        guard (try? data.write(to: tmp, options: .atomic)) != nil else { return }
+        _ = try? FileManager.default.replaceItemAt(url, withItemAt: tmp)
+    }
+
+    func signature() -> String {
+        lock.lock()
+        let sorted = table.sorted(by: { $0.key < $1.key })
+        lock.unlock()
+
+        var buffer = ""
+        for (key, p) in sorted {
+            buffer += "\(key):\(p.inputPerToken):\(p.outputPerToken):\(p.cacheCreationPerToken):\(p.cacheReadPerToken):\(p.thresholdTokens ?? -1):\(p.inputPerTokenAboveThreshold ?? -1):\(p.outputPerTokenAboveThreshold ?? -1):\(p.cacheCreationPerTokenAboveThreshold ?? -1):\(p.cacheReadPerTokenAboveThreshold ?? -1)"
+        }
+        let fnvOffsetBasis: UInt64 = 0xcbf2_9ce4_8422_2325
+        let fnvPrime: UInt64 = 0x0000_0100_0000_01b3
+        var hash = fnvOffsetBasis
+        for byte in buffer.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* fnvPrime
+        }
+        return String(hash, radix: 16)
+    }
+
     static func isPlausibleRefresh(_ candidate: [String: ClaudeModelPricing]) -> Bool {
         let hasSonnet4Family = candidate.keys.contains(where: { $0.hasPrefix("claude-sonnet-4") })
         let hasOpus4Family = candidate.keys.contains(where: { $0.hasPrefix("claude-opus-4") })

--- a/notchi/notchi/Services/Cost/PricingCatalog.swift
+++ b/notchi/notchi/Services/Cost/PricingCatalog.swift
@@ -118,7 +118,7 @@ final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
                 cacheReadPerTokenAboveThreshold: firstTier.map { $0.cache_read / perMillion })
         }
 
-        guard isPlausibleRefresh(updated) else { return }
+        guard Self.isPlausibleRefresh(updated) else { return }
         replaceTable(updated)
     }
 
@@ -127,9 +127,11 @@ final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
         table = updated
     }
 
-    private func isPlausibleRefresh(_ candidate: [String: ClaudeModelPricing]) -> Bool {
-        let hasSonnet4 = candidate["claude-sonnet-4"] != nil
+    // Symmetric prefix checks: models.dev may key Sonnet/Opus with version suffixes
+    // (e.g. claude-sonnet-4-5), so an exact-key match would silently reject every refresh.
+    static func isPlausibleRefresh(_ candidate: [String: ClaudeModelPricing]) -> Bool {
+        let hasSonnet4Family = candidate.keys.contains(where: { $0.hasPrefix("claude-sonnet-4") })
         let hasOpus4Family = candidate.keys.contains(where: { $0.hasPrefix("claude-opus-4") })
-        return hasSonnet4 && hasOpus4Family
+        return hasSonnet4Family && hasOpus4Family
     }
 }

--- a/notchi/notchi/Services/Cost/PricingCatalog.swift
+++ b/notchi/notchi/Services/Cost/PricingCatalog.swift
@@ -152,13 +152,13 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
         }
 
         guard Self.isPlausibleRefresh(updated) else { return }
-        replaceTable(updated)
-        persistSnapshot(updated)
+        persistSnapshot(mergeIntoTable(updated))
     }
 
-    private func replaceTable(_ updated: [String: ClaudeModelPricing]) {
+    private func mergeIntoTable(_ updated: [String: ClaudeModelPricing]) -> [String: ClaudeModelPricing] {
         lock.lock(); defer { lock.unlock() }
-        table = updated
+        table.merge(updated) { _, new in new }
+        return table
     }
 
     private func persistSnapshot(_ updated: [String: ClaudeModelPricing]) {

--- a/notchi/notchi/Services/Cost/PricingCatalog.swift
+++ b/notchi/notchi/Services/Cost/PricingCatalog.swift
@@ -178,9 +178,11 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
         let sorted = table.sorted(by: { $0.key < $1.key })
         lock.unlock()
 
+        let fmt: (Double) -> String = { String(format: "%.12g", $0) }
+        let fmtOpt: (Double?) -> String = { $0.map { String(format: "%.12g", $0) } ?? "-" }
         var buffer = ""
         for (key, p) in sorted {
-            buffer += "\(key):\(p.inputPerToken):\(p.outputPerToken):\(p.cacheCreationPerToken):\(p.cacheReadPerToken):\(p.thresholdTokens ?? -1):\(p.inputPerTokenAboveThreshold ?? -1):\(p.outputPerTokenAboveThreshold ?? -1):\(p.cacheCreationPerTokenAboveThreshold ?? -1):\(p.cacheReadPerTokenAboveThreshold ?? -1)"
+            buffer += "\(key):\(fmt(p.inputPerToken)):\(fmt(p.outputPerToken)):\(fmt(p.cacheCreationPerToken)):\(fmt(p.cacheReadPerToken)):\(p.thresholdTokens ?? -1):\(fmtOpt(p.inputPerTokenAboveThreshold)):\(fmtOpt(p.outputPerTokenAboveThreshold)):\(fmtOpt(p.cacheCreationPerTokenAboveThreshold)):\(fmtOpt(p.cacheReadPerTokenAboveThreshold))"
         }
         let fnvOffsetBasis: UInt64 = 0xcbf2_9ce4_8422_2325
         let fnvPrime: UInt64 = 0x0000_0100_0000_01b3

--- a/notchi/notchi/Services/Cost/PricingCatalog.swift
+++ b/notchi/notchi/Services/Cost/PricingCatalog.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
+    private struct Snapshot: Decodable {
+        let version: Int
+        let models: [String: ClaudeModelPricingDTO]
+    }
+
+    private struct ClaudeModelPricingDTO: Decodable {
+        let inputPerToken: Double
+        let outputPerToken: Double
+        let cacheCreationPerToken: Double
+        let cacheReadPerToken: Double
+        let cacheCreation1hPerToken: Double?
+        let thresholdTokens: Int?
+        let inputPerTokenAboveThreshold: Double?
+        let outputPerTokenAboveThreshold: Double?
+        let cacheCreationPerTokenAboveThreshold: Double?
+        let cacheReadPerTokenAboveThreshold: Double?
+
+        func toPricing() -> ClaudeModelPricing {
+            ClaudeModelPricing(
+                inputPerToken: inputPerToken,
+                outputPerToken: outputPerToken,
+                cacheCreationPerToken: cacheCreationPerToken,
+                cacheReadPerToken: cacheReadPerToken,
+                cacheCreation1hPerToken: cacheCreation1hPerToken,
+                thresholdTokens: thresholdTokens,
+                inputPerTokenAboveThreshold: inputPerTokenAboveThreshold,
+                outputPerTokenAboveThreshold: outputPerTokenAboveThreshold,
+                cacheCreationPerTokenAboveThreshold: cacheCreationPerTokenAboveThreshold,
+                cacheReadPerTokenAboveThreshold: cacheReadPerTokenAboveThreshold)
+        }
+    }
+
+    // models.dev /api.json shape — only the fields we need
+    private struct ModelsDev: Decodable {
+        let anthropic: ModelsDev.Provider?
+
+        struct Provider: Decodable {
+            let models: [String: ModelsDev.ModelEntry]
+        }
+
+        struct ModelEntry: Decodable {
+            let cost: ModelsDev.Cost?
+        }
+
+        struct Cost: Decodable {
+            let input: Double
+            let output: Double
+            let cache_read: Double
+            let cache_write: Double
+            let tiers: [ModelsDev.Tier]?
+        }
+
+        struct Tier: Decodable {
+            let input: Double
+            let output: Double
+            let cache_read: Double
+            let cache_write: Double
+            let tier: ModelsDev.TierSpec?
+        }
+
+        struct TierSpec: Decodable {
+            let type: String
+            let size: Int
+        }
+    }
+
+    private let lock = NSLock()
+    private var table: [String: ClaudeModelPricing]
+
+    init(fallbackBundle: Bundle) {
+        table = Self.loadFallback(bundle: fallbackBundle)
+    }
+
+    private static func loadFallback(bundle: Bundle) -> [String: ClaudeModelPricing] {
+        guard let url = bundle.url(forResource: "claude-pricing-fallback", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let snap = try? JSONDecoder().decode(Snapshot.self, from: data)
+        else { return [:] }
+        return snap.models.mapValues { $0.toPricing() }
+    }
+
+    func pricing(model: String, on date: Date) -> ClaudeModelPricing? {
+        let key = CostPricing.normalizeClaudeModel(model)
+        lock.lock(); defer { lock.unlock() }
+        return table[key]
+    }
+
+    func refreshFromNetwork() async {
+        guard let url = URL(string: "https://models.dev/api.json") else { return }
+        guard let (data, _) = try? await URLSession.shared.data(from: url) else { return }
+        guard let decoded = try? JSONDecoder().decode(ModelsDev.self, from: data),
+              let provider = decoded.anthropic else { return }
+
+        let perMillion = 1_000_000.0
+        var updated: [String: ClaudeModelPricing] = [:]
+
+        for (rawId, entry) in provider.models {
+            guard let cost = entry.cost else { continue }
+            let key = CostPricing.normalizeClaudeModel(rawId)
+
+            // Extract tier pricing when the first tier is a context-size threshold
+            let firstTier = cost.tiers?.first(where: { $0.tier?.type == "context" })
+            let thresholdTokens = firstTier?.tier?.size
+
+            updated[key] = ClaudeModelPricing(
+                inputPerToken: cost.input / perMillion,
+                outputPerToken: cost.output / perMillion,
+                cacheCreationPerToken: cost.cache_write / perMillion,
+                cacheReadPerToken: cost.cache_read / perMillion,
+                cacheCreation1hPerToken: nil,
+                thresholdTokens: thresholdTokens,
+                inputPerTokenAboveThreshold: firstTier.map { $0.input / perMillion },
+                outputPerTokenAboveThreshold: firstTier.map { $0.output / perMillion },
+                cacheCreationPerTokenAboveThreshold: firstTier.map { $0.cache_write / perMillion },
+                cacheReadPerTokenAboveThreshold: firstTier.map { $0.cache_read / perMillion })
+        }
+
+        guard isPlausibleRefresh(updated) else { return }
+        replaceTable(updated)
+    }
+
+    private func replaceTable(_ updated: [String: ClaudeModelPricing]) {
+        lock.lock(); defer { lock.unlock() }
+        table = updated
+    }
+
+    private func isPlausibleRefresh(_ candidate: [String: ClaudeModelPricing]) -> Bool {
+        let hasSonnet4 = candidate["claude-sonnet-4"] != nil
+        let hasOpus4Family = candidate.keys.contains(where: { $0.hasPrefix("claude-opus-4") })
+        return hasSonnet4 && hasOpus4Family
+    }
+}

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -1,0 +1,108 @@
+import Charts
+import SwiftUI
+
+enum CostStatFormatter {
+    private static let usdFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .currency
+        f.currencyCode = "USD"
+        f.currencySymbol = "$"
+        f.usesGroupingSeparator = true
+        f.minimumFractionDigits = 2
+        f.maximumFractionDigits = 2
+        return f
+    }()
+
+    static func tokens(_ n: Int) -> String {
+        switch n {
+        case 1_000_000_000...:
+            let v = Double(n) / 1_000_000_000
+            return "\(formatted(v))B"
+        case 1_000_000...:
+            let v = Double(n) / 1_000_000
+            return "\(formatted(v))M"
+        case 1_000...:
+            let v = Double(n) / 1_000
+            return "\(formatted(v))K"
+        default:
+            return "\(n)"
+        }
+    }
+
+    static func usd(_ amount: Double) -> String {
+        usdFormatter.string(from: NSNumber(value: amount)) ?? String(format: "$%.2f", amount)
+    }
+
+    private static func formatted(_ v: Double) -> String {
+        v.truncatingRemainder(dividingBy: 1) == 0
+            ? String(Int(v))
+            : String(format: "%.1f", v)
+    }
+}
+
+@MainActor
+struct CostDashboardView: View {
+    let store: CostHistoryStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let report = store.report {
+                statsGrid(report)
+                chart(report)
+                Text("est. API value · not billed on subscription")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                if report.entries.contains(where: { $0.requestCount > 0 && $0.pricedFraction < 1 }) {
+                    Text("Some models lack pricing — cost is partial")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            } else if store.isScanning {
+                ProgressView("Scanning usage…").font(.caption)
+            } else {
+                Text("No cost history yet").font(.caption).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder private func statsGrid(_ r: DailyCostReport) -> some View {
+        Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 8) {
+            GridRow {
+                stat("Today", CostStatFormatter.usd(r.todayCostUSD))
+                stat("30d cost", CostStatFormatter.usd(r.windowCostUSD))
+            }
+            GridRow {
+                stat("30d tokens", CostStatFormatter.tokens(r.windowTokens))
+                stat("Latest tokens", CostStatFormatter.tokens(r.latestTokens))
+            }
+        }
+        if let top = r.topModel {
+            Text("Top model: \(top)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func stat(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            Text(value).font(.title3.weight(.semibold))
+        }
+    }
+
+    @ViewBuilder private func chart(_ r: DailyCostReport) -> some View {
+        let maxCost = r.entries.map(\.costUSD).max() ?? 0
+        Chart(r.entries) { e in
+            BarMark(x: .value("Day", e.date, unit: .day), y: .value("Cost", e.costUSD))
+                .foregroundStyle(
+                    e.costUSD >= maxCost && maxCost > 0
+                        ? Color(nsColor: .systemYellow)
+                        : Color.secondary.opacity(0.7)
+                )
+        }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartLegend(.hidden)
+        .frame(height: 90)
+    }
+}

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -78,25 +78,24 @@ struct CostDashboardView: View {
     }
 
     @ViewBuilder private func statsRow(_ r: DailyCostReport) -> some View {
-        HStack(alignment: .top, spacing: 16) {
+        HStack(alignment: .top, spacing: 12) {
             stat("Today", CostStatFormatter.usd(r.todayCostUSD))
             stat("30d cost", CostStatFormatter.usd(r.windowCostUSD))
             stat("30d tokens", CostStatFormatter.tokens(r.windowTokens))
             stat("Latest tokens", CostStatFormatter.tokens(r.latestTokens))
             stat("Top model", r.topModel.map(CostStatFormatter.modelName) ?? "—")
-            Spacer(minLength: 0)
         }
     }
 
     private func stat(_ title: String, _ value: String) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(title).font(.caption2).foregroundStyle(TerminalColors.dimmedText)
-                .lineLimit(1)
+                .lineLimit(1).minimumScaleFactor(0.7)
             Text(value).font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(TerminalColors.primaryText)
-                .lineLimit(1)
+                .lineLimit(1).minimumScaleFactor(0.7)
         }
-        .fixedSize(horizontal: true, vertical: false)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder private func hoverDetail(_ r: DailyCostReport) -> some View {

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -39,20 +39,31 @@ enum CostStatFormatter {
             ? String(Int(v))
             : String(format: "%.1f", v)
     }
+
+    static func modelName(_ raw: String) -> String {
+        var s = raw
+        if let slash = s.lastIndex(of: "/") { s = String(s[s.index(after: slash)...]) }
+        if s.hasPrefix("claude-") { s.removeFirst("claude-".count) }
+        let parts = s.split(separator: "-").map(String.init)
+        guard let family = parts.first, !family.isEmpty else { return raw }
+        let name = family.prefix(1).uppercased() + family.dropFirst()
+        let version = parts.dropFirst().joined(separator: ".")
+        return version.isEmpty ? name : "\(name) \(version)"
+    }
 }
 
 @MainActor
 struct CostDashboardView: View {
     let store: CostHistoryStore
 
+    @State private var selected: DailyCostReport.DayEntry?
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 8) {
             if let report = store.report {
-                statsGrid(report)
+                statsRow(report)
+                hoverDetail(report)
                 chart(report)
-                Text("est. API value · not billed on subscription")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
                 if report.entries.contains(where: { $0.requestCount > 0 && $0.pricedFraction < 1 }) {
                     Text("Some models lack pricing — cost is partial")
                         .font(.caption2)
@@ -61,49 +72,93 @@ struct CostDashboardView: View {
             } else if store.isScanning {
                 ProgressView("Scanning usage…").font(.caption)
             } else {
-                Text("No cost history yet").font(.caption).foregroundStyle(.secondary)
+                Text("No cost history yet").font(.caption).foregroundStyle(TerminalColors.dimmedText)
             }
         }
     }
 
-    @ViewBuilder private func statsGrid(_ r: DailyCostReport) -> some View {
-        Grid(alignment: .leading, horizontalSpacing: 24, verticalSpacing: 8) {
-            GridRow {
-                stat("Today", CostStatFormatter.usd(r.todayCostUSD))
-                stat("30d cost", CostStatFormatter.usd(r.windowCostUSD))
-            }
-            GridRow {
-                stat("30d tokens", CostStatFormatter.tokens(r.windowTokens))
-                stat("Latest tokens", CostStatFormatter.tokens(r.latestTokens))
-            }
-        }
-        if let top = r.topModel {
-            Text("Top model: \(top)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+    @ViewBuilder private func statsRow(_ r: DailyCostReport) -> some View {
+        HStack(alignment: .top, spacing: 16) {
+            stat("Today", CostStatFormatter.usd(r.todayCostUSD))
+            stat("30d cost", CostStatFormatter.usd(r.windowCostUSD))
+            stat("30d tokens", CostStatFormatter.tokens(r.windowTokens))
+            stat("Latest tokens", CostStatFormatter.tokens(r.latestTokens))
+            stat("Top model", r.topModel.map(CostStatFormatter.modelName) ?? "—")
+            Spacer(minLength: 0)
         }
     }
 
     private func stat(_ title: String, _ value: String) -> some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(title).font(.caption).foregroundStyle(.secondary)
-            Text(value).font(.title3.weight(.semibold))
+            Text(title).font(.caption2).foregroundStyle(TerminalColors.dimmedText)
+                .lineLimit(1)
+            Text(value).font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(TerminalColors.primaryText)
+                .lineLimit(1)
         }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    @ViewBuilder private func hoverDetail(_ r: DailyCostReport) -> some View {
+        Text(selected.map { s in
+            "\(Self.dayFormatter.string(from: s.date)) · "
+                + "\(CostStatFormatter.usd(s.costUSD)) · "
+                + "\(CostStatFormatter.tokens(s.totalTokens)) tok"
+        } ?? " ")
+        .font(.caption2)
+        .foregroundStyle(TerminalColors.primaryText)
+        .lineLimit(1)
+    }
+
+    private static let barColor = Color(red: 0.85, green: 0.49, blue: 0.26)
+    private static let peakBarColor = Color(red: 0.97, green: 0.62, blue: 0.32)
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f
+    }()
+
+    private func barColor(for e: DailyCostReport.DayEntry, maxCost: Double) -> Color {
+        if let s = selected, s.id == e.id { return Self.peakBarColor }
+        if e.costUSD >= maxCost && maxCost > 0 { return Self.peakBarColor }
+        return Self.barColor
+    }
+
+    private func nearest(to date: Date, in entries: [DailyCostReport.DayEntry]) -> DailyCostReport.DayEntry? {
+        entries.min(by: {
+            abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date))
+        })
     }
 
     @ViewBuilder private func chart(_ r: DailyCostReport) -> some View {
         let maxCost = r.entries.map(\.costUSD).max() ?? 0
         Chart(r.entries) { e in
             BarMark(x: .value("Day", e.date, unit: .day), y: .value("Cost", e.costUSD))
-                .foregroundStyle(
-                    e.costUSD >= maxCost && maxCost > 0
-                        ? Color(nsColor: .systemYellow)
-                        : Color.secondary.opacity(0.7)
-                )
+                .foregroundStyle(barColor(for: e, maxCost: maxCost))
         }
         .chartXAxis(.hidden)
         .chartYAxis(.hidden)
         .chartLegend(.hidden)
         .frame(height: 90)
+        .chartOverlay { proxy in
+            GeometryReader { geo in
+                Rectangle()
+                    .fill(Color.clear)
+                    .contentShape(Rectangle())
+                    .onContinuousHover { phase in
+                        switch phase {
+                        case .active(let location):
+                            guard let plotFrame = proxy.plotFrame else { return }
+                            let x = location.x - geo[plotFrame].origin.x
+                            if let date: Date = proxy.value(atX: x) {
+                                selected = nearest(to: date, in: r.entries)
+                            }
+                        case .ended:
+                            selected = nil
+                        }
+                    }
+            }
+        }
     }
 }

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -5,6 +5,7 @@ enum CostStatFormatter {
     private static let usdFormatter: NumberFormatter = {
         let f = NumberFormatter()
         f.numberStyle = .currency
+        f.locale = Locale(identifier: "en_US")
         f.currencyCode = "USD"
         f.currencySymbol = "$"
         f.usesGroupingSeparator = true

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -433,26 +433,27 @@ struct ExpandedPanelView: View {
 
     @ViewBuilder
     private func usageDetailContent(geometry: GeometryProxy) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            if isActivityCollapsed {
-                Spacer()
-                    .allowsHitTesting(false)
-            } else {
-                Spacer()
-                    .frame(height: geometry.size.height * 0.3)
-                    .allowsHitTesting(false)
+        let headerClearance = isActivityCollapsed ? 8 : geometry.size.height * 0.3
+        VStack(spacing: 0) {
+            Spacer()
+                .frame(height: headerClearance)
+                .allowsHitTesting(false)
+
+            ScrollView(showsIndicators: false) {
+                UsageDetailView(
+                    claudeUsage: usageService,
+                    codexUsage: codexUsageService,
+                    costStore: CostHistoryStore.shared,
+                    defaultProvider: usageDetailDefaultProvider
+                )
+                .padding(.horizontal, 12)
+                .padding(.top, 8)
+                .padding(.bottom, 12)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
-
-            UsageDetailView(
-                claudeUsage: usageService,
-                codexUsage: codexUsageService,
-                defaultProvider: usageDetailDefaultProvider
-            )
-            .padding(.horizontal, 12)
-
-            Spacer(minLength: 0)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
-        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     @ViewBuilder

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -11,7 +11,7 @@ struct UsageDetailView: View {
     init(
         claudeUsage: ClaudeUsageService,
         codexUsage: CodexUsageService,
-        costStore: CostHistoryStore = .shared,
+        costStore: CostHistoryStore,
         defaultProvider: AgentProvider
     ) {
         self.claudeUsage = claudeUsage
@@ -80,8 +80,19 @@ struct UsageDetailView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 10) {
             header
+
+            switch resolvedProvider {
+            case .claude:
+                CostDashboardView(store: costStore)
+            case .codex:
+                Text("Cost history coming soon")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider().background(Color.white.opacity(0.08))
 
             ForEach(periods, id: \.title) { period in
                 UsagePeriodRowView(display: period)
@@ -93,17 +104,6 @@ struct UsageDetailView: View {
 
             if let codexCreditsUSD {
                 CodexCreditsRowView(remainingUSD: codexCreditsUSD)
-            }
-
-            Divider().background(Color.white.opacity(0.08))
-
-            switch resolvedProvider {
-            case .claude:
-                CostDashboardView(store: costStore)
-            case .codex:
-                Text("Cost history coming soon")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
         }
         .padding(.top, 8)

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct UsageDetailView: View {
     let claudeUsage: ClaudeUsageService
     let codexUsage: CodexUsageService
+    let costStore: CostHistoryStore
     let defaultProvider: AgentProvider
 
     @State private var selectedProvider: AgentProvider
@@ -10,10 +11,12 @@ struct UsageDetailView: View {
     init(
         claudeUsage: ClaudeUsageService,
         codexUsage: CodexUsageService,
+        costStore: CostHistoryStore = .shared,
         defaultProvider: AgentProvider
     ) {
         self.claudeUsage = claudeUsage
         self.codexUsage = codexUsage
+        self.costStore = costStore
         self.defaultProvider = defaultProvider
         _selectedProvider = State(initialValue: defaultProvider)
     }
@@ -90,6 +93,17 @@ struct UsageDetailView: View {
 
             if let codexCreditsUSD {
                 CodexCreditsRowView(remainingUSD: codexCreditsUSD)
+            }
+
+            Divider().background(Color.white.opacity(0.08))
+
+            switch resolvedProvider {
+            case .claude:
+                CostDashboardView(store: costStore)
+            case .codex:
+                Text("Cost history coming soon")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .padding(.top, 8)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -47,6 +47,7 @@ if [[ "$preset" == "focused" ]]; then
         "-only-testing:Tests/NotchPanelManagerTests"
         "-only-testing:Tests/UsageBarViewTests"
         "-only-testing:Tests/DailyCostReportTests"
+        "-only-testing:Tests/CostHistoryStoreTests"
         "-only-testing:Tests/ClaudeModelPricingTests"
     )
 fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -46,6 +46,7 @@ if [[ "$preset" == "focused" ]]; then
         "-only-testing:Tests/KeychainManagerTests"
         "-only-testing:Tests/NotchPanelManagerTests"
         "-only-testing:Tests/UsageBarViewTests"
+        "-only-testing:Tests/DailyCostReportTests"
     )
 fi
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -47,6 +47,7 @@ if [[ "$preset" == "focused" ]]; then
         "-only-testing:Tests/NotchPanelManagerTests"
         "-only-testing:Tests/UsageBarViewTests"
         "-only-testing:Tests/DailyCostReportTests"
+        "-only-testing:Tests/ClaudeModelPricingTests"
     )
 fi
 


### PR DESCRIPTION
## Summary
Adds a 30-day cost & token history dashboard to the expanded usage panel, derived locally from Claude Code transcripts — daily cost bars, headline stats (Today, 30d cost/tokens, latest tokens, top model), and per-day hover detail. Runs alongside the existing percentage-based usage (untouched).

## How it works
- **Scanner** (`ClaudeCostScanner`): incrementally parses `~/.claude/projects/**/*.jsonl` (byte-offset per file, skips unchanged via size+mtime, clean full rescan on truncation/deletion), extracts per-message token usage, dedups on `message.id` + `requestId`.
- **Pricing** (`CostPricing` / `PricingCatalog`): date-aware, per-message ≥200K context tier; sourced from **models.dev** (fetched + persisted to disk, overlaid on a slim embedded fallback). A pricing **signature** invalidates and re-prices the cache when prices change.
- **Store** (`CostHistoryStore`): `@MainActor @Observable`; scans **off the main actor** on a timer; the cost data layer is `nonisolated`.
- **UI** (`CostDashboardView`): SwiftUI Charts bar chart + headline grid, mounted in `UsageDetailView` under the Claude provider (Codex shows "coming soon").

## Notes
- Cost is a **notional API-equivalent estimate** — subscription users aren't billed per token.
- No new third-party dependencies.
- `nonisolated(unsafe) seen` (per-scan dedup) is race-free as used: the only `scan()` caller is the store, serialized by its `@MainActor` `isScanning` guard.

## Testing
- Unit tests: pricing (incl. threshold tier), dedup, incremental offset, **truncation double-count regression**, cache version/signature reset, signature determinism + sub-ULP float tolerance, models.dev snapshot round-trip, report derivation, stat formatters.
- Daily cost/tokens manually validated against `npx ccusage daily` — matched to the cent.
- Sandbox enumeration of `~/.claude/projects` verified on-device.

## Follow-ups (non-blocking)
- Truncation triggers an all-files rescan; a per-file reset would be tighter I/O.