### PR TITLE
fix(usage): keep usage enabled when reconnect fails with cached usage

### DIFF
--- a/notchi/Tests/ClaudeUsageServiceTests+TokenRecovery.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests+TokenRecovery.swift
@@ -81,6 +81,33 @@ extension ClaudeUsageServiceTests {
         XCTAssertFalse(AppSettings.isUsageEnabled)
     }
 
+    func testConnectAndStartPollingKeepsUsageEnabledWhenUsageIsVisible() async throws {
+        let scheduler = PollSchedulerSpy()
+        let dependencies = makeDependencies(
+            scheduler: scheduler,
+            resolveUserAgent: { "claude-code/2.1.77" },
+            getCachedOAuthToken: { _ in nil },
+            getOAuthCredentials: { _ in nil },
+            fetchUsage: { _ in
+                XCTFail("fetchUsage should not run without a token")
+                return (Data(), self.makeResponse(statusCode: 200))
+            }
+        )
+
+        let service = ClaudeUsageService(dependencies: dependencies)
+        service.currentUsage = makeQuotaPeriod(utilization: 42)
+        AppSettings.isUsageEnabled = true
+
+        service.connectAndStartPolling()
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertTrue(AppSettings.isUsageEnabled)
+        XCTAssertEqual(service.recoveryAction, .reconnect)
+        XCTAssertEqual(service.currentUsage?.usagePercentage, 42)
+        XCTAssertEqual(scheduler.intervals, [300])
+    }
+
     func testStartPollingPrefersEnvironmentTokenBeforeKeychainLookups() async throws {
         let scheduler = PollSchedulerSpy()
         var environmentTokenCalls = 0

--- a/notchi/notchi/Services/ClaudeUsageService.swift
+++ b/notchi/notchi/Services/ClaudeUsageService.swift
@@ -746,7 +746,11 @@ final class ClaudeUsageService {
                 prefersRecoveredCredentials: true
             ) else {
                 presentReconnectRequired(message: "Claude authentication needs attention.")
-                AppSettings.isUsageEnabled = false
+                if currentUsage != nil {
+                    scheduleSelfHealRetry()
+                } else {
+                    AppSettings.isUsageEnabled = false
+                }
                 return
             }
             cachedToken = resolution.token


### PR DESCRIPTION
## Summary
Second half of the sleep/wake usage-ring fix (follows #78).

`connectAndStartPolling` had the same anti-pattern that `startPolling` did: on a token-resolution failure it unconditionally set `AppSettings.isUsageEnabled = false`, which hides the collapsed-notch usage ring even when cached usage is present. A transient keychain blip during a manual reconnect/retry could therefore blank the ring.

## Change
Mirror the guard already in `startPolling` (#78): only disable usage when there is no cached usage (`currentUsage == nil`); otherwise keep it enabled, present the reconnect affordance, and schedule a self-heal retry. This closes the last copy of this path — both `isUsageEnabled = false` sites in `ClaudeUsageService` are now guarded.

## Testing
- New `testConnectAndStartPollingKeepsUsageEnabledWhenUsageIsVisible` (usage visible + no token → stays enabled, reconnect shown, self-heal scheduled).
- Existing no-usage connect test still asserts the disable path.
- `./scripts/test.sh` passes.