### PR TITLE
feat(cost): Codex cost & token history dashboard

### DIFF
--- a/notchi/Tests/CodexCostScannerTests.swift
+++ b/notchi/Tests/CodexCostScannerTests.swift
@@ -196,4 +196,41 @@ final class CodexCostScannerTests: XCTestCase {
                        "truncated file must trigger a clean full rescan, not double-count")
         XCTAssertEqual(secondCache.buckets["2026-06-24"]?["gpt-5"]?.input, 300)
     }
+
+    func testIncrementalScanPreservesModelAcrossWrites() throws {
+        let url = try writeFile([turnContextLine(model: "gpt-5.5")])
+        let root = url.deletingLastPathComponent().deletingLastPathComponent()
+        let s = scanner(root: root, pricing: Gpt55Price())
+        let first = s.scan(cache: emptyCache(), now: now())
+        XCTAssertNil(first.buckets["2026-06-24"]?["gpt-5.5"])
+
+        let fh = try FileHandle(forWritingTo: url); fh.seekToEndOfFile()
+        fh.write((tokenCountLine(lastUsage: (input: 1000, cached: 0, output: 500)) + "\n").data(using: .utf8)!)
+        try fh.close()
+        let second = s.scan(cache: first, now: now())
+
+        XCTAssertEqual(second.buckets["2026-06-24"]?["gpt-5.5"]?.input, 1000)
+        XCTAssertNil(second.buckets["2026-06-24"]?["gpt-5"],
+                     "model must persist across the scan boundary, not fall back to gpt-5")
+    }
+
+    func testIncrementalScanPreservesBaselineForTotalFallback() throws {
+        let url = try writeFile([
+            turnContextLine(model: "gpt-5"),
+            tokenCountLine(timestamp: "2026-06-24T12:00:00.000Z", lastUsage: nil, totalUsage: (input: 1000, cached: 0, output: 0)),
+        ])
+        let root = url.deletingLastPathComponent().deletingLastPathComponent()
+        let s = scanner(root: root)
+        let first = s.scan(cache: emptyCache(), now: now())
+        XCTAssertEqual(first.buckets["2026-06-24"]?["gpt-5"]?.input, 1000)
+
+        let fh = try FileHandle(forWritingTo: url); fh.seekToEndOfFile()
+        fh.write((tokenCountLine(timestamp: "2026-06-24T12:05:00.000Z", lastUsage: nil, totalUsage: (input: 1500, cached: 0, output: 0)) + "\n")
+            .data(using: .utf8)!)
+        try fh.close()
+        let second = s.scan(cache: first, now: now())
+
+        XCTAssertEqual(second.buckets["2026-06-24"]?["gpt-5"]?.input, 1500,
+                       "baseline must persist so the cumulative total yields a 500 delta, not 1500")
+    }
 }

--- a/notchi/Tests/CodexCostScannerTests.swift
+++ b/notchi/Tests/CodexCostScannerTests.swift
@@ -1,0 +1,199 @@
+import XCTest
+@testable import notchi
+
+final class CodexCostScannerTests: XCTestCase {
+    private struct FlatPrice: ClaudePricingProviding {
+        nonisolated func pricing(model: String, on date: Date) -> ClaudeModelPricing? {
+            ClaudeModelPricing(inputPerToken: 1e-6, outputPerToken: 1e-6,
+                cacheCreationPerToken: 0, cacheReadPerToken: 0, cacheCreation1hPerToken: nil,
+                thresholdTokens: nil, inputPerTokenAboveThreshold: nil,
+                outputPerTokenAboveThreshold: nil, cacheCreationPerTokenAboveThreshold: nil,
+                cacheReadPerTokenAboveThreshold: nil)
+        }
+    }
+
+    private struct Gpt55Price: ClaudePricingProviding {
+        nonisolated func pricing(model: String, on date: Date) -> ClaudeModelPricing? {
+            ClaudeModelPricing(inputPerToken: 5e-6, outputPerToken: 3e-5,
+                cacheCreationPerToken: 0, cacheReadPerToken: 5e-7, cacheCreation1hPerToken: nil,
+                thresholdTokens: 272000, inputPerTokenAboveThreshold: 1e-5,
+                outputPerTokenAboveThreshold: 4.5e-5, cacheCreationPerTokenAboveThreshold: 0,
+                cacheReadPerTokenAboveThreshold: 1e-6)
+        }
+    }
+
+    private func tokenCountLine(timestamp: String = "2026-06-24T12:00:00.000Z",
+                                 lastUsage: (input: Int, cached: Int, output: Int)?,
+                                 totalUsage: (input: Int, cached: Int, output: Int)? = nil) -> String {
+        var infoParts: [String] = []
+        if let l = lastUsage {
+            infoParts.append("""
+            "last_token_usage":{"input_tokens":\(l.input),"cached_input_tokens":\(l.cached),"output_tokens":\(l.output),"reasoning_output_tokens":0,"total_tokens":\(l.input + l.output)}
+            """)
+        }
+        if let t = totalUsage {
+            infoParts.append("""
+            "total_token_usage":{"input_tokens":\(t.input),"cached_input_tokens":\(t.cached),"output_tokens":\(t.output),"reasoning_output_tokens":0,"total_tokens":\(t.input + t.output)}
+            """)
+        }
+        let info = infoParts.joined(separator: ",")
+        return """
+        {"type":"event_msg","timestamp":"\(timestamp)","payload":{"type":"token_count","info":{\(info)}}}
+        """
+    }
+
+    private func turnContextLine(model: String, timestamp: String = "2026-06-24T11:00:00.000Z") -> String {
+        """
+        {"type":"turn_context","timestamp":"\(timestamp)","payload":{"model":"\(model)"}}
+        """
+    }
+
+    private func writeFile(_ lines: [String]) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("sessions").appendingPathComponent("s.jsonl")
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try (lines.joined(separator: "\n") + "\n").data(using: .utf8)!.write(to: url)
+        return url
+    }
+
+    private func scanner(root: URL, pricing: any ClaudePricingProviding = FlatPrice()) -> CodexCostScanner {
+        var cal = Calendar(identifier: .gregorian); cal.timeZone = TimeZone(identifier: "UTC")!
+        return CodexCostScanner(projectsRoots: [root], pricing: pricing, windowDays: 30, calendar: cal)
+    }
+
+    private func emptyCache() -> CostUsageCache {
+        CostUsageCache(version: CostUsageCache.currentVersion, files: [:], buckets: [:])
+    }
+
+    private func now() -> Date {
+        ISO8601DateFormatter().date(from: "2026-06-24T12:00:00Z")!
+    }
+
+    func testTwoLastUsageEventsSumIntoOneDay() throws {
+        let url = try writeFile([
+            tokenCountLine(lastUsage: (input: 300, cached: 0, output: 100)),
+            tokenCountLine(lastUsage: (input: 200, cached: 0, output: 50)),
+        ])
+        let root = url.deletingLastPathComponent().deletingLastPathComponent()
+        let s = scanner(root: root)
+        let out = s.scan(cache: emptyCache(), now: now())
+
+        let expectedInput = 500
+        let expectedOutput = 150
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.input, expectedInput)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.output, expectedOutput)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.requestCount, 2)
+    }
+
+    func testTokenMappingPartialCacheRead() throws {
+        let url = try writeFile([
+            tokenCountLine(lastUsage: (input: 1000, cached: 200, output: 500)),
+        ])
+        let root = url.deletingLastPathComponent().deletingLastPathComponent()
+        let s = scanner(root: root)
+        let out = s.scan(cache: emptyCache(), now: now())
+
+        let expectedInput = 800
+        let expectedCacheRead = 200
+        let expectedOutput = 500
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.input, expectedInput)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.cacheRead, expectedCacheRead)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.output, expectedOutput)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.cacheCreation, 0)
+    }
+
+    func testTotalUsageFallbackDeltaFromBaseline() throws {
+        let url = try writeFile([
+            tokenCountLine(lastUsage: nil, totalUsage: (input: 400, cached: 50, output: 200)),
+            tokenCountLine(lastUsage: nil, totalUsage: (input: 700, cached: 80, output: 350)),
+        ])
+        let root = url.deletingLastPathComponent().deletingLastPathComponent()
+        let s = scanner(root: root)
+        let out = s.scan(cache: emptyCache(), now: now())
+
+        let firstDeltaInput = 400 - 0
+        let firstDeltaCached = 50 - 0
+        let firstDeltaOutput = 200 - 0
+        let secondDeltaInput = 700 - 400
+        let secondDeltaCached = 80 - 50
+        let secondDeltaOutput = 350 - 200
+
+        let expectedInput = (firstDeltaInput - firstDeltaCached) + (secondDeltaInput - secondDeltaCached)
+        let expectedCacheRead = firstDeltaCached + secondDeltaCached
+        let expectedOutput = firstDeltaOutput + secondDeltaOutput
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.input, expectedInput)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.cacheRead, expectedCacheRead)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.output, expectedOutput)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.requestCount, 2)
+    }
+
+    func testDuplicateEventTupleCountedOnce() throws {
+        let sameLine = tokenCountLine(lastUsage: (input: 300, cached: 50, output: 100))
+        let url = try writeFile([sameLine, sameLine])
+        let root = url.deletingLastPathComponent().deletingLastPathComponent()
+        let s = scanner(root: root)
+        let out = s.scan(cache: emptyCache(), now: now())
+
+        let expectedInput = 250
+        let expectedCacheRead = 50
+        let expectedOutput = 100
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.input, expectedInput)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.cacheRead, expectedCacheRead)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.output, expectedOutput)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5"]?.requestCount, 1)
+    }
+
+    func testTurnContextModelDrivesNormalizedBucketKey() throws {
+        let url = try writeFile([
+            turnContextLine(model: "gpt-5.5"),
+            tokenCountLine(lastUsage: (input: 100, cached: 0, output: 50)),
+        ])
+        let root = url.deletingLastPathComponent().deletingLastPathComponent()
+        let s = scanner(root: root)
+        let out = s.scan(cache: emptyCache(), now: now())
+
+        XCTAssertNil(out.buckets["2026-06-24"]?["gpt-5"], "default model bucket must not exist")
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5.5"]?.requestCount, 1)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5.5"]?.input, 100)
+    }
+
+    func testGpt55CostPricedCorrectly() throws {
+        let url = try writeFile([
+            turnContextLine(model: "gpt-5.5"),
+            tokenCountLine(lastUsage: (input: 1000, cached: 200, output: 500)),
+        ])
+        let root = url.deletingLastPathComponent().deletingLastPathComponent()
+        let s = scanner(root: root, pricing: Gpt55Price())
+        let out = s.scan(cache: emptyCache(), now: now())
+
+        let mappedInput = 800
+        let mappedCacheRead = 200
+        let mappedOutput = 500
+        let expectedCostUSD = Double(mappedInput) * 5e-6
+            + Double(mappedCacheRead) * 5e-7
+            + Double(mappedOutput) * 3e-5
+        let expectedNanos = Int((expectedCostUSD * 1_000_000_000).rounded())
+
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5.5"]?.costNanos, expectedNanos)
+        XCTAssertEqual(out.buckets["2026-06-24"]?["gpt-5.5"]?.pricedCount, 1)
+    }
+
+    func testTruncatedFileFullyRescansWithoutDoubleCounting() throws {
+        let url = try writeFile([
+            tokenCountLine(timestamp: "2026-06-24T12:00:00.000Z", lastUsage: (input: 300, cached: 0, output: 100)),
+            tokenCountLine(timestamp: "2026-06-24T13:00:00.000Z", lastUsage: (input: 200, cached: 0, output: 50)),
+        ])
+        let root = url.deletingLastPathComponent().deletingLastPathComponent()
+        let s = scanner(root: root)
+        let firstCache = s.scan(cache: emptyCache(), now: now())
+        XCTAssertEqual(firstCache.buckets["2026-06-24"]?["gpt-5"]?.requestCount, 2)
+
+        try (tokenCountLine(timestamp: "2026-06-24T12:00:00.000Z", lastUsage: (input: 300, cached: 0, output: 100)) + "\n")
+            .data(using: .utf8)!.write(to: url)
+        let secondCache = s.scan(cache: firstCache, now: now())
+        XCTAssertEqual(secondCache.buckets["2026-06-24"]?["gpt-5"]?.requestCount, 1,
+                       "truncated file must trigger a clean full rescan, not double-count")
+        XCTAssertEqual(secondCache.buckets["2026-06-24"]?["gpt-5"]?.input, 300)
+    }
+}

--- a/notchi/Tests/CodexModelPricingTests.swift
+++ b/notchi/Tests/CodexModelPricingTests.swift
@@ -1,0 +1,160 @@
+import XCTest
+@testable import notchi
+
+final class CodexModelPricingTests: XCTestCase {
+
+    private let gpt55InputPerToken: Double = 5.0 / 1_000_000
+    private let gpt55OutputPerToken: Double = 30.0 / 1_000_000
+    private let gpt55CacheReadPerToken: Double = 0.5 / 1_000_000
+    private let gpt55InputAbove: Double = 10.0 / 1_000_000
+    private let gpt55OutputAbove: Double = 45.0 / 1_000_000
+    private let gpt55CacheReadAbove: Double = 1.0 / 1_000_000
+
+    private func gpt55Pricing() -> ClaudeModelPricing {
+        ClaudeModelPricing(
+            inputPerToken: gpt55InputPerToken,
+            outputPerToken: gpt55OutputPerToken,
+            cacheCreationPerToken: 0,
+            cacheReadPerToken: gpt55CacheReadPerToken,
+            cacheCreation1hPerToken: nil,
+            thresholdTokens: 272_000,
+            inputPerTokenAboveThreshold: gpt55InputAbove,
+            outputPerTokenAboveThreshold: gpt55OutputAbove,
+            cacheCreationPerTokenAboveThreshold: 0,
+            cacheReadPerTokenAboveThreshold: gpt55CacheReadAbove)
+    }
+
+    func testGpt55CostWithCachedInputBelowThreshold() {
+        let inputTokens = 100_000
+        let cachedInputTokens = 20_000
+        let outputTokens = 5_000
+
+        let billableInput = inputTokens - cachedInputTokens
+        let cost = CostPricing.claudeCostUSD(
+            model: "gpt-5.5",
+            input: billableInput,
+            cacheRead: cachedInputTokens,
+            cacheCreation: 0,
+            cacheCreation1h: 0,
+            output: outputTokens,
+            pricing: gpt55Pricing())
+
+        let expectedInputCost = Double(billableInput) * gpt55InputPerToken
+        let expectedCacheReadCost = Double(cachedInputTokens) * gpt55CacheReadPerToken
+        let expectedOutputCost = Double(outputTokens) * gpt55OutputPerToken
+        let expected = expectedInputCost + expectedCacheReadCost + expectedOutputCost
+
+        XCTAssertEqual(cost!, expected, accuracy: 1e-12)
+    }
+
+    func testGpt55CostAbove272KThresholdUsesAboveRates() {
+        let billableInput = 200_000
+        let cachedInput = 100_000
+        let outputTokens = 2_000
+
+        let cost = CostPricing.claudeCostUSD(
+            model: "gpt-5.5",
+            input: billableInput,
+            cacheRead: cachedInput,
+            cacheCreation: 0,
+            cacheCreation1h: 0,
+            output: outputTokens,
+            pricing: gpt55Pricing())
+
+        let expectedInputCost = Double(billableInput) * gpt55InputAbove
+        let expectedCacheReadCost = Double(cachedInput) * gpt55CacheReadAbove
+        let expectedOutputCost = Double(outputTokens) * gpt55OutputAbove
+        let expected = expectedInputCost + expectedCacheReadCost + expectedOutputCost
+
+        XCTAssertEqual(cost!, expected, accuracy: 1e-9)
+    }
+
+    func testNormalizeOpenAIModelStripsOpenAIPrefix() {
+        XCTAssertEqual(CostPricing.normalizeOpenAIModel("openai/gpt-5.5"), "gpt-5.5")
+        XCTAssertEqual(CostPricing.normalizeOpenAIModel("gpt-5.5"), "gpt-5.5")
+    }
+
+    func testNormalizeOpenAIModelStripsDateSuffix() {
+        XCTAssertEqual(CostPricing.normalizeOpenAIModel("gpt-5.5-2025-04-01"), "gpt-5.5")
+        XCTAssertEqual(CostPricing.normalizeOpenAIModel("openai/gpt-5.4-2025-03-15"), "gpt-5.4")
+    }
+
+    func testPlausibilityGuardAcceptsGpt5TableAndRejectsClaudeOnly() {
+        let anyPricing = ClaudeModelPricing(
+            inputPerToken: 5e-6, outputPerToken: 3e-5,
+            cacheCreationPerToken: 0, cacheReadPerToken: 5e-7,
+            cacheCreation1hPerToken: nil, thresholdTokens: nil,
+            inputPerTokenAboveThreshold: nil, outputPerTokenAboveThreshold: nil,
+            cacheCreationPerTokenAboveThreshold: nil, cacheReadPerTokenAboveThreshold: nil)
+
+        let gpt5Table = ["gpt-5": anyPricing, "gpt-5.5": anyPricing]
+        XCTAssertTrue(PricingCatalog.isPlausibleRefresh(gpt5Table, anchors: ["gpt-5"]))
+
+        let claudeTable = ["claude-sonnet-4": anyPricing, "claude-opus-4": anyPricing]
+        XCTAssertFalse(PricingCatalog.isPlausibleRefresh(claudeTable, anchors: ["gpt-5"]))
+
+        XCTAssertFalse(PricingCatalog.isPlausibleRefresh([:], anchors: ["gpt-5"]))
+    }
+
+    func testCodexCatalogFallbackLoadsFromBundle() {
+        let catalog = PricingCatalog(config: .codex, fallbackBundle: .main)
+        let p = catalog.pricing(model: "gpt-5.5", on: Date())
+        XCTAssertNotNil(p, "codex fallback must price gpt-5.5")
+        XCTAssertEqual(p!.inputPerToken, 5e-6, accuracy: 1e-15)
+    }
+
+    func testModelsDevOpenAIBranchDecodesGpt5xPricing() throws {
+        let json = """
+        {
+          "openai": {
+            "models": {
+              "gpt-5.5": {
+                "cost": {
+                  "input": 5.0,
+                  "output": 30.0,
+                  "cache_read": 0.5,
+                  "cache_write": 0.0
+                }
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let catalog = PricingCatalog(config: .codex, fallbackBundle: .main)
+        catalog.processNetworkData(json)
+
+        let p = catalog.pricing(model: "gpt-5.5", on: Date())
+        XCTAssertNotNil(p)
+        XCTAssertEqual(p!.inputPerToken, 5.0 / 1_000_000, accuracy: 1e-15)
+        XCTAssertEqual(p!.outputPerToken, 30.0 / 1_000_000, accuracy: 1e-15)
+        XCTAssertEqual(p!.cacheReadPerToken, 0.5 / 1_000_000, accuracy: 1e-15)
+    }
+
+    func testCodexGpt55ProCostBillsCachedInputAtInputRate() {
+        let catalog = PricingCatalog(config: .codex, fallbackBundle: .main)
+        let p = catalog.pricing(model: "gpt-5.5-pro", on: Date())
+        XCTAssertNotNil(p, "codex fallback must price gpt-5.5-pro")
+
+        let gpt55ProInputPerToken: Double = 30.0 / 1_000_000
+        let gpt55ProOutputPerToken: Double = 180.0 / 1_000_000
+        let freshInputTokens = 6_000
+        let cachedInputTokens = 4_000
+        let outputTokens = 2_000
+
+        let cost = CostPricing.claudeCostUSD(
+            model: "gpt-5.5-pro",
+            input: freshInputTokens,
+            cacheRead: cachedInputTokens,
+            cacheCreation: 0,
+            cacheCreation1h: 0,
+            output: outputTokens,
+            pricing: p!)
+
+        let expected = Double(freshInputTokens) * gpt55ProInputPerToken
+            + Double(cachedInputTokens) * gpt55ProInputPerToken
+            + Double(outputTokens) * gpt55ProOutputPerToken
+
+        XCTAssertEqual(cost!, expected, accuracy: 1e-12)
+    }
+}

--- a/notchi/Tests/DailyCostReportTests.swift
+++ b/notchi/Tests/DailyCostReportTests.swift
@@ -15,6 +15,25 @@ final class CostHistoryStoreTests: XCTestCase {
         XCTAssertEqual(store.report?.topModel, "claude-opus-4")
         XCTAssertFalse(store.isScanning)
     }
+
+    @MainActor
+    func testRefreshStampsConfiguredProviderOnReport() async {
+        let buckets: DayModelBuckets = [
+            "2026-06-25": ["gpt-5.5": ModelTokenTotals(input: 100, output: 50, costNanos: 1_000,
+                                                       requestCount: 1, pricedCount: 1)]
+        ]
+        let store = CostHistoryStore(windowDays: 7, calendar: .current, provider: .codex,
+            scanProvider: { _ in buckets })
+        await store.refresh()
+        XCTAssertEqual(store.report?.provider, .codex)
+    }
+
+    @MainActor
+    func testRefreshDefaultsToClaudeProvider() async {
+        let store = CostHistoryStore(windowDays: 7, calendar: .current, scanProvider: { _ in [:] })
+        await store.refresh()
+        XCTAssertEqual(store.report?.provider, .claude)
+    }
 }
 
 final class DailyCostReportTests: XCTestCase {

--- a/notchi/notchi/AppDelegate.swift
+++ b/notchi/notchi/AppDelegate.swift
@@ -64,6 +64,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
             await ClaudeUsageService.shared.startPolling()
             await CodexUsageService.shared.refreshFromAPI()
             await CostHistoryStore.shared.start()
+            await CostHistoryStore.sharedCodex.start()
         }
     }
 

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -87,6 +87,7 @@ struct NotchContentView: View {
     var stateMachine: NotchiStateMachine = .shared
     var panelManager: NotchPanelManager = .shared
     var usageService: ClaudeUsageService = .shared
+    var codexUsageService: CodexUsageService = .shared
     var haptics: HapticService = .shared
     @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @ObservedObject private var updateManager = UpdateManager.shared
@@ -300,10 +301,18 @@ struct NotchContentView: View {
         max(0, notchSize.height - 12) + 24
     }
 
+    private var ringProvider: AgentProvider {
+        activeSession?.provider ?? .claude
+    }
+
+    private var ringIsStale: Bool {
+        ringProvider == .codex ? codexUsageService.isUsageStale : usageService.isUsageStale
+    }
+
     private var usageRingPercentage: Int? {
-        guard AppSettings.isUsageEnabled,
-              let usage = usageService.currentUsage else { return nil }
-        return usage.usagePercentage
+        guard AppSettings.isUsageEnabled else { return nil }
+        let usage = ringProvider == .codex ? codexUsageService.currentUsage : usageService.currentUsage
+        return usage?.usagePercentage
     }
 
     private var compactContentWidth: CGFloat {
@@ -638,7 +647,7 @@ struct NotchContentView: View {
     private func ringSlot(side: NotchSide) -> some View {
         let _ = logRingState(side: side)
         if let usageRingPercentage, !isLaunchWaveActive {
-            UsageRingView(percentage: usageRingPercentage, isStale: usageService.isUsageStale)
+            UsageRingView(percentage: usageRingPercentage, isStale: ringIsStale)
                 .opacity(collapsedHeaderSpriteVisuals.opacity)
                 .animation(collapsedHeaderSpriteVisibilityAnimation, value: isExpanded)
                 .frame(width: sideWidth)

--- a/notchi/notchi/Resources/codex-pricing-fallback.json
+++ b/notchi/notchi/Resources/codex-pricing-fallback.json
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "models": {
+    "gpt-5": {
+      "inputPerToken": 0.00000125,
+      "outputPerToken": 0.00001,
+      "cacheCreationPerToken": 0,
+      "cacheReadPerToken": 0.000000125
+    },
+    "gpt-5-codex": {
+      "inputPerToken": 0.00000125,
+      "outputPerToken": 0.00001,
+      "cacheCreationPerToken": 0,
+      "cacheReadPerToken": 0.000000125
+    },
+    "gpt-5-mini": {
+      "inputPerToken": 0.00000025,
+      "outputPerToken": 0.000002,
+      "cacheCreationPerToken": 0,
+      "cacheReadPerToken": 0.000000025
+    },
+    "gpt-5.3-codex": {
+      "inputPerToken": 0.00000175,
+      "outputPerToken": 0.000014,
+      "cacheCreationPerToken": 0,
+      "cacheReadPerToken": 0.000000175
+    },
+    "gpt-5.4": {
+      "inputPerToken": 0.0000025,
+      "outputPerToken": 0.000015,
+      "cacheCreationPerToken": 0,
+      "cacheReadPerToken": 0.00000025,
+      "thresholdTokens": 272000,
+      "inputPerTokenAboveThreshold": 0.000005,
+      "outputPerTokenAboveThreshold": 0.0000225,
+      "cacheCreationPerTokenAboveThreshold": 0,
+      "cacheReadPerTokenAboveThreshold": 0.0000005
+    },
+    "gpt-5.4-mini": {
+      "inputPerToken": 0.00000075,
+      "outputPerToken": 0.0000045,
+      "cacheCreationPerToken": 0,
+      "cacheReadPerToken": 0.000000075
+    },
+    "gpt-5.5": {
+      "inputPerToken": 0.000005,
+      "outputPerToken": 0.00003,
+      "cacheCreationPerToken": 0,
+      "cacheReadPerToken": 0.0000005,
+      "thresholdTokens": 272000,
+      "inputPerTokenAboveThreshold": 0.00001,
+      "outputPerTokenAboveThreshold": 0.000045,
+      "cacheCreationPerTokenAboveThreshold": 0,
+      "cacheReadPerTokenAboveThreshold": 0.000001
+    },
+    "gpt-5.5-pro": {
+      "inputPerToken": 0.00003,
+      "outputPerToken": 0.00018,
+      "cacheCreationPerToken": 0,
+      "cacheReadPerToken": 0.00003
+    }
+  }
+}

--- a/notchi/notchi/Services/Cost/ClaudeModelPricing.swift
+++ b/notchi/notchi/Services/Cost/ClaudeModelPricing.swift
@@ -25,6 +25,13 @@ nonisolated enum CostPricing {
         return s
     }
 
+    static func normalizeOpenAIModel(_ raw: String) -> String {
+        var s = raw
+        if s.hasPrefix("openai/") { s = String(s.dropFirst("openai/".count)) }
+        if let r = s.range(of: #"-\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) { s.removeSubrange(r) }
+        return s
+    }
+
     static func claudeCostUSD(
         model: String, input: Int, cacheRead: Int, cacheCreation: Int,
         cacheCreation1h: Int, output: Int, pricing: ClaudeModelPricing) -> Double?

--- a/notchi/notchi/Services/Cost/CodexCostScanner.swift
+++ b/notchi/notchi/Services/Cost/CodexCostScanner.swift
@@ -6,15 +6,6 @@ nonisolated final class CodexCostScanner {
     let windowDays: Int
     let calendar: Calendar
 
-    nonisolated(unsafe) private var seen = Set<String>()
-
-    nonisolated(unsafe) private let isoFractional: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return f
-    }()
-    nonisolated(unsafe) private let isoPlain = ISO8601DateFormatter()
-
     nonisolated init(projectsRoots: [URL], pricing: any ClaudePricingProviding, windowDays: Int, calendar: Calendar) {
         self.projectsRoots = projectsRoots
         self.pricing = pricing
@@ -25,7 +16,6 @@ nonisolated final class CodexCostScanner {
     nonisolated deinit {}
 
     nonisolated func scan(cache input: CostUsageCache, now: Date) -> CostUsageCache {
-        seen.removeAll()
         var cache = input
         if anyTrackedFileShrank(cache.files) {
             cache.files = [:]
@@ -34,6 +24,11 @@ nonisolated final class CodexCostScanner {
         let windowStart = calendar.date(byAdding: .day, value: -(windowDays - 1),
                                         to: calendar.startOfDay(for: now))!
         let sinceKey = DailyCostReport.dayKey(windowStart, calendar: calendar)
+
+        let isoFractional = ISO8601DateFormatter()
+        isoFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let isoPlain = ISO8601DateFormatter()
+        var seen = Set<String>()
 
         for root in projectsRoots {
             guard let en = FileManager.default.enumerator(
@@ -46,8 +41,13 @@ nonisolated final class CodexCostScanner {
                 var state = cache.files[path] ?? .init(size: 0, mtime: 0, offset: 0)
                 if state.size == size, state.mtime == mtime { continue }
                 let startOffset = (size >= state.size) ? state.offset : 0
+                let resume = startOffset > 0 ? state.codexResume : nil
 
-                state.offset = parseFile(url: url, startOffset: startOffset, sinceKey: sinceKey, into: &cache.buckets)
+                let result = parseFile(url: url, startOffset: startOffset, sinceKey: sinceKey, resume: resume,
+                                       seen: &seen, isoFractional: isoFractional, isoPlain: isoPlain,
+                                       into: &cache.buckets)
+                state.offset = result.offset
+                state.codexResume = result.resume
                 state.size = size
                 state.mtime = mtime
                 cache.files[path] = state
@@ -66,34 +66,54 @@ nonisolated final class CodexCostScanner {
     }
 
     nonisolated private func parseFile(url: URL, startOffset: Int64, sinceKey: String,
-                                       into buckets: inout DayModelBuckets) -> Int64 {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return startOffset }
+                                       resume: CostUsageCache.CodexResume?,
+                                       seen: inout Set<String>,
+                                       isoFractional: ISO8601DateFormatter, isoPlain: ISO8601DateFormatter,
+                                       into buckets: inout DayModelBuckets) -> (offset: Int64, resume: CostUsageCache.CodexResume) {
+        var currentModel = resume?.model
+        var runningBaseline: (input: Int, cached: Int, output: Int)?
+        if let i = resume?.baseInput, let c = resume?.baseCached, let o = resume?.baseOutput {
+            runningBaseline = (i, c, o)
+        }
+
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            return (startOffset, resumeState(currentModel, runningBaseline))
+        }
         defer { try? handle.close() }
         if startOffset > 0 { try? handle.seek(toOffset: UInt64(startOffset)) }
-        guard let data = try? handle.readToEnd(), !data.isEmpty else { return startOffset }
+        guard let data = try? handle.readToEnd(), !data.isEmpty else {
+            return (startOffset, resumeState(currentModel, runningBaseline))
+        }
 
         var consumed = startOffset
         var lineStart = data.startIndex
         let newline = UInt8(ascii: "\n")
         var i = data.startIndex
-        var currentModel: String? = nil
-        var runningBaseline: (input: Int, cached: Int, output: Int)? = nil
         while i < data.endIndex {
             if data[i] == newline {
                 let lineData = data[lineStart..<i]
                 consumed += Int64(lineData.count) + 1
                 handleLine(lineData, sinceKey: sinceKey, currentModel: &currentModel,
-                           runningBaseline: &runningBaseline, into: &buckets)
+                           runningBaseline: &runningBaseline, seen: &seen,
+                           isoFractional: isoFractional, isoPlain: isoPlain, into: &buckets)
                 lineStart = data.index(after: i)
             }
             i = data.index(after: i)
         }
-        return consumed
+        return (consumed, resumeState(currentModel, runningBaseline))
+    }
+
+    nonisolated private func resumeState(_ model: String?,
+                                         _ baseline: (input: Int, cached: Int, output: Int)?) -> CostUsageCache.CodexResume {
+        CostUsageCache.CodexResume(model: model, baseInput: baseline?.input,
+                                   baseCached: baseline?.cached, baseOutput: baseline?.output)
     }
 
     nonisolated private func handleLine(_ lineData: Data, sinceKey: String,
                                         currentModel: inout String?,
                                         runningBaseline: inout (input: Int, cached: Int, output: Int)?,
+                                        seen: inout Set<String>,
+                                        isoFractional: ISO8601DateFormatter, isoPlain: ISO8601DateFormatter,
                                         into buckets: inout DayModelBuckets) {
         guard lineData.range(of: Data(#""token_count""#.utf8)) != nil
             || lineData.range(of: Data(#""turn_context""#.utf8)) != nil else { return }
@@ -112,7 +132,7 @@ nonisolated final class CodexCostScanner {
               let payload = obj["payload"] as? [String: Any],
               payload["type"] as? String == "token_count",
               let ts = obj["timestamp"] as? String,
-              let date = parseTimestamp(ts) else { return }
+              let date = parseTimestamp(ts, isoFractional: isoFractional, isoPlain: isoPlain) else { return }
 
         let dayKey = DailyCostReport.dayKey(date, calendar: calendar)
         guard dayKey >= sinceKey else { return }
@@ -171,7 +191,8 @@ nonisolated final class CodexCostScanner {
 
     nonisolated private func intval(_ v: Any?) -> Int { (v as? NSNumber)?.intValue ?? 0 }
 
-    nonisolated private func parseTimestamp(_ s: String) -> Date? {
+    nonisolated private func parseTimestamp(_ s: String, isoFractional: ISO8601DateFormatter,
+                                            isoPlain: ISO8601DateFormatter) -> Date? {
         isoFractional.date(from: s) ?? isoPlain.date(from: s)
     }
 }

--- a/notchi/notchi/Services/Cost/CodexCostScanner.swift
+++ b/notchi/notchi/Services/Cost/CodexCostScanner.swift
@@ -95,7 +95,8 @@ nonisolated final class CodexCostScanner {
                                         currentModel: inout String?,
                                         runningBaseline: inout (input: Int, cached: Int, output: Int)?,
                                         into buckets: inout DayModelBuckets) {
-        guard lineData.range(of: Data(#""type""#.utf8)) != nil else { return }
+        guard lineData.range(of: Data(#""token_count""#.utf8)) != nil
+            || lineData.range(of: Data(#""turn_context""#.utf8)) != nil else { return }
         guard let obj = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any],
               let type_ = obj["type"] as? String else { return }
 

--- a/notchi/notchi/Services/Cost/CodexCostScanner.swift
+++ b/notchi/notchi/Services/Cost/CodexCostScanner.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+nonisolated final class CodexCostScanner {
+    let projectsRoots: [URL]
+    let pricing: any ClaudePricingProviding
+    let windowDays: Int
+    let calendar: Calendar
+
+    nonisolated(unsafe) private var seen = Set<String>()
+
+    nonisolated(unsafe) private let isoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    nonisolated(unsafe) private let isoPlain = ISO8601DateFormatter()
+
+    nonisolated init(projectsRoots: [URL], pricing: any ClaudePricingProviding, windowDays: Int, calendar: Calendar) {
+        self.projectsRoots = projectsRoots
+        self.pricing = pricing
+        self.windowDays = windowDays
+        self.calendar = calendar
+    }
+
+    nonisolated deinit {}
+
+    nonisolated func scan(cache input: CostUsageCache, now: Date) -> CostUsageCache {
+        seen.removeAll()
+        var cache = input
+        if anyTrackedFileShrank(cache.files) {
+            cache.files = [:]
+            cache.buckets = [:]
+        }
+        let windowStart = calendar.date(byAdding: .day, value: -(windowDays - 1),
+                                        to: calendar.startOfDay(for: now))!
+        let sinceKey = DailyCostReport.dayKey(windowStart, calendar: calendar)
+
+        for root in projectsRoots {
+            guard let en = FileManager.default.enumerator(
+                at: root, includingPropertiesForKeys: [.fileSizeKey, .contentModificationDateKey]) else { continue }
+            for case let url as URL in en where url.pathExtension == "jsonl" {
+                let path = url.path
+                let attrs = try? FileManager.default.attributesOfItem(atPath: path)
+                let size = (attrs?[.size] as? NSNumber)?.int64Value ?? 0
+                let mtime = ((attrs?[.modificationDate] as? Date)?.timeIntervalSince1970) ?? 0
+                var state = cache.files[path] ?? .init(size: 0, mtime: 0, offset: 0)
+                if state.size == size, state.mtime == mtime { continue }
+                let startOffset = (size >= state.size) ? state.offset : 0
+
+                state.offset = parseFile(url: url, startOffset: startOffset, sinceKey: sinceKey, into: &cache.buckets)
+                state.size = size
+                state.mtime = mtime
+                cache.files[path] = state
+            }
+        }
+        cache.buckets = cache.buckets.filter { $0.key >= sinceKey }
+        return cache
+    }
+
+    nonisolated private func anyTrackedFileShrank(_ files: [String: CostUsageCache.FileState]) -> Bool {
+        for (path, state) in files {
+            let size = ((try? FileManager.default.attributesOfItem(atPath: path))?[.size] as? NSNumber)?.int64Value ?? 0
+            if size < state.size { return true }
+        }
+        return false
+    }
+
+    nonisolated private func parseFile(url: URL, startOffset: Int64, sinceKey: String,
+                                       into buckets: inout DayModelBuckets) -> Int64 {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return startOffset }
+        defer { try? handle.close() }
+        if startOffset > 0 { try? handle.seek(toOffset: UInt64(startOffset)) }
+        guard let data = try? handle.readToEnd(), !data.isEmpty else { return startOffset }
+
+        var consumed = startOffset
+        var lineStart = data.startIndex
+        let newline = UInt8(ascii: "\n")
+        var i = data.startIndex
+        var currentModel: String? = nil
+        var runningBaseline: (input: Int, cached: Int, output: Int)? = nil
+        while i < data.endIndex {
+            if data[i] == newline {
+                let lineData = data[lineStart..<i]
+                consumed += Int64(lineData.count) + 1
+                handleLine(lineData, sinceKey: sinceKey, currentModel: &currentModel,
+                           runningBaseline: &runningBaseline, into: &buckets)
+                lineStart = data.index(after: i)
+            }
+            i = data.index(after: i)
+        }
+        return consumed
+    }
+
+    nonisolated private func handleLine(_ lineData: Data, sinceKey: String,
+                                        currentModel: inout String?,
+                                        runningBaseline: inout (input: Int, cached: Int, output: Int)?,
+                                        into buckets: inout DayModelBuckets) {
+        guard lineData.range(of: Data(#""type""#.utf8)) != nil else { return }
+        guard let obj = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any],
+              let type_ = obj["type"] as? String else { return }
+
+        if type_ == "turn_context" {
+            if let payload = obj["payload"] as? [String: Any],
+               let model = payload["model"] as? String {
+                currentModel = model
+            }
+            return
+        }
+
+        guard type_ == "event_msg",
+              let payload = obj["payload"] as? [String: Any],
+              payload["type"] as? String == "token_count",
+              let ts = obj["timestamp"] as? String,
+              let date = parseTimestamp(ts) else { return }
+
+        let dayKey = DailyCostReport.dayKey(date, calendar: calendar)
+        guard dayKey >= sinceKey else { return }
+
+        guard let info = payload["info"] as? [String: Any] else { return }
+        let last = info["last_token_usage"] as? [String: Any]
+        let total = info["total_token_usage"] as? [String: Any]
+
+        let delta: (input: Int, cached: Int, output: Int)
+        if let last {
+            delta = (intval(last["input_tokens"]), intval(last["cached_input_tokens"]), intval(last["output_tokens"]))
+        } else if let total {
+            let totalTuple = (intval(total["input_tokens"]), intval(total["cached_input_tokens"]), intval(total["output_tokens"]))
+            if let baseline = runningBaseline {
+                delta = (
+                    max(0, totalTuple.0 - baseline.input),
+                    max(0, totalTuple.1 - baseline.cached),
+                    max(0, totalTuple.2 - baseline.output)
+                )
+            } else {
+                delta = totalTuple
+            }
+        } else {
+            return
+        }
+
+        if let total {
+            runningBaseline = (intval(total["input_tokens"]), intval(total["cached_input_tokens"]), intval(total["output_tokens"]))
+        }
+
+        if delta.input == 0, delta.cached == 0, delta.output == 0 { return }
+
+        let rawModel = currentModel ?? "gpt-5"
+        let normalizedModel = CostPricing.normalizeOpenAIModel(rawModel)
+        let cached = min(delta.cached, delta.input)
+        let mappedInput = delta.input - cached
+        let mappedCacheRead = cached
+        let mappedOutput = delta.output
+
+        let dedupKey = "\(ts)|\(normalizedModel)|\(delta.input)|\(delta.cached)|\(delta.output)"
+        if !seen.insert(dedupKey).inserted { return }
+
+        let pricingResult = pricing.pricing(model: rawModel, on: date)
+        let cost = pricingResult.map {
+            CostPricing.claudeCostUSD(model: rawModel, input: mappedInput, cacheRead: mappedCacheRead,
+                cacheCreation: 0, cacheCreation1h: 0, output: mappedOutput, pricing: $0)
+        } ?? nil
+        let nanos = cost.map { Int(($0 * 1_000_000_000).rounded()) } ?? 0
+
+        var dayModels = buckets[dayKey] ?? [:]
+        dayModels[normalizedModel] = (dayModels[normalizedModel] ?? ModelTokenTotals()) + ModelTokenTotals(
+            input: mappedInput, cacheRead: mappedCacheRead, cacheCreation: 0, cacheCreation1h: 0,
+            output: mappedOutput, costNanos: nanos, requestCount: 1, pricedCount: cost == nil ? 0 : 1)
+        buckets[dayKey] = dayModels
+    }
+
+    nonisolated private func intval(_ v: Any?) -> Int { (v as? NSNumber)?.intValue ?? 0 }
+
+    nonisolated private func parseTimestamp(_ s: String) -> Date? {
+        isoFractional.date(from: s) ?? isoPlain.date(from: s)
+    }
+}

--- a/notchi/notchi/Services/Cost/CostHistoryStore.swift
+++ b/notchi/notchi/Services/Cost/CostHistoryStore.swift
@@ -10,34 +10,33 @@ final class CostHistoryStore {
 
     private let windowDays: Int
     private let calendar: Calendar
+    private let provider: CostProvider
     private let scanProvider: @Sendable (Date) async -> DayModelBuckets
     private var timer: Timer?
     private let refreshInterval: TimeInterval = 90
     private let pricingCatalog: PricingCatalog?
 
-    init(windowDays: Int = 30, calendar: Calendar = .current,
+    init(windowDays: Int = 30, calendar: Calendar = .current, provider: CostProvider = .claude,
          scanProvider: @escaping @Sendable (Date) async -> DayModelBuckets) {
         self.windowDays = windowDays
         self.calendar = calendar
+        self.provider = provider
         self.scanProvider = scanProvider
         self.pricingCatalog = nil
     }
 
     convenience init(windowDays: Int = 30, calendar: Calendar = .current,
+                     provider: CostProvider = .claude,
                      pricing: PricingCatalog,
                      projectsRoots: [URL],
                      cacheURL: URL) {
-        let scanner = ClaudeCostScanner(
-            projectsRoots: projectsRoots,
-            pricing: pricing,
-            windowDays: windowDays,
-            calendar: calendar)
-
-        self.init(windowDays: windowDays, calendar: calendar, pricingCatalog: pricing) { now in
+        let scan = Self.makeScan(provider: provider, projectsRoots: projectsRoots,
+                                 pricing: pricing, windowDays: windowDays, calendar: calendar)
+        self.init(windowDays: windowDays, calendar: calendar, provider: provider, pricingCatalog: pricing) { now in
             await Task.detached(priority: .utility) {
                 let sig = pricing.signature()
                 let cache = CostUsageCacheStore.load(url: cacheURL).reconciled(withPricingSignature: sig)
-                var updated = scanner.scan(cache: cache, now: now)
+                var updated = scan(cache, now)
                 updated.pricingSignature = sig
                 CostUsageCacheStore.save(updated, to: cacheURL)
                 return updated.buckets
@@ -45,10 +44,25 @@ final class CostHistoryStore {
         }
     }
 
-    private init(windowDays: Int, calendar: Calendar, pricingCatalog: PricingCatalog,
+    private static func makeScan(provider: CostProvider, projectsRoots: [URL], pricing: PricingCatalog,
+                                 windowDays: Int, calendar: Calendar) -> @Sendable (CostUsageCache, Date) -> CostUsageCache {
+        switch provider {
+        case .claude:
+            let scanner = ClaudeCostScanner(projectsRoots: projectsRoots, pricing: pricing,
+                                            windowDays: windowDays, calendar: calendar)
+            return { scanner.scan(cache: $0, now: $1) }
+        case .codex:
+            let scanner = CodexCostScanner(projectsRoots: projectsRoots, pricing: pricing,
+                                           windowDays: windowDays, calendar: calendar)
+            return { scanner.scan(cache: $0, now: $1) }
+        }
+    }
+
+    private init(windowDays: Int, calendar: Calendar, provider: CostProvider, pricingCatalog: PricingCatalog,
                  scanProvider: @escaping @Sendable (Date) async -> DayModelBuckets) {
         self.windowDays = windowDays
         self.calendar = calendar
+        self.provider = provider
         self.scanProvider = scanProvider
         self.pricingCatalog = pricingCatalog
     }
@@ -73,27 +87,40 @@ final class CostHistoryStore {
         let windowStart = calendar.date(byAdding: .day, value: -(windowDays - 1),
                                         to: calendar.startOfDay(for: now))!
         report = DailyCostReport.make(
-            provider: .claude, buckets: buckets,
+            provider: provider, buckets: buckets,
             windowStart: windowStart, today: now, calendar: calendar)
         lastScan = now
     }
 }
 
-// MARK: - Shared singleton
+// MARK: - Shared singletons
 
 extension CostHistoryStore {
-    static let shared: CostHistoryStore = {
-        let pricing = PricingCatalog(fallbackBundle: .main,
-                                     snapshotURL: PricingCatalog.defaultSnapshotURL())
-        let projectsRoot = URL(fileURLWithPath: NSHomeDirectory())
-            .appendingPathComponent(".claude/projects", isDirectory: true)
-        let cacheURL: URL
+    static let shared = makeStore(
+        provider: .claude, config: .claude,
+        projectsRoots: [homeURL(".claude/projects")], cacheFile: "claude.json")
+
+    static let sharedCodex = makeStore(
+        provider: .codex, config: .codex,
+        projectsRoots: [homeURL(".codex/sessions"), homeURL(".codex/archived_sessions")],
+        cacheFile: "codex.json")
+
+    private static func homeURL(_ sub: String) -> URL {
+        URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(sub, isDirectory: true)
+    }
+
+    private static func cacheURL(_ file: String) -> URL {
         if let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
-            cacheURL = cachesDir.appendingPathComponent("CostUsage/claude.json")
-        } else {
-            cacheURL = URL(fileURLWithPath: NSHomeDirectory())
-                .appendingPathComponent(".notchi/CostUsage/claude.json")
+            return cachesDir.appendingPathComponent("CostUsage/\(file)")
         }
-        return CostHistoryStore(pricing: pricing, projectsRoots: [projectsRoot], cacheURL: cacheURL)
-    }()
+        return URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".notchi/CostUsage/\(file)")
+    }
+
+    private static func makeStore(provider: CostProvider, config: ProviderConfig,
+                                  projectsRoots: [URL], cacheFile: String) -> CostHistoryStore {
+        let pricing = PricingCatalog(config: config, fallbackBundle: .main,
+                                     snapshotURL: PricingCatalog.defaultSnapshotURL(for: config))
+        return CostHistoryStore(provider: provider, pricing: pricing,
+                                projectsRoots: projectsRoots, cacheURL: cacheURL(cacheFile))
+    }
 }

--- a/notchi/notchi/Services/Cost/CostUsageCache.swift
+++ b/notchi/notchi/Services/Cost/CostUsageCache.swift
@@ -1,10 +1,18 @@
 import Foundation
 
 nonisolated struct CostUsageCache: Codable, Equatable {
+    nonisolated struct CodexResume: Codable, Equatable {
+        var model: String?
+        var baseInput: Int?
+        var baseCached: Int?
+        var baseOutput: Int?
+    }
+
     nonisolated struct FileState: Codable, Equatable {
         var size: Int64
         var mtime: Double
         var offset: Int64
+        var codexResume: CodexResume? = nil
     }
 
     static let currentVersion = 1

--- a/notchi/notchi/Services/Cost/PricingCatalog.swift
+++ b/notchi/notchi/Services/Cost/PricingCatalog.swift
@@ -1,5 +1,29 @@
 import Foundation
 
+nonisolated struct ProviderConfig: Sendable {
+    let fallbackResource: String
+    let modelsDevKey: ModelsDevKey
+    let plausibilityAnchors: [String]
+    let normalize: @Sendable (String) -> String
+    let snapshotFileName: String
+
+    enum ModelsDevKey: Sendable { case anthropic, openai }
+
+    static let claude = ProviderConfig(
+        fallbackResource: "claude-pricing-fallback",
+        modelsDevKey: .anthropic,
+        plausibilityAnchors: ["claude-sonnet-4", "claude-opus-4"],
+        normalize: CostPricing.normalizeClaudeModel,
+        snapshotFileName: "models-dev.json")
+
+    static let codex = ProviderConfig(
+        fallbackResource: "codex-pricing-fallback",
+        modelsDevKey: .openai,
+        plausibilityAnchors: ["gpt-5"],
+        normalize: CostPricing.normalizeOpenAIModel,
+        snapshotFileName: "models-dev-openai.json")
+}
+
 nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Sendable {
     private struct Snapshot: Codable {
         let version: Int
@@ -48,6 +72,7 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
 
     private struct ModelsDev: Decodable {
         let anthropic: ModelsDev.Provider?
+        let openai: ModelsDev.Provider?
 
         struct Provider: Decodable {
             let models: [String: ModelsDev.ModelEntry]
@@ -82,9 +107,11 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
     private let lock = NSLock()
     private var table: [String: ClaudeModelPricing]
     private let snapshotURL: URL?
+    private let config: ProviderConfig
 
-    init(fallbackBundle: Bundle, snapshotURL: URL? = nil) {
-        table = Self.loadFallback(bundle: fallbackBundle)
+    init(config: ProviderConfig = .claude, fallbackBundle: Bundle, snapshotURL: URL? = nil) {
+        self.config = config
+        table = Self.loadFallback(bundle: fallbackBundle, config: config)
         if let url = snapshotURL, let overlay = Self.loadSnapshot(url: url) {
             table.merge(overlay) { _, new in new }
         }
@@ -92,12 +119,13 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
     }
 
     init(table: [String: ClaudeModelPricing]) {
+        self.config = .claude
         self.table = table
         self.snapshotURL = nil
     }
 
-    private static func loadFallback(bundle: Bundle) -> [String: ClaudeModelPricing] {
-        guard let url = bundle.url(forResource: "claude-pricing-fallback", withExtension: "json"),
+    private static func loadFallback(bundle: Bundle, config: ProviderConfig) -> [String: ClaudeModelPricing] {
+        guard let url = bundle.url(forResource: config.fallbackResource, withExtension: "json"),
               let data = try? Data(contentsOf: url),
               let snap = try? JSONDecoder().decode(Snapshot.self, from: data)
         else { return [:] }
@@ -116,8 +144,13 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
             .appendingPathComponent("CostUsage/models-dev.json")
     }
 
+    static func defaultSnapshotURL(for config: ProviderConfig) -> URL? {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("CostUsage/\(config.snapshotFileName)")
+    }
+
     func pricing(model: String, on date: Date) -> ClaudeModelPricing? {
-        let key = CostPricing.normalizeClaudeModel(model)
+        let key = config.normalize(model)
         lock.lock(); defer { lock.unlock() }
         return table[key]
     }
@@ -125,15 +158,24 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
     func refreshFromNetwork() async {
         guard let url = URL(string: "https://models.dev/api.json") else { return }
         guard let (data, _) = try? await URLSession.shared.data(from: url) else { return }
-        guard let decoded = try? JSONDecoder().decode(ModelsDev.self, from: data),
-              let provider = decoded.anthropic else { return }
+        processNetworkData(data)
+    }
+
+    func processNetworkData(_ data: Data) {
+        guard let decoded = try? JSONDecoder().decode(ModelsDev.self, from: data) else { return }
+        let provider: ModelsDev.Provider?
+        switch config.modelsDevKey {
+        case .anthropic: provider = decoded.anthropic
+        case .openai: provider = decoded.openai
+        }
+        guard let provider else { return }
 
         let perMillion = 1_000_000.0
         var updated: [String: ClaudeModelPricing] = [:]
 
         for (rawId, entry) in provider.models {
             guard let cost = entry.cost else { continue }
-            let key = CostPricing.normalizeClaudeModel(rawId)
+            let key = config.normalize(rawId)
 
             let firstTier = cost.tiers?.first(where: { $0.tier?.type == "context" })
             let thresholdTokens = firstTier?.tier?.size
@@ -151,7 +193,7 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
                 cacheReadPerTokenAboveThreshold: firstTier.map { $0.cache_read / perMillion })
         }
 
-        guard Self.isPlausibleRefresh(updated) else { return }
+        guard Self.isPlausibleRefresh(updated, anchors: config.plausibilityAnchors) else { return }
         persistSnapshot(mergeIntoTable(updated))
     }
 
@@ -195,8 +237,10 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
     }
 
     static func isPlausibleRefresh(_ candidate: [String: ClaudeModelPricing]) -> Bool {
-        let hasSonnet4Family = candidate.keys.contains(where: { $0.hasPrefix("claude-sonnet-4") })
-        let hasOpus4Family = candidate.keys.contains(where: { $0.hasPrefix("claude-opus-4") })
-        return hasSonnet4Family && hasOpus4Family
+        isPlausibleRefresh(candidate, anchors: ProviderConfig.claude.plausibilityAnchors)
+    }
+
+    static func isPlausibleRefresh(_ candidate: [String: ClaudeModelPricing], anchors: [String]) -> Bool {
+        anchors.allSatisfy { anchor in candidate.keys.contains(where: { $0.hasPrefix(anchor) }) }
     }
 }

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -110,13 +110,12 @@ struct CostDashboardView: View {
         .lineLimit(1)
     }
 
-    private static let claudeBar = Color(red: 0.85, green: 0.49, blue: 0.26)
-    private static let claudePeak = Color(red: 0.97, green: 0.62, blue: 0.32)
-    private static let codexBar = Color(red: 0.18, green: 0.64, blue: 0.52)
-    private static let codexPeak = Color(red: 0.30, green: 0.80, blue: 0.66)
-
-    private func accent(_ provider: CostProvider) -> Color { provider == .codex ? Self.codexBar : Self.claudeBar }
-    private func peak(_ provider: CostProvider) -> Color { provider == .codex ? Self.codexPeak : Self.claudePeak }
+    private func accent(_ provider: CostProvider) -> Color {
+        provider == .codex ? TerminalColors.codexAccentDeep : TerminalColors.claudeOrangeDeep
+    }
+    private func peak(_ provider: CostProvider) -> Color {
+        provider == .codex ? TerminalColors.codexAccent : TerminalColors.claudeOrange
+    }
 
     private static let dayFormatter: DateFormatter = {
         let f = DateFormatter()

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -43,6 +43,7 @@ enum CostStatFormatter {
     static func modelName(_ raw: String) -> String {
         var s = raw
         if let slash = s.lastIndex(of: "/") { s = String(s[s.index(after: slash)...]) }
+        if s.lowercased().hasPrefix("gpt") { return "GPT" + s.dropFirst(3) }
         if s.hasPrefix("claude-") { s.removeFirst("claude-".count) }
         let parts = s.split(separator: "-").map(String.init)
         guard let family = parts.first, !family.isEmpty else { return raw }
@@ -109,8 +110,13 @@ struct CostDashboardView: View {
         .lineLimit(1)
     }
 
-    private static let barColor = Color(red: 0.85, green: 0.49, blue: 0.26)
-    private static let peakBarColor = Color(red: 0.97, green: 0.62, blue: 0.32)
+    private static let claudeBar = Color(red: 0.85, green: 0.49, blue: 0.26)
+    private static let claudePeak = Color(red: 0.97, green: 0.62, blue: 0.32)
+    private static let codexBar = Color(red: 0.18, green: 0.64, blue: 0.52)
+    private static let codexPeak = Color(red: 0.30, green: 0.80, blue: 0.66)
+
+    private func accent(_ provider: CostProvider) -> Color { provider == .codex ? Self.codexBar : Self.claudeBar }
+    private func peak(_ provider: CostProvider) -> Color { provider == .codex ? Self.codexPeak : Self.claudePeak }
 
     private static let dayFormatter: DateFormatter = {
         let f = DateFormatter()
@@ -118,10 +124,10 @@ struct CostDashboardView: View {
         return f
     }()
 
-    private func barColor(for e: DailyCostReport.DayEntry, maxCost: Double) -> Color {
-        if let s = selected, s.id == e.id { return Self.peakBarColor }
-        if e.costUSD >= maxCost && maxCost > 0 { return Self.peakBarColor }
-        return Self.barColor
+    private func barColor(for e: DailyCostReport.DayEntry, maxCost: Double, provider: CostProvider) -> Color {
+        if let s = selected, s.id == e.id { return peak(provider) }
+        if e.costUSD >= maxCost && maxCost > 0 { return peak(provider) }
+        return accent(provider)
     }
 
     private func nearest(to date: Date, in entries: [DailyCostReport.DayEntry]) -> DailyCostReport.DayEntry? {
@@ -134,7 +140,7 @@ struct CostDashboardView: View {
         let maxCost = r.entries.map(\.costUSD).max() ?? 0
         Chart(r.entries) { e in
             BarMark(x: .value("Day", e.date, unit: .day), y: .value("Cost", e.costUSD))
-                .foregroundStyle(barColor(for: e, maxCost: maxCost))
+                .foregroundStyle(barColor(for: e, maxCost: maxCost, provider: r.provider))
         }
         .chartXAxis(.hidden)
         .chartYAxis(.hidden)

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -444,6 +444,7 @@ struct ExpandedPanelView: View {
                     claudeUsage: usageService,
                     codexUsage: codexUsageService,
                     costStore: CostHistoryStore.shared,
+                    codexCostStore: CostHistoryStore.sharedCodex,
                     defaultProvider: usageDetailDefaultProvider
                 )
                 .padding(.horizontal, 12)

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -4,6 +4,7 @@ struct UsageDetailView: View {
     let claudeUsage: ClaudeUsageService
     let codexUsage: CodexUsageService
     let costStore: CostHistoryStore
+    let codexCostStore: CostHistoryStore
     let defaultProvider: AgentProvider
 
     @State private var selectedProvider: AgentProvider
@@ -12,11 +13,13 @@ struct UsageDetailView: View {
         claudeUsage: ClaudeUsageService,
         codexUsage: CodexUsageService,
         costStore: CostHistoryStore,
+        codexCostStore: CostHistoryStore,
         defaultProvider: AgentProvider
     ) {
         self.claudeUsage = claudeUsage
         self.codexUsage = codexUsage
         self.costStore = costStore
+        self.codexCostStore = codexCostStore
         self.defaultProvider = defaultProvider
         _selectedProvider = State(initialValue: defaultProvider)
     }
@@ -87,9 +90,7 @@ struct UsageDetailView: View {
             case .claude:
                 CostDashboardView(store: costStore)
             case .codex:
-                Text("Cost history coming soon")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                CostDashboardView(store: codexCostStore)
             }
 
             Divider().background(Color.white.opacity(0.08))


### PR DESCRIPTION
## Summary
Extends the cost & token history dashboard to a second provider, **Codex (OpenAI)**, reading local `~/.codex/sessions/**/*.jsonl` transcripts — mirroring the Claude dashboard on the Codex side of the usage-detail toggle. Algorithm cross-checked against CodexBar and ccusage (which agree), and validated against an independent reimplementation over real data to the cent.

## How it works
- **Scanner** (`CodexCostScanner`): incrementally parses `~/.codex/sessions` (+ `archived_sessions`), tracks the model from `turn_context`, and reads `event_msg`/`token_count` events — using `last_token_usage` as the per-turn delta with a `total_token_usage` baseline to recover/guard against double-counting, skipping zero deltas, and deduping replayed fork/resume history.
- **Token mapping**: `cached_input_tokens` (⊆ input) → billed as `input − cached` at input rate + `cached` at cache-read rate; `reasoning_output_tokens` already inside `output_tokens` (not billed separately). This reuses `claudeCostUSD` verbatim — the 272K context tier gates on full Codex input.
- **Pricing**: `PricingCatalog` generalized via a provider config (`anthropic`/`openai` models.dev branch, per-provider fallback resource + plausibility anchors). New `codex-pricing-fallback.json` (gpt-5 family, incl. 272K tiers); live prices from models.dev (openai).
- **Store/UI**: `CostHistoryStore` gains a `provider` field + `sharedCodex` factory (`CostUsage/codex.json`); `UsageDetailView`'s Codex tab now renders the dashboard; chart uses the app's real provider tokens (`codexAccent`/`claudeOrange`).

## Also fixed
- **Notch usage ring is now provider-aware** — it read percentage + stale flag only from the Claude service, so the ring dimmed as "stale" whenever Claude was inactive even while Codex was the active session. Now resolves the active provider and reads from the matching service.

## Testing
- Unit tests: Codex pricing (cached + 272K tier, normalize, plausibility, models.dev openai decode, bundle fallback), scanner (delta/baseline, token mapping, dedup, truncation, model tracking, cost), store provider stamping.
- Data validated against an independent reimplementation over real `~/.codex` data (matched to the cent; top model gpt-5.5).

## Notes
- Cost is a notional API-equivalent estimate. No new dependencies.