### PR TITLE
fix(usage): model-scoped weekly limits and usage panel overhaul

### DIFF
--- a/notchi/Tests/ClaudeUsageServiceTests+Polling.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests+Polling.swift
@@ -20,7 +20,7 @@ extension ClaudeUsageServiceTests {
         XCTAssertEqual(service.currentWeeklyUsage?.usagePercentage, 58)
     }
 
-    func testSuccessfulFetchPublishesSonnetUsageFromSevenDaySonnet() async throws {
+    func testSuccessfulFetchPublishesModelUsageFromSevenDaySonnet() async throws {
         let dependencies = makeDependencies(
             scheduler: PollSchedulerSpy(),
             resolveUserAgent: { "claude-code/2.1.77" },
@@ -33,10 +33,85 @@ extension ClaudeUsageServiceTests {
 
         await service.performFetch(with: "token")
 
-        XCTAssertEqual(service.currentSonnetUsage?.usagePercentage, 22)
+        XCTAssertEqual(service.currentModelUsage?.usagePercentage, 22)
+        XCTAssertEqual(service.currentModelUsageName, "Sonnet")
     }
 
-    func testSuccessfulFetchWithoutSevenDaySonnetLeavesSonnetUsageNil() async throws {
+    func testSuccessfulFetchPublishesModelUsageFromScopedWeeklyLimit() async throws {
+        let dependencies = makeDependencies(
+            scheduler: PollSchedulerSpy(),
+            resolveUserAgent: { "claude-code/2.1.77" },
+            fetchUsage: { _ in
+                (
+                    self.makeSuccessPayload(
+                        utilization: 42,
+                        weeklyUtilization: 58,
+                        scopedWeeklyLimit: (modelName: "Fable", percent: 59)
+                    ),
+                    self.makeResponse(statusCode: 200)
+                )
+            }
+        )
+
+        let service = ClaudeUsageService(dependencies: dependencies)
+
+        await service.performFetch(with: "token")
+
+        XCTAssertEqual(service.currentModelUsage?.usagePercentage, 59)
+        XCTAssertEqual(service.currentModelUsageName, "Fable")
+    }
+
+    func testSevenDayOpusTakesPrecedenceOverSevenDaySonnet() async throws {
+        let dependencies = makeDependencies(
+            scheduler: PollSchedulerSpy(),
+            resolveUserAgent: { "claude-code/2.1.77" },
+            fetchUsage: { _ in
+                (
+                    self.makeSuccessPayload(
+                        utilization: 42,
+                        weeklyUtilization: 58,
+                        sonnetUtilization: 22,
+                        opusUtilization: 31
+                    ),
+                    self.makeResponse(statusCode: 200)
+                )
+            }
+        )
+
+        let service = ClaudeUsageService(dependencies: dependencies)
+
+        await service.performFetch(with: "token")
+
+        XCTAssertEqual(service.currentModelUsage?.usagePercentage, 31)
+        XCTAssertEqual(service.currentModelUsageName, "Opus")
+    }
+
+    func testScopedWeeklyLimitTakesPrecedenceOverSevenDaySonnet() async throws {
+        let dependencies = makeDependencies(
+            scheduler: PollSchedulerSpy(),
+            resolveUserAgent: { "claude-code/2.1.77" },
+            fetchUsage: { _ in
+                (
+                    self.makeSuccessPayload(
+                        utilization: 42,
+                        weeklyUtilization: 58,
+                        sonnetUtilization: 22,
+                        scopedWeeklyLimit: (modelName: "Fable", percent: 59)
+                    ),
+                    self.makeResponse(statusCode: 200)
+                )
+            }
+        )
+
+        let service = ClaudeUsageService(dependencies: dependencies)
+
+        await service.performFetch(with: "token")
+
+        XCTAssertEqual(service.currentModelUsage?.usagePercentage, 59)
+        XCTAssertEqual(service.currentModelUsageName, "Fable")
+    }
+
+    func testSuccessfulFetchWithoutModelBucketLeavesModelUsageNil() async throws {
         let dependencies = makeDependencies(
             scheduler: PollSchedulerSpy(),
             resolveUserAgent: { "claude-code/2.1.77" },
@@ -49,7 +124,8 @@ extension ClaudeUsageServiceTests {
 
         await service.performFetch(with: "token")
 
-        XCTAssertNil(service.currentSonnetUsage)
+        XCTAssertNil(service.currentModelUsage)
+        XCTAssertNil(service.currentModelUsageName)
     }
 
     func testSuccessfulFetchWithoutSevenDayLeavesWeeklyUsageNil() async throws {

--- a/notchi/Tests/ClaudeUsageServiceTests.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests.swift
@@ -200,6 +200,8 @@ final class ClaudeUsageServiceTests: XCTestCase {
         weeklyUtilization: Double? = nil,
         weeklyResetAt: String = "2099-01-08T01:00:00Z",
         sonnetUtilization: Double? = nil,
+        opusUtilization: Double? = nil,
+        scopedWeeklyLimit: (modelName: String, percent: Double)? = nil,
         extraUsage: ExtraUsage? = nil
     ) -> Data {
         var payload: [String: Any] = [
@@ -214,6 +216,39 @@ final class ClaudeUsageServiceTests: XCTestCase {
 
         if let sonnetUtilization {
             payload["seven_day_sonnet"] = ["utilization": sonnetUtilization]
+        }
+
+        if let opusUtilization {
+            payload["seven_day_opus"] = ["utilization": opusUtilization]
+        }
+
+        if let scopedWeeklyLimit {
+            payload["limits"] = [
+                [
+                    "kind": "session",
+                    "percent": utilization,
+                    "resets_at": resetAt,
+                    "scope": NSNull(),
+                ],
+                [
+                    "kind": "weekly_all",
+                    "percent": weeklyUtilization ?? 0,
+                    "resets_at": weeklyResetAt,
+                    "scope": NSNull(),
+                ],
+                [
+                    "kind": "weekly_scoped",
+                    "percent": scopedWeeklyLimit.percent,
+                    "resets_at": weeklyResetAt,
+                    "scope": [
+                        "model": [
+                            "id": NSNull(),
+                            "display_name": scopedWeeklyLimit.modelName,
+                        ],
+                        "surface": NSNull(),
+                    ],
+                ] as [String: Any],
+            ]
         }
 
         if let extraUsage {
@@ -240,7 +275,8 @@ final class ClaudeUsageServiceTests: XCTestCase {
         isHeadersFallbackActive: Bool = false,
         lastGoodUsage: QuotaPeriod? = nil,
         lastGoodWeeklyUsage: QuotaPeriod? = nil,
-        lastGoodSonnetUsage: QuotaPeriod? = nil,
+        lastGoodModelUsage: QuotaPeriod? = nil,
+        lastGoodModelUsageName: String? = nil,
         lastGoodExtraUsage: ExtraUsage? = nil,
         lastObservedExtraUsageCredits: Double? = nil,
         extraUsageResetMarker: String? = nil,
@@ -252,7 +288,8 @@ final class ClaudeUsageServiceTests: XCTestCase {
             isHeadersFallbackActive: isHeadersFallbackActive,
             lastGoodUsage: lastGoodUsage,
             lastGoodWeeklyUsage: lastGoodWeeklyUsage,
-            lastGoodSonnetUsage: lastGoodSonnetUsage,
+            lastGoodModelUsage: lastGoodModelUsage,
+            lastGoodModelUsageName: lastGoodModelUsageName,
             lastGoodExtraUsage: lastGoodExtraUsage,
             lastObservedExtraUsageCredits: lastObservedExtraUsageCredits,
             extraUsageResetMarker: extraUsageResetMarker,

--- a/notchi/Tests/UsageDisplayTests.swift
+++ b/notchi/Tests/UsageDisplayTests.swift
@@ -84,19 +84,19 @@ final class UsageDisplayTests: XCTestCase {
         let usage = QuotaPeriod(utilization: 10, resetDate: futureReset)
         let extra = ExtraUsage(isEnabled: true, monthlyLimit: 20, usedCredits: 5, utilization: nil)
 
-        XCTAssertTrue(UsageMetrics.claudeHasData(usage: usage, weeklyUsage: nil, sonnetUsage: nil, extraUsage: nil))
-        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: usage, sonnetUsage: nil, extraUsage: nil))
-        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, sonnetUsage: nil, extraUsage: extra))
+        XCTAssertTrue(UsageMetrics.claudeHasData(usage: usage, weeklyUsage: nil, modelUsage: nil, extraUsage: nil))
+        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: usage, modelUsage: nil, extraUsage: nil))
+        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, modelUsage: nil, extraUsage: extra))
     }
 
-    func testClaudeHasDataTrueForSonnetOnlyData() {
-        let sonnet = QuotaPeriod(utilization: 0, resetDate: nil)
-        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, sonnetUsage: sonnet, extraUsage: nil))
+    func testClaudeHasDataTrueForModelOnlyData() {
+        let model = QuotaPeriod(utilization: 0, resetDate: nil)
+        XCTAssertTrue(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, modelUsage: model, extraUsage: nil))
     }
 
     func testClaudeHasDataFalseWhenNoUsableData() {
         let disabledExtra = ExtraUsage(isEnabled: false, monthlyLimit: 20, usedCredits: 5, utilization: nil)
-        XCTAssertFalse(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, sonnetUsage: nil, extraUsage: disabledExtra))
+        XCTAssertFalse(UsageMetrics.claudeHasData(usage: nil, weeklyUsage: nil, modelUsage: nil, extraUsage: disabledExtra))
     }
 
     func testCodexHasDataReflectsPeriodPresence() {

--- a/notchi/notchi/Models/UsageDisplay.swift
+++ b/notchi/notchi/Models/UsageDisplay.swift
@@ -29,8 +29,8 @@ nonisolated enum UsageMetrics {
         )
     }
 
-    static func claudeHasData(usage: QuotaPeriod?, weeklyUsage: QuotaPeriod?, sonnetUsage: QuotaPeriod?, extraUsage: ExtraUsage?) -> Bool {
-        usage != nil || weeklyUsage != nil || sonnetUsage != nil || extraUsageDisplay(extraUsage) != nil
+    static func claudeHasData(usage: QuotaPeriod?, weeklyUsage: QuotaPeriod?, modelUsage: QuotaPeriod?, extraUsage: ExtraUsage?) -> Bool {
+        usage != nil || weeklyUsage != nil || modelUsage != nil || extraUsageDisplay(extraUsage) != nil
     }
 
     static func codexHasData(usage: QuotaPeriod?, weeklyUsage: QuotaPeriod?) -> Bool {

--- a/notchi/notchi/Models/UsageQuota.swift
+++ b/notchi/notchi/Models/UsageQuota.swift
@@ -3,14 +3,58 @@ import Foundation
 nonisolated struct UsageResponse: Decodable {
     let fiveHour: QuotaPeriod?
     let sevenDay: QuotaPeriod?
+    let sevenDayOpus: QuotaPeriod?
     let sevenDaySonnet: QuotaPeriod?
     let extraUsage: ExtraUsage?
+    let limits: [UsageLimitEntry]?
 
     enum CodingKeys: String, CodingKey {
         case fiveHour = "five_hour"
         case sevenDay = "seven_day"
+        case sevenDayOpus = "seven_day_opus"
         case sevenDaySonnet = "seven_day_sonnet"
         case extraUsage = "extra_usage"
+        case limits
+    }
+
+    var modelWeekly: (name: String, period: QuotaPeriod)? {
+        if let entry = limits?.first(where: { $0.kind == "weekly_scoped" && $0.scope?.model != nil }) {
+            let name = entry.scope?.model?.displayName ?? "Model"
+            return (name, QuotaPeriod(utilization: entry.percent, resetsAt: entry.resetsAt))
+        }
+        if let sevenDayOpus {
+            return ("Opus", sevenDayOpus)
+        }
+        if let sevenDaySonnet {
+            return ("Sonnet", sevenDaySonnet)
+        }
+        return nil
+    }
+}
+
+nonisolated struct UsageLimitEntry: Decodable {
+    let kind: String
+    let percent: Double
+    let resetsAt: String?
+    let scope: Scope?
+
+    struct Scope: Decodable {
+        let model: Model?
+
+        struct Model: Decodable {
+            let displayName: String?
+
+            enum CodingKeys: String, CodingKey {
+                case displayName = "display_name"
+            }
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case percent
+        case resetsAt = "resets_at"
+        case scope
     }
 }
 

--- a/notchi/notchi/Services/ClaudeUsageService.swift
+++ b/notchi/notchi/Services/ClaudeUsageService.swift
@@ -21,7 +21,8 @@ struct ClaudeUsageRecoverySnapshot: Codable, Equatable {
     let isHeadersFallbackActive: Bool
     let lastGoodUsage: QuotaPeriod?
     let lastGoodWeeklyUsage: QuotaPeriod?
-    let lastGoodSonnetUsage: QuotaPeriod?
+    let lastGoodModelUsage: QuotaPeriod?
+    let lastGoodModelUsageName: String?
     let lastGoodExtraUsage: ExtraUsage?
     let lastObservedExtraUsageCredits: Double?
     let extraUsageResetMarker: String?
@@ -684,7 +685,8 @@ final class ClaudeUsageService {
 
     var currentUsage: QuotaPeriod?
     var currentWeeklyUsage: QuotaPeriod?
-    var currentSonnetUsage: QuotaPeriod?
+    var currentModelUsage: QuotaPeriod?
+    var currentModelUsageName: String?
     var currentExtraUsage: ExtraUsage?
     var isUsingExtraUsage = false
     var isLoading = false
@@ -1282,7 +1284,9 @@ final class ClaudeUsageService {
             clearTransientState()
             currentUsage = usageResponse.fiveHour
             currentWeeklyUsage = usageResponse.sevenDay
-            currentSonnetUsage = usageResponse.sevenDaySonnet
+            let modelWeekly = usageResponse.modelWeekly
+            currentModelUsage = modelWeekly?.period
+            currentModelUsageName = modelWeekly?.name
             lastObservedAt = usageResponse.fiveHour == nil ? nil : dependencies.now()
             reconcileExtraUsageState(
                 with: usageResponse.extraUsage,
@@ -1889,7 +1893,8 @@ final class ClaudeUsageService {
         guard isUsageStillValid(currentUsage, now: now) else {
             currentUsage = nil
             currentWeeklyUsage = nil
-            currentSonnetUsage = nil
+            currentModelUsage = nil
+            currentModelUsageName = nil
             clearOAuthBackoffState()
             presentRetryableIssue(
                 noUsageMessage: "No rate limit headers, retrying in \(Int(pollInterval))s",
@@ -1922,7 +1927,8 @@ final class ClaudeUsageService {
 
         currentUsage = isUsageStillValid(snapshot.lastGoodUsage, now: now) ? snapshot.lastGoodUsage : nil
         currentWeeklyUsage = isUsageStillValid(snapshot.lastGoodWeeklyUsage, now: now) ? snapshot.lastGoodWeeklyUsage : nil
-        currentSonnetUsage = isUsageStillValid(snapshot.lastGoodSonnetUsage, now: now) ? snapshot.lastGoodSonnetUsage : nil
+        currentModelUsage = isUsageStillValid(snapshot.lastGoodModelUsage, now: now) ? snapshot.lastGoodModelUsage : nil
+        currentModelUsageName = currentModelUsage == nil ? nil : snapshot.lastGoodModelUsageName
         lastObservedAt = currentUsage == nil ? nil : now
         currentExtraUsage = snapshot.lastGoodExtraUsage
         lastObservedExtraUsageCredits = snapshot.lastObservedExtraUsageCredits
@@ -1972,14 +1978,15 @@ final class ClaudeUsageService {
         let now = dependencies.now()
         let usageToPersist = isUsageStillValid(currentUsage, now: now) ? currentUsage : nil
         let weeklyToPersist = isUsageStillValid(currentWeeklyUsage, now: now) ? currentWeeklyUsage : nil
-        let sonnetToPersist = isUsageStillValid(currentSonnetUsage, now: now) ? currentSonnetUsage : nil
+        let modelToPersist = isUsageStillValid(currentModelUsage, now: now) ? currentModelUsage : nil
         return ClaudeUsageRecoverySnapshot(
             oauthBackoffUntil: oauthBackoffUntil,
             oauthHeadersFallbackProbeUntil: oauthHeadersFallbackProbeUntil,
             isHeadersFallbackActive: isHeadersFallbackActive,
             lastGoodUsage: usageToPersist,
             lastGoodWeeklyUsage: weeklyToPersist,
-            lastGoodSonnetUsage: sonnetToPersist,
+            lastGoodModelUsage: modelToPersist,
+            lastGoodModelUsageName: modelToPersist == nil ? nil : currentModelUsageName,
             lastGoodExtraUsage: currentExtraUsage,
             lastObservedExtraUsageCredits: lastObservedExtraUsageCredits,
             extraUsageResetMarker: extraUsageResetMarker,

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -139,7 +139,7 @@ struct CostDashboardView: View {
 
     private func stat(_ title: String, _ value: String, valueSize: CGFloat) -> some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(title).font(.caption2).foregroundStyle(TerminalColors.dimmedText)
+            Text(title).font(.caption2).foregroundStyle(TerminalColors.secondaryText)
                 .lineLimit(1)
             Text(value).font(.system(size: valueSize, weight: .semibold))
                 .foregroundStyle(TerminalColors.primaryText)
@@ -160,9 +160,8 @@ struct CostDashboardView: View {
         return f
     }()
 
-    private func barColor(for e: DailyCostReport.DayEntry, maxCost: Double, provider: CostProvider) -> Color {
+    private func barColor(for e: DailyCostReport.DayEntry, provider: CostProvider) -> Color {
         if let s = selected, s.id == e.id { return peak(provider) }
-        if e.costUSD >= maxCost && maxCost > 0 { return peak(provider) }
         return accent(provider)
     }
 
@@ -173,10 +172,9 @@ struct CostDashboardView: View {
     }
 
     @ViewBuilder private func chart(_ r: DailyCostReport) -> some View {
-        let maxCost = r.entries.map(\.costUSD).max() ?? 0
         Chart(r.entries) { e in
             BarMark(x: .value("Day", e.date, unit: .day), y: .value("Cost", e.costUSD))
-                .foregroundStyle(barColor(for: e, maxCost: maxCost, provider: r.provider))
+                .foregroundStyle(barColor(for: e, provider: r.provider))
         }
         .chartXAxis(.hidden)
         .chartYAxis(.hidden)

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -56,6 +56,7 @@ enum CostStatFormatter {
 @MainActor
 struct CostDashboardView: View {
     let store: CostHistoryStore
+    var sizingPeerStore: CostHistoryStore?
 
     @State private var selected: DailyCostReport.DayEntry?
 
@@ -63,7 +64,6 @@ struct CostDashboardView: View {
         VStack(alignment: .leading, spacing: 8) {
             if let report = store.report {
                 statsRow(report)
-                hoverDetail(report)
                 chart(report)
                 if report.entries.contains(where: { $0.requestCount > 0 && $0.pricedFraction < 1 }) {
                     Text("Some models lack pricing — cost is partial")
@@ -78,36 +78,73 @@ struct CostDashboardView: View {
         }
     }
 
-    @ViewBuilder private func statsRow(_ r: DailyCostReport) -> some View {
-        HStack(alignment: .top, spacing: 12) {
-            stat("Today", CostStatFormatter.usd(r.todayCostUSD))
-            stat("30d cost", CostStatFormatter.usd(r.windowCostUSD))
-            stat("30d tokens", CostStatFormatter.tokens(r.windowTokens))
-            stat("Latest tokens", CostStatFormatter.tokens(r.latestTokens))
-            stat("Top model", r.topModel.map(CostStatFormatter.modelName) ?? "—")
-        }
+    private static let statColumnWeights: [CGFloat] = [0.20, 0.19, 0.23, 0.19, 0.19]
+    private static let statSpacing: CGFloat = 12
+    private static let statValueBaseSize: CGFloat = 15
+
+    private static func statItems(
+        _ r: DailyCostReport,
+        selected: DailyCostReport.DayEntry?
+    ) -> [(title: String, value: String)] {
+        [
+            (
+                selected.map { dayFormatter.string(from: $0.date) } ?? "Today",
+                CostStatFormatter.usd(selected?.costUSD ?? r.todayCostUSD)
+            ),
+            (
+                selected.map { "\(dayFormatter.string(from: $0.date)) toks" } ?? "Today's toks",
+                CostStatFormatter.tokens(selected?.totalTokens ?? r.latestTokens)
+            ),
+            ("30d", CostStatFormatter.usd(r.windowCostUSD)),
+            ("30d toks", CostStatFormatter.tokens(r.windowTokens)),
+            ("Top model", r.topModel.map(CostStatFormatter.modelName) ?? "—"),
+        ]
     }
 
-    private func stat(_ title: String, _ value: String) -> some View {
+    @ViewBuilder private func statsRow(_ r: DailyCostReport) -> some View {
+        let items = Self.statItems(r, selected: selected)
+        let peerValues = sizingPeerStore?.report.map { Self.statItems($0, selected: nil).map(\.value) } ?? []
+        GeometryReader { geo in
+            let available = geo.size.width - Self.statSpacing * CGFloat(items.count - 1)
+            let widths = Self.statColumnWeights.map { $0 * available }
+            let valueSize = Self.fittedValueFontSize(
+                valueSets: [items.map(\.value), peerValues],
+                widths: widths
+            )
+            HStack(alignment: .top, spacing: Self.statSpacing) {
+                ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                    stat(item.title, item.value, valueSize: valueSize)
+                        .frame(width: widths[index], alignment: .leading)
+                }
+            }
+        }
+        .frame(height: 34)
+    }
+
+    private static let statLayoutSafetyMargin: CGFloat = 2
+
+    private static func fittedValueFontSize(valueSets: [[String]], widths: [CGFloat]) -> CGFloat {
+        let pairs = valueSets.flatMap { Array(zip($0, widths)) }
+        var size = statValueBaseSize
+        while size > 8 {
+            let font = NSFont.systemFont(ofSize: size, weight: .semibold)
+            let fits = pairs.allSatisfy { value, width in
+                (value as NSString).size(withAttributes: [.font: font]).width <= width - statLayoutSafetyMargin
+            }
+            if fits { return size }
+            size -= 1
+        }
+        return size
+    }
+
+    private func stat(_ title: String, _ value: String, valueSize: CGFloat) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(title).font(.caption2).foregroundStyle(TerminalColors.dimmedText)
-                .lineLimit(1).minimumScaleFactor(0.7)
-            Text(value).font(.system(size: 15, weight: .semibold))
+                .lineLimit(1)
+            Text(value).font(.system(size: valueSize, weight: .semibold))
                 .foregroundStyle(TerminalColors.primaryText)
-                .lineLimit(1).minimumScaleFactor(0.7)
+                .lineLimit(1)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    @ViewBuilder private func hoverDetail(_ r: DailyCostReport) -> some View {
-        Text(selected.map { s in
-            "\(Self.dayFormatter.string(from: s.date)) · "
-                + "\(CostStatFormatter.usd(s.costUSD)) · "
-                + "\(CostStatFormatter.tokens(s.totalTokens)) tok"
-        } ?? " ")
-        .font(.caption2)
-        .foregroundStyle(TerminalColors.primaryText)
-        .lineLimit(1)
     }
 
     private func accent(_ provider: CostProvider) -> Color {

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -181,7 +181,7 @@ struct CostDashboardView: View {
         .chartXAxis(.hidden)
         .chartYAxis(.hidden)
         .chartLegend(.hidden)
-        .frame(height: 90)
+        .frame(height: 105)
         .chartOverlay { proxy in
             GeometryReader { geo in
                 Rectangle()

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -212,7 +212,7 @@ struct ExpandedPanelView: View {
         UsageMetrics.claudeHasData(
             usage: usageService.currentUsage,
             weeklyUsage: usageService.currentWeeklyUsage,
-            sonnetUsage: usageService.currentSonnetUsage,
+            modelUsage: usageService.currentModelUsage,
             extraUsage: usageService.currentExtraUsage
         )
             || UsageMetrics.codexHasData(

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -439,19 +439,16 @@ struct ExpandedPanelView: View {
                 .frame(height: headerClearance)
                 .allowsHitTesting(false)
 
-            ScrollView(showsIndicators: false) {
-                UsageDetailView(
-                    claudeUsage: usageService,
-                    codexUsage: codexUsageService,
-                    costStore: CostHistoryStore.shared,
-                    codexCostStore: CostHistoryStore.sharedCodex,
-                    defaultProvider: usageDetailDefaultProvider
-                )
-                .padding(.horizontal, 12)
-                .padding(.top, 8)
-                .padding(.bottom, 12)
-                .frame(maxWidth: .infinity, alignment: .topLeading)
-            }
+            UsageDetailView(
+                claudeUsage: usageService,
+                codexUsage: codexUsageService,
+                costStore: CostHistoryStore.shared,
+                codexCostStore: CostHistoryStore.sharedCodex,
+                defaultProvider: usageDetailDefaultProvider
+            )
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+            .padding(.bottom, 12)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/notchi/notchi/Views/UsageBarView.swift
+++ b/notchi/notchi/Views/UsageBarView.swift
@@ -186,6 +186,11 @@ struct UsageBarView: View {
                                 .foregroundColor(TerminalColors.red.opacity(0.85))
                                 .lineLimit(1)
                         }
+                        if onOpenDetail != nil {
+                            Image(systemName: "chart.bar.xaxis")
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundColor(TerminalColors.secondaryText)
+                        }
                         if usage != nil {
                             Text("\(effectivePercentage)%")
                                 .font(.system(size: 11, weight: .semibold, design: .monospaced))

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -86,32 +86,56 @@ struct UsageDetailView: View {
             : nil
     }
 
+    private var costDashboardStores: (store: CostHistoryStore, peer: CostHistoryStore) {
+        switch resolvedProvider {
+        case .claude: (costStore, codexCostStore)
+        case .codex: (codexCostStore, costStore)
+        }
+    }
+
+    private var usageRowCount: Int {
+        periods.count + (extraUsage == nil ? 0 : 1) + (codexCreditsUSD == nil ? 0 : 1)
+    }
+
+    @ViewBuilder private var usageRows: some View {
+        ForEach(periods, id: \.title) { period in
+            UsagePeriodRowView(display: period)
+        }
+
+        if let extraUsage {
+            ExtraUsageRowView(display: extraUsage)
+        }
+
+        if let codexCreditsUSD {
+            CodexCreditsRowView(remainingUSD: codexCreditsUSD)
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             header
+                .padding(.bottom, -4)
 
-            switch resolvedProvider {
-            case .claude:
-                CostDashboardView(store: costStore, sizingPeerStore: codexCostStore)
-            case .codex:
-                CostDashboardView(store: codexCostStore, sizingPeerStore: costStore)
-            }
+            CostDashboardView(
+                store: costDashboardStores.store,
+                sizingPeerStore: costDashboardStores.peer
+            )
+            .padding(.bottom, 2)
 
-            Divider().background(Color.white.opacity(0.08))
-
-            ForEach(periods, id: \.title) { period in
-                UsagePeriodRowView(display: period)
-            }
-
-            if let extraUsage {
-                ExtraUsageRowView(display: extraUsage)
-            }
-
-            if let codexCreditsUSD {
-                CodexCreditsRowView(remainingUSD: codexCreditsUSD)
+            if usageRowCount >= 3 {
+                LazyVGrid(
+                    columns: [
+                        GridItem(.flexible(), spacing: 14, alignment: .topLeading),
+                        GridItem(.flexible(), alignment: .topLeading),
+                    ],
+                    spacing: 12
+                ) {
+                    usageRows
+                }
+            } else {
+                usageRows
             }
         }
-        .padding(.top, 8)
         .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 
@@ -134,13 +158,13 @@ struct UsageDetailView: View {
             ForEach([AgentProvider.claude, .codex], id: \.self) { provider in
                 Button(action: { selectedProvider = provider }) {
                     Text(provider.displayName)
-                        .font(.system(size: 13, weight: .semibold))
+                        .font(.system(size: 14, weight: .semibold))
                         .foregroundColor(
                             resolvedProvider == provider
                                 ? TerminalColors.primaryText
                                 : TerminalColors.dimmedText
                         )
-                        .padding(.horizontal, 10)
+                        .padding(.horizontal, 6)
                         .padding(.vertical, 4)
                         .background(
                             RoundedRectangle(cornerRadius: 6)
@@ -150,6 +174,7 @@ struct UsageDetailView: View {
                 .buttonStyle(.plain)
             }
         }
+        .padding(.leading, -6)
     }
 }
 
@@ -167,7 +192,7 @@ private struct UsageProgressBar: View {
                     .frame(width: geometry.size.width * Double(min(max(percentUsed, 0), 100)) / 100)
             }
         }
-        .frame(height: 6)
+        .frame(height: 5)
     }
 }
 
@@ -185,11 +210,11 @@ struct UsagePeriodRowView: View {
                     .foregroundColor(TerminalColors.primaryText)
                 if display.isStale {
                     Text("stale data")
-                        .font(.system(size: 11))
+                        .font(.system(size: 10))
                         .foregroundColor(TerminalColors.secondaryText)
                 } else if let resetText = display.resetText {
                     Text(resetText)
-                        .font(.system(size: 11))
+                        .font(.system(size: 10))
                         .foregroundColor(TerminalColors.secondaryText)
                 }
                 Spacer()
@@ -219,7 +244,7 @@ struct ExtraUsageRowView: View {
                 Text("\(Self.currency(display.monthlyLimit)) limit")
                     .foregroundColor(TerminalColors.secondaryText)
             }
-            .font(.system(size: 11))
+            .font(.system(size: 10))
         }
     }
 
@@ -235,7 +260,7 @@ struct CodexCreditsRowView: View {
     let remainingUSD: Double
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 7) {
+        VStack(alignment: .leading, spacing: 3) {
             Text("Extra usage")
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(TerminalColors.primaryText)
@@ -244,7 +269,7 @@ struct CodexCreditsRowView: View {
                     .foregroundColor(TerminalColors.secondaryText)
                 Spacer()
             }
-            .font(.system(size: 11))
+            .font(.system(size: 10))
         }
     }
 }

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -28,7 +28,7 @@ struct UsageDetailView: View {
         UsageMetrics.claudeHasData(
             usage: claudeUsage.currentUsage,
             weeklyUsage: claudeUsage.currentWeeklyUsage,
-            sonnetUsage: claudeUsage.currentSonnetUsage,
+            modelUsage: claudeUsage.currentModelUsage,
             extraUsage: claudeUsage.currentExtraUsage
         )
     }
@@ -60,7 +60,11 @@ struct UsageDetailView: View {
             return [
                 UsageMetrics.periodDisplay(title: "Session", usage: claudeUsage.currentUsage, isStale: stale),
                 UsageMetrics.periodDisplay(title: "Weekly", usage: claudeUsage.currentWeeklyUsage, isStale: heldOver),
-                UsageMetrics.periodDisplay(title: "Sonnet", usage: claudeUsage.currentSonnetUsage, isStale: heldOver),
+                UsageMetrics.periodDisplay(
+                    title: claudeUsage.currentModelUsageName ?? "Model",
+                    usage: claudeUsage.currentModelUsage,
+                    isStale: heldOver
+                ),
             ].compactMap { $0 }
         case .codex:
             let stale = codexUsage.isUsageStale
@@ -88,9 +92,9 @@ struct UsageDetailView: View {
 
             switch resolvedProvider {
             case .claude:
-                CostDashboardView(store: costStore)
+                CostDashboardView(store: costStore, sizingPeerStore: codexCostStore)
             case .codex:
-                CostDashboardView(store: codexCostStore)
+                CostDashboardView(store: codexCostStore, sizingPeerStore: costStore)
             }
 
             Divider().background(Color.white.opacity(0.08))


### PR DESCRIPTION
## Summary

- **Parse model-scoped weekly limits.** The usage API moved per-model weekly quotas out of `seven_day_sonnet` into a `limits` array whose `weekly_scoped` entry carries the model display name (currently *Fable*). The usage row now renders that name dynamically, with fallbacks to `seven_day_opus` then `seven_day_sonnet` for older responses. Service state renamed to model-neutral vocabulary (`currentModelUsage`/`currentModelUsageName`, persisted in the recovery snapshot).
- **Stable cost dashboard stats row.** Fixed fractional column widths (no more shifting while scrubbing the chart), one fit-verified font size shared across all values *and both providers* (via a sizing peer store) so numbers never truncate or render at mixed sizes. Stats reordered to Today, Today's toks, 30d, 30d toks, Top model; hover now updates the first two stats in place of the removed hover-detail line.
- **Usage panel layout.** Usage rows lay out in a 2-column grid when 3+ are present; scroll wrapper and chart divider removed; provider toggle chips aligned flush with the content edge; assorted spacing/typography polish (10pt secondary text, 5pt bars, 105pt chart, uniform bar accent with hover-only highlight).

## Behavior notes

- A previously persisted recovery snapshot loses its stale Sonnet row once (persisted key renamed); it repopulates on the next successful poll.
- `seven_day_opus` now takes precedence over `seven_day_sonnet` when both legacy keys are present.

## Testing

- `./scripts/test.sh focused` passes.
- New tests: scoped weekly limit parsing publishes percent + model name; scoped entry takes precedence over legacy keys; Opus fallback beats Sonnet; nil model bucket leaves the row hidden.
- Manual: verified against the live usage API response shape (Fable at the model-scoped entry); eyeballed panel across Claude/Codex tabs, hover scrubbing, and grid layouts.