### PR TITLE
feat(emotion): support custom API base URL for analysis providers

### DIFF
--- a/notchi/Tests/EmotionAnalysisBaseURLTests.swift
+++ b/notchi/Tests/EmotionAnalysisBaseURLTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import XCTest
+@testable import notchi
+
+final class EmotionAnalysisBaseURLTests: XCTestCase {
+    private static let defaultClaudeEndpoint = URL(string: "https://api.anthropic.com/v1/messages")!
+    private static let defaultOpenAIEndpoint = URL(string: "https://api.openai.com/v1/chat/completions")!
+
+    @MainActor
+    override func setUp() {
+        super.setUp()
+        clearStoredBaseURLs()
+    }
+
+    @MainActor
+    override func tearDown() {
+        clearStoredBaseURLs()
+        super.tearDown()
+    }
+
+    @MainActor
+    private func clearStoredBaseURLs() {
+        AppSettings.setApiBaseURL(nil, for: .claude)
+        AppSettings.setApiBaseURL(nil, for: .openAI)
+    }
+
+    func testEndpointURLDefaultsWhenBaseURLMissing() {
+        XCTAssertEqual(EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: nil), Self.defaultClaudeEndpoint)
+        XCTAssertEqual(EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: ""), Self.defaultClaudeEndpoint)
+        XCTAssertEqual(EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: "   "), Self.defaultClaudeEndpoint)
+        XCTAssertEqual(EmotionAnalysisProvider.openAI.endpointURL(fromBaseURL: nil), Self.defaultOpenAIEndpoint)
+    }
+
+    func testEndpointURLNormalizesCommonClaudeBaseURLShapes() {
+        XCTAssertEqual(
+            EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: "https://relay.example.com"),
+            URL(string: "https://relay.example.com/v1/messages")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: "https://relay.example.com/"),
+            URL(string: "https://relay.example.com/v1/messages")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: "https://relay.example.com/v1"),
+            URL(string: "https://relay.example.com/v1/messages")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: "https://relay.example.com/v1/messages"),
+            URL(string: "https://relay.example.com/v1/messages")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: "https://relay.example.com/proxy/"),
+            URL(string: "https://relay.example.com/proxy/v1/messages")
+        )
+    }
+
+    func testEndpointURLNormalizesCommonOpenAIBaseURLShapes() {
+        XCTAssertEqual(
+            EmotionAnalysisProvider.openAI.endpointURL(fromBaseURL: "https://relay.example.com"),
+            URL(string: "https://relay.example.com/v1/chat/completions")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.openAI.endpointURL(fromBaseURL: "https://relay.example.com/v1"),
+            URL(string: "https://relay.example.com/v1/chat/completions")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.openAI.endpointURL(fromBaseURL: "https://relay.example.com/v1/chat/completions"),
+            URL(string: "https://relay.example.com/v1/chat/completions")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.openAI.endpointURL(fromBaseURL: "https://relay.example.com/proxy"),
+            URL(string: "https://relay.example.com/proxy/v1/chat/completions")
+        )
+    }
+
+    func testEndpointURLPrependsHTTPSWhenSchemeMissing() {
+        XCTAssertEqual(
+            EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: "relay.example.com"),
+            URL(string: "https://relay.example.com/v1/messages")
+        )
+    }
+
+    func testEndpointURLRejectsUnparseableBaseURL() {
+        XCTAssertNil(EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: "https://"))
+        XCTAssertNil(EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: "not a url"))
+        XCTAssertNil(EmotionAnalysisProvider.openAI.endpointURL(fromBaseURL: "https://exa mple.com"))
+    }
+
+    @MainActor
+    func testApiBaseURLRoundTripIsProviderScoped() {
+        AppSettings.setApiBaseURL("https://claude-relay.example.com", for: .claude)
+        AppSettings.setApiBaseURL("https://openai-relay.example.com", for: .openAI)
+
+        XCTAssertEqual(AppSettings.apiBaseURL(for: .claude), "https://claude-relay.example.com")
+        XCTAssertEqual(AppSettings.apiBaseURL(for: .openAI), "https://openai-relay.example.com")
+    }
+
+    @MainActor
+    func testApiBaseURLStoresTrimmedValueAndClearsWhenEmpty() {
+        AppSettings.setApiBaseURL("  https://relay.example.com  ", for: .claude)
+        XCTAssertEqual(AppSettings.apiBaseURL(for: .claude), "https://relay.example.com")
+
+        AppSettings.setApiBaseURL("   ", for: .claude)
+        XCTAssertNil(AppSettings.apiBaseURL(for: .claude))
+
+        AppSettings.setApiBaseURL(nil, for: .claude)
+        XCTAssertNil(AppSettings.apiBaseURL(for: .claude))
+    }
+
+    @MainActor
+    func testManualEndpointURLUsesStoredBaseURLAndFallsBackToDefault() {
+        XCTAssertEqual(EmotionAnalyzer.manualEndpointURL(for: .claude), Self.defaultClaudeEndpoint)
+
+        AppSettings.setApiBaseURL("https://relay.example.com", for: .claude)
+        XCTAssertEqual(
+            EmotionAnalyzer.manualEndpointURL(for: .claude),
+            URL(string: "https://relay.example.com/v1/messages")
+        )
+
+        AppSettings.setApiBaseURL("https://", for: .claude)
+        XCTAssertNil(EmotionAnalyzer.manualEndpointURL(for: .claude))
+    }
+
+    @MainActor
+    func testTestConfigurationThrowsForInvalidBaseURL() async {
+        do {
+            _ = try await EmotionAnalyzer.shared.testConfiguration(
+                provider: .claude,
+                model: .claudeHaiku45,
+                apiKey: "sk-test",
+                baseURL: "https://"
+            )
+            XCTFail("Expected invalidBaseURL error")
+        } catch let error as EmotionAnalysisRequestError {
+            guard case .invalidBaseURL = error else {
+                XCTFail("Expected invalidBaseURL, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -24,6 +24,15 @@ enum EmotionAnalysisProvider: String, CaseIterable, Identifiable {
         }
     }
 
+    var apiBaseURLPlaceholder: String {
+        switch self {
+        case .claude:
+            "api.anthropic.com"
+        case .openAI:
+            "api.openai.com"
+        }
+    }
+
     var apiKeyURL: URL {
         switch self {
         case .claude:
@@ -144,6 +153,8 @@ struct AppSettings {
     private static let emotionAnalysisProviderKey = "emotionAnalysisProvider"
     private static let emotionAnalysisClaudeModelKey = "emotionAnalysisClaudeModel"
     private static let emotionAnalysisOpenAIModelKey = "emotionAnalysisOpenAIModel"
+    private static let emotionAnalysisClaudeBaseURLKey = "emotionAnalysisClaudeBaseURL"
+    private static let emotionAnalysisOpenAIBaseURLKey = "emotionAnalysisOpenAIBaseURL"
     private static let lastUsedAgentProviderKey = "lastUsedAgentProvider"
     nonisolated private static let agentHooksDisabledProvidersKey = "agentHooksDisabledProviders"
 
@@ -320,6 +331,30 @@ struct AppSettings {
             anthropicApiKey = key
         case .openAI:
             openAIApiKey = key
+        }
+    }
+
+    static func apiBaseURL(for provider: EmotionAnalysisProvider) -> String? {
+        let value = UserDefaults.standard.string(forKey: apiBaseURLKey(for: provider))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return value?.isEmpty == false ? value : nil
+    }
+
+    static func setApiBaseURL(_ baseURL: String?, for provider: EmotionAnalysisProvider) {
+        let trimmed = baseURL?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmed, !trimmed.isEmpty {
+            UserDefaults.standard.set(trimmed, forKey: apiBaseURLKey(for: provider))
+        } else {
+            UserDefaults.standard.removeObject(forKey: apiBaseURLKey(for: provider))
+        }
+    }
+
+    private static func apiBaseURLKey(for provider: EmotionAnalysisProvider) -> String {
+        switch provider {
+        case .claude:
+            emotionAnalysisClaudeBaseURLKey
+        case .openAI:
+            emotionAnalysisOpenAIBaseURLKey
         }
     }
 

--- a/notchi/notchi/Services/EmotionAnalyzer.swift
+++ b/notchi/notchi/Services/EmotionAnalyzer.swift
@@ -58,30 +58,59 @@ struct ClaudeSettingsConfig {
     }
 
     nonisolated static func buildMessagesURL(from baseURL: String) -> URL? {
-        let logger = Logger(subsystem: "com.ruban.notchi", category: "EmotionAnalyzer")
-        guard var components = URLComponents(string: baseURL) else {
+        guard let url = EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: baseURL) else {
+            let logger = Logger(subsystem: "com.ruban.notchi", category: "EmotionAnalyzer")
             logger.error("Invalid ANTHROPIC_BASE_URL: \(baseURL, privacy: .public)")
             return nil
         }
-
-        let normalizedPath = components.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        switch true {
-        case normalizedPath.isEmpty:
-            components.path = "/v1/messages"
-        case normalizedPath.hasSuffix("/v1/messages") || normalizedPath == "v1/messages":
-            components.path = "/\(normalizedPath)"
-        case normalizedPath.hasSuffix("/v1") || normalizedPath == "v1":
-            components.path = "/\(normalizedPath)/messages"
-        default:
-            components.path = "/\(normalizedPath)/v1/messages"
-        }
-
-        return components.url
+        return url
     }
 }
 
 enum OpenAISettingsConfig {
     nonisolated static let defaultAPIURL = URL(string: "https://api.openai.com/v1/chat/completions")!
+}
+
+extension EmotionAnalysisProvider {
+    nonisolated var defaultEndpointURL: URL {
+        switch self {
+        case .claude:
+            ClaudeSettingsConfig.defaultAPIURL
+        case .openAI:
+            OpenAISettingsConfig.defaultAPIURL
+        }
+    }
+
+    nonisolated private var endpointPathComponents: [String] {
+        switch self {
+        case .claude:
+            ["v1", "messages"]
+        case .openAI:
+            ["v1", "chat", "completions"]
+        }
+    }
+
+    nonisolated func endpointURL(fromBaseURL baseURL: String?) -> URL? {
+        let trimmed = baseURL?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else {
+            return defaultEndpointURL
+        }
+
+        let urlString = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+        guard var components = URLComponents(string: urlString),
+              let host = components.host,
+              !host.isEmpty else {
+            return nil
+        }
+
+        let baseComponents = components.path.split(separator: "/").map(String.init)
+        let endpoint = endpointPathComponents
+        let overlap = (0...min(baseComponents.count, endpoint.count))
+            .reversed()
+            .first { Array(baseComponents.suffix($0)) == Array(endpoint.prefix($0)) } ?? 0
+        components.path = "/" + (baseComponents + endpoint.dropFirst(overlap)).joined(separator: "/")
+        return components.url
+    }
 }
 
 private struct HaikuResponse: Decodable {
@@ -117,6 +146,7 @@ struct EmotionAnalysisTestResult {
 
 enum EmotionAnalysisRequestError: LocalizedError {
     case missingAPIKey(EmotionAnalysisProvider)
+    case invalidBaseURL
     case httpStatus(provider: String, statusCode: Int)
     case invalidResponse
 
@@ -124,6 +154,8 @@ enum EmotionAnalysisRequestError: LocalizedError {
         switch self {
         case .missingAPIKey(let provider):
             "Missing \(provider.displayName) API key"
+        case .invalidBaseURL:
+            "Invalid API base URL"
         case .httpStatus(let provider, let statusCode):
             "\(provider) API returned HTTP \(statusCode)"
         case .invalidResponse:
@@ -135,6 +167,8 @@ enum EmotionAnalysisRequestError: LocalizedError {
         switch self {
         case .missingAPIKey:
             "Missing"
+        case .invalidBaseURL:
+            "Bad URL"
         case .httpStatus(_, let statusCode):
             "HTTP \(statusCode)"
         case .invalidResponse:
@@ -344,12 +378,19 @@ final class EmotionAnalyzer {
         }
     }
 
+    static func manualEndpointURL(for provider: EmotionAnalysisProvider) -> URL? {
+        provider.endpointURL(fromBaseURL: AppSettings.apiBaseURL(for: provider))
+    }
+
     private func resolveClaudeProvider() -> ClaudeEmotionAnalysisProvider? {
         if let apiKey = KeychainManager.getAnthropicApiKey(allowInteraction: false)?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !apiKey.isEmpty {
+            guard let apiURL = Self.manualEndpointURL(for: .claude) else {
+                return nil
+            }
             return ClaudeEmotionAnalysisProvider(
-                apiURL: ClaudeSettingsConfig.defaultAPIURL,
+                apiURL: apiURL,
                 apiKey: apiKey,
                 model: AppSettings.selectedEmotionAnalysisModel(for: .claude).rawValue
             )
@@ -369,12 +410,13 @@ final class EmotionAnalyzer {
     private func resolveOpenAIProvider() -> OpenAIEmotionAnalysisProvider? {
         guard let apiKey = KeychainManager.getOpenAIApiKey(allowInteraction: false)?
             .trimmingCharacters(in: .whitespacesAndNewlines),
-              !apiKey.isEmpty else {
+              !apiKey.isEmpty,
+              let apiURL = Self.manualEndpointURL(for: .openAI) else {
             return nil
         }
 
         return OpenAIEmotionAnalysisProvider(
-            apiURL: OpenAISettingsConfig.defaultAPIURL,
+            apiURL: apiURL,
             apiKey: apiKey,
             model: AppSettings.selectedEmotionAnalysisModel(for: .openAI).rawValue
         )
@@ -383,9 +425,10 @@ final class EmotionAnalyzer {
     func testConfiguration(
         provider: EmotionAnalysisProvider,
         model: EmotionAnalysisModel,
-        apiKey: String?
+        apiKey: String?,
+        baseURL: String?
     ) async throws -> EmotionAnalysisTestResult {
-        let analysisProvider = try resolveProvider(provider: provider, model: model, apiKey: apiKey)
+        let analysisProvider = try resolveProvider(provider: provider, model: model, apiKey: apiKey, baseURL: baseURL)
         let start = ContinuousClock.now
         let result = try await analysisProvider.analyze(prompt: Self.testPrompt, systemPrompt: Self.systemPrompt)
         let elapsed = (ContinuousClock.now - start).components
@@ -401,15 +444,19 @@ final class EmotionAnalyzer {
     private func resolveProvider(
         provider: EmotionAnalysisProvider,
         model: EmotionAnalysisModel,
-        apiKey: String?
+        apiKey: String?,
+        baseURL: String?
     ) throws -> EmotionAnalysisProviding {
         let trimmedKey = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
         switch provider {
         case .claude:
             if !trimmedKey.isEmpty {
+                guard let apiURL = provider.endpointURL(fromBaseURL: baseURL) else {
+                    throw EmotionAnalysisRequestError.invalidBaseURL
+                }
                 return ClaudeEmotionAnalysisProvider(
-                    apiURL: ClaudeSettingsConfig.defaultAPIURL,
+                    apiURL: apiURL,
                     apiKey: trimmedKey,
                     model: model.rawValue
                 )
@@ -429,8 +476,12 @@ final class EmotionAnalyzer {
                 throw EmotionAnalysisRequestError.missingAPIKey(provider)
             }
 
+            guard let apiURL = provider.endpointURL(fromBaseURL: baseURL) else {
+                throw EmotionAnalysisRequestError.invalidBaseURL
+            }
+
             return OpenAIEmotionAnalysisProvider(
-                apiURL: OpenAISettingsConfig.defaultAPIURL,
+                apiURL: apiURL,
                 apiKey: trimmedKey,
                 model: model.rawValue
             )

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -520,11 +520,13 @@ private struct EmotionAnalysisSettingsView: View {
     @State private var provider = AppSettings.emotionAnalysisProvider
     @State private var model = AppSettings.selectedEmotionAnalysisModel(for: AppSettings.emotionAnalysisProvider)
     @State private var apiKeyInput = AppSettings.apiKey(for: AppSettings.emotionAnalysisProvider) ?? ""
+    @State private var baseURLInput = AppSettings.apiBaseURL(for: AppSettings.emotionAnalysisProvider) ?? ""
     @State private var isProviderPickerExpanded = false
     @State private var isModelPickerExpanded = false
     @State private var testState: TestState = .idle
     @State private var setupLinkShakePhase: CGFloat = 0
     @FocusState private var isAPIKeyFocused: Bool
+    @FocusState private var isBaseURLFocused: Bool
 
     private var hasApiKey: Bool {
         !apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -537,6 +539,7 @@ private struct EmotionAnalysisSettingsView: View {
                 providerSection
                 modelSection
                 apiKeySection
+                baseURLSection
                 testSection
                 setupSection
             }
@@ -544,11 +547,19 @@ private struct EmotionAnalysisSettingsView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onDisappear {
             saveApiKey(for: provider)
+            saveBaseURL(for: provider)
         }
         .animation(.spring(response: 0.3), value: isProviderPickerExpanded)
         .animation(.spring(response: 0.3), value: isModelPickerExpanded)
         .onChange(of: apiKeyInput) { _, _ in
             resetTestState()
+        }
+        .onChange(of: baseURLInput) { _, _ in
+            resetTestState()
+        }
+        .onChange(of: isBaseURLFocused) { _, focused in
+            guard !focused else { return }
+            saveBaseURL(for: provider)
         }
         .onChange(of: isAPIKeyFocused) { _, focused in
             guard focused else { return }
@@ -689,6 +700,49 @@ private struct EmotionAnalysisSettingsView: View {
             }
             .buttonStyle(.plain)
         }
+    }
+
+    private var baseURLSection: some View {
+        HStack {
+            Image(systemName: "link")
+                .font(.system(size: 12))
+                .foregroundColor(TerminalColors.secondaryText)
+                .frame(width: 20)
+
+            Text("Base URL")
+                .font(.system(size: 12))
+                .foregroundColor(TerminalColors.primaryText)
+                .layoutPriority(1)
+
+            Spacer(minLength: 12)
+
+            baseURLField
+        }
+        .padding(.vertical, SettingsLayout.rowVerticalPadding)
+    }
+
+    private var baseURLField: some View {
+        ZStack(alignment: .leading) {
+            TextField("", text: $baseURLInput)
+                .textFieldStyle(.plain)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(TerminalColors.primaryText)
+                .padding(.horizontal, SettingsLayout.fieldHorizontalPadding)
+                .padding(.vertical, SettingsLayout.fieldVerticalPadding)
+                .background(Color.white.opacity(0.06))
+                .cornerRadius(6)
+                .focused($isBaseURLFocused)
+                .onSubmit { saveBaseURL(for: provider) }
+
+            if baseURLInput.isEmpty {
+                Text(provider.apiBaseURLPlaceholder)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(TerminalColors.dimmedText)
+                    .padding(.leading, SettingsLayout.fieldHorizontalPadding)
+                    .allowsHitTesting(false)
+            }
+        }
+        .frame(minWidth: 220, maxWidth: 300)
     }
 
     private var setupSection: some View {
@@ -877,10 +931,12 @@ private struct EmotionAnalysisSettingsView: View {
         blurAPIKeyField()
         guard newProvider != provider else { return }
         saveApiKey(for: provider)
+        saveBaseURL(for: provider)
         provider = newProvider
         AppSettings.emotionAnalysisProvider = newProvider
         model = AppSettings.selectedEmotionAnalysisModel(for: newProvider)
         apiKeyInput = AppSettings.apiKey(for: newProvider) ?? ""
+        baseURLInput = AppSettings.apiBaseURL(for: newProvider) ?? ""
         resetTestState()
     }
 
@@ -897,6 +953,10 @@ private struct EmotionAnalysisSettingsView: View {
         AppSettings.setApiKey(trimmed.isEmpty ? nil : trimmed, for: provider)
     }
 
+    private func saveBaseURL(for provider: EmotionAnalysisProvider) {
+        AppSettings.setApiBaseURL(baseURLInput, for: provider)
+    }
+
     private func openAPIKeyPage() {
         blurAPIKeyField()
         NSWorkspace.shared.open(provider.apiKeyURL)
@@ -910,18 +970,20 @@ private struct EmotionAnalysisSettingsView: View {
         let currentProvider = provider
         let currentModel = model
         let currentAPIKey = apiKeyInput
+        let currentBaseURL = baseURLInput
 
         Task { @MainActor in
             do {
                 let result = try await EmotionAnalyzer.shared.testConfiguration(
                     provider: currentProvider,
                     model: currentModel,
-                    apiKey: currentAPIKey
+                    apiKey: currentAPIKey,
+                    baseURL: currentBaseURL
                 )
-                guard isCurrentTestSnapshot(provider: currentProvider, model: currentModel, apiKey: currentAPIKey) else { return }
+                guard isCurrentTestSnapshot(provider: currentProvider, model: currentModel, apiKey: currentAPIKey, baseURL: currentBaseURL) else { return }
                 testState = .success(result)
             } catch {
-                guard isCurrentTestSnapshot(provider: currentProvider, model: currentModel, apiKey: currentAPIKey) else { return }
+                guard isCurrentTestSnapshot(provider: currentProvider, model: currentModel, apiKey: currentAPIKey, baseURL: currentBaseURL) else { return }
                 testState = .failure(testErrorText(error))
             }
         }
@@ -934,9 +996,10 @@ private struct EmotionAnalysisSettingsView: View {
     private func isCurrentTestSnapshot(
         provider: EmotionAnalysisProvider,
         model: EmotionAnalysisModel,
-        apiKey: String
+        apiKey: String,
+        baseURL: String
     ) -> Bool {
-        self.provider == provider && self.model == model && apiKeyInput == apiKey
+        self.provider == provider && self.model == model && apiKeyInput == apiKey && baseURLInput == baseURL
     }
 
     private func blurAPIKeyField() {


### PR DESCRIPTION
## Summary
Adds an optional **Base URL** field next to the API key in the emotion analysis settings, for both the Claude and OpenAI providers. Users on third-party relays/proxies (see #62) can now point requests at their relay endpoint; leaving the field empty uses the official endpoint, so existing setups are unaffected.

## Changes
- `AppSettings`: per-provider base URL stored in UserDefaults (`apiBaseURL(for:)` / `setApiBaseURL`)
- `EmotionAnalyzer`: endpoint built from the stored base URL via a shared normalizer (`endpointURL(fromBaseURL:)`) that handles missing schemes, trailing slashes, `/v1` suffixes, and path prefixes; the existing `ANTHROPIC_BASE_URL` settings.json path now delegates to the same normalizer with unchanged behavior
- `PanelSettingsView`: Base URL field below the API key, saved on submit/blur/provider switch; Test button validates key + URL together and shows "Bad URL" for unparseable input
- Out of scope: usage tracking (`ClaudeUsageService`) — it authenticates via Claude Code OAuth against `/api/oauth/usage`, which relays don't serve

## Testing
- 9 new unit tests (URL normalization per provider, settings round-trip, invalid-URL error path); full suite passes (466 tests)
- Manually verified with the OpenAI provider: official URL, scheme-less URL, `/v1` suffix, fake host (fails correctly), garbage URL (Bad URL badge), persistence across provider switches and relaunch

See #62