### PR TITLE
feat(notch): collapsed-notch deep links and session pairing

### DIFF
--- a/notchi/Tests/ExpandedPanelViewTests.swift
+++ b/notchi/Tests/ExpandedPanelViewTests.swift
@@ -168,6 +168,7 @@ final class ExpandedPanelViewTests: XCTestCase {
         let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
 
         let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            requestedProvider: nil,
             contextSession: codexSession,
             lastUsedProvider: .claude,
             claudeHasData: true,
@@ -177,8 +178,23 @@ final class ExpandedPanelViewTests: XCTestCase {
         XCTAssertEqual(provider, .codex)
     }
 
+    func testUsageDetailOpensOnRequestedProviderOverContextSession() {
+        let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
+
+        let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            requestedProvider: .claude,
+            contextSession: codexSession,
+            lastUsedProvider: .codex,
+            claudeHasData: true,
+            codexHasData: true
+        )
+
+        XCTAssertEqual(provider, .claude)
+    }
+
     func testUsageDetailOpensOnLastUsedProviderWhenIdleAndItHasData() {
         let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            requestedProvider: nil,
             contextSession: nil,
             lastUsedProvider: .codex,
             claudeHasData: true,
@@ -190,6 +206,7 @@ final class ExpandedPanelViewTests: XCTestCase {
 
     func testUsageDetailPrefersProviderWithDataOverLastUsedWithoutData() {
         let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            requestedProvider: nil,
             contextSession: nil,
             lastUsedProvider: .codex,
             claudeHasData: true,
@@ -201,6 +218,7 @@ final class ExpandedPanelViewTests: XCTestCase {
 
     func testUsageDetailPrefersCodexWithDataOverLastUsedClaudeWithoutData() {
         let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            requestedProvider: nil,
             contextSession: nil,
             lastUsedProvider: .claude,
             claudeHasData: false,
@@ -212,6 +230,7 @@ final class ExpandedPanelViewTests: XCTestCase {
 
     func testUsageDetailOpensOnLastUsedProviderWhenIdleWithNoDataAnywhere() {
         let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            requestedProvider: nil,
             contextSession: nil,
             lastUsedProvider: .codex,
             claudeHasData: false,

--- a/notchi/Tests/ExpandedPanelViewTests.swift
+++ b/notchi/Tests/ExpandedPanelViewTests.swift
@@ -170,9 +170,7 @@ final class ExpandedPanelViewTests: XCTestCase {
         let provider = ExpandedPanelView.usageDetailDefaultProvider(
             requestedProvider: nil,
             contextSession: codexSession,
-            lastUsedProvider: .claude,
-            claudeHasData: true,
-            codexHasData: true
+            lastUsedProvider: .claude
         )
 
         XCTAssertEqual(provider, .codex)
@@ -184,57 +182,17 @@ final class ExpandedPanelViewTests: XCTestCase {
         let provider = ExpandedPanelView.usageDetailDefaultProvider(
             requestedProvider: .claude,
             contextSession: codexSession,
-            lastUsedProvider: .codex,
-            claudeHasData: true,
-            codexHasData: true
+            lastUsedProvider: .codex
         )
 
         XCTAssertEqual(provider, .claude)
     }
 
-    func testUsageDetailOpensOnLastUsedProviderWhenIdleAndItHasData() {
+    func testUsageDetailOpensOnLastUsedProviderWhenIdle() {
         let provider = ExpandedPanelView.usageDetailDefaultProvider(
             requestedProvider: nil,
             contextSession: nil,
-            lastUsedProvider: .codex,
-            claudeHasData: true,
-            codexHasData: true
-        )
-
-        XCTAssertEqual(provider, .codex)
-    }
-
-    func testUsageDetailPrefersProviderWithDataOverLastUsedWithoutData() {
-        let provider = ExpandedPanelView.usageDetailDefaultProvider(
-            requestedProvider: nil,
-            contextSession: nil,
-            lastUsedProvider: .codex,
-            claudeHasData: true,
-            codexHasData: false
-        )
-
-        XCTAssertEqual(provider, .claude)
-    }
-
-    func testUsageDetailPrefersCodexWithDataOverLastUsedClaudeWithoutData() {
-        let provider = ExpandedPanelView.usageDetailDefaultProvider(
-            requestedProvider: nil,
-            contextSession: nil,
-            lastUsedProvider: .claude,
-            claudeHasData: false,
-            codexHasData: true
-        )
-
-        XCTAssertEqual(provider, .codex)
-    }
-
-    func testUsageDetailOpensOnLastUsedProviderWhenIdleWithNoDataAnywhere() {
-        let provider = ExpandedPanelView.usageDetailDefaultProvider(
-            requestedProvider: nil,
-            contextSession: nil,
-            lastUsedProvider: .codex,
-            claudeHasData: false,
-            codexHasData: false
+            lastUsedProvider: .codex
         )
 
         XCTAssertEqual(provider, .codex)

--- a/notchi/Tests/ExpandedPanelViewTests.swift
+++ b/notchi/Tests/ExpandedPanelViewTests.swift
@@ -164,6 +164,52 @@ final class ExpandedPanelViewTests: XCTestCase {
         )
     }
 
+    func testUsageDetailOpensOnContextSessionProviderRegardlessOfLastUsed() {
+        let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
+
+        let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            contextSession: codexSession,
+            lastUsedProvider: .claude,
+            claudeHasData: true,
+            codexHasData: true
+        )
+
+        XCTAssertEqual(provider, .codex)
+    }
+
+    func testUsageDetailOpensOnLastUsedProviderWhenIdleAndItHasData() {
+        let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            contextSession: nil,
+            lastUsedProvider: .codex,
+            claudeHasData: true,
+            codexHasData: true
+        )
+
+        XCTAssertEqual(provider, .codex)
+    }
+
+    func testUsageDetailPrefersProviderWithDataOverLastUsedWithoutData() {
+        let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            contextSession: nil,
+            lastUsedProvider: .codex,
+            claudeHasData: true,
+            codexHasData: false
+        )
+
+        XCTAssertEqual(provider, .claude)
+    }
+
+    func testUsageDetailOpensOnLastUsedProviderWhenIdleWithNoDataAnywhere() {
+        let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            contextSession: nil,
+            lastUsedProvider: .codex,
+            claudeHasData: false,
+            codexHasData: false
+        )
+
+        XCTAssertEqual(provider, .codex)
+    }
+
     func testCodexUsageBarIgnoresClaudeUsageSetting() {
         XCTAssertTrue(ExpandedPanelView.sharedUsageBarIsEnabled(provider: .codex, appUsageEnabled: false))
         XCTAssertFalse(ExpandedPanelView.sharedUsageBarIsEnabled(provider: .claude, appUsageEnabled: false))

--- a/notchi/Tests/ExpandedPanelViewTests.swift
+++ b/notchi/Tests/ExpandedPanelViewTests.swift
@@ -199,6 +199,17 @@ final class ExpandedPanelViewTests: XCTestCase {
         XCTAssertEqual(provider, .claude)
     }
 
+    func testUsageDetailPrefersCodexWithDataOverLastUsedClaudeWithoutData() {
+        let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            contextSession: nil,
+            lastUsedProvider: .claude,
+            claudeHasData: false,
+            codexHasData: true
+        )
+
+        XCTAssertEqual(provider, .codex)
+    }
+
     func testUsageDetailOpensOnLastUsedProviderWhenIdleWithNoDataAnywhere() {
         let provider = ExpandedPanelView.usageDetailDefaultProvider(
             contextSession: nil,

--- a/notchi/Tests/NotchContentViewTests.swift
+++ b/notchi/Tests/NotchContentViewTests.swift
@@ -29,6 +29,44 @@ final class NotchContentViewTests: XCTestCase {
         XCTAssertFalse(NotchSlotContent.conflict(.ring, .latest))
     }
 
+    func testRingProviderFollowsDisplayedSpriteSessionOverSelectedSession() {
+        let claudeSpriteSession = SessionData(sessionId: "claude-session", provider: .claude, cwd: "/tmp/project")
+        let codexSelectedSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
+
+        XCTAssertEqual(
+            NotchContentView.collapsedRingProvider(
+                spriteSession: claudeSpriteSession,
+                effectiveSession: codexSelectedSession,
+                lastUsedProvider: .codex
+            ),
+            .claude
+        )
+    }
+
+    func testRingProviderFallsBackToEffectiveSessionWithoutDisplayedSprite() {
+        let codexSelectedSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
+
+        XCTAssertEqual(
+            NotchContentView.collapsedRingProvider(
+                spriteSession: nil,
+                effectiveSession: codexSelectedSession,
+                lastUsedProvider: .claude
+            ),
+            .codex
+        )
+    }
+
+    func testRingProviderFallsBackToLastUsedProviderWhenIdle() {
+        XCTAssertEqual(
+            NotchContentView.collapsedRingProvider(
+                spriteSession: nil,
+                effectiveSession: nil,
+                lastUsedProvider: .codex
+            ),
+            .codex
+        )
+    }
+
     func testGrassIslandRendersOnlyForExpandedActivityView() {
         XCTAssertTrue(
             NotchContentView.shouldRenderGrassIsland(

--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -1364,6 +1364,101 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(session.task, .working)
     }
 
+    func testPinnedSessionHoldsWhileOtherSessionsHaveNoNewerActivity() {
+        let selected = SessionData(sessionId: "pinned-claude", provider: .claude, cwd: "/tmp/project")
+        let selectedAt = Date(timeIntervalSince1970: 1_000)
+
+        let pinned = SessionStore.pinnedSession(
+            selected: selected,
+            selectedAt: selectedAt,
+            otherSessionActivities: [
+                Date(timeIntervalSince1970: 900),
+                Date(timeIntervalSince1970: 1_000),
+            ]
+        )
+
+        XCTAssertEqual(pinned?.id, selected.id)
+    }
+
+    func testPinnedSessionReleasesWhenAnotherSessionActsAfterSelection() {
+        let selected = SessionData(sessionId: "pinned-claude", provider: .claude, cwd: "/tmp/project")
+
+        let pinned = SessionStore.pinnedSession(
+            selected: selected,
+            selectedAt: Date(timeIntervalSince1970: 1_000),
+            otherSessionActivities: [Date(timeIntervalSince1970: 1_001)]
+        )
+
+        XCTAssertNil(pinned)
+    }
+
+    func testPinnedSessionRequiresBothSelectionAndTimestamp() {
+        let session = SessionData(sessionId: "pinned-claude", provider: .claude, cwd: "/tmp/project")
+
+        XCTAssertNil(
+            SessionStore.pinnedSession(
+                selected: nil,
+                selectedAt: Date(timeIntervalSince1970: 1_000),
+                otherSessionActivities: []
+            )
+        )
+        XCTAssertNil(
+            SessionStore.pinnedSession(
+                selected: session,
+                selectedAt: nil,
+                otherSessionActivities: []
+            )
+        )
+    }
+
+    func testSelectionTimestampFollowsSelectAndClear() {
+        let store = SessionStore.shared
+        let session = store.process(makeEvent(
+            sessionId: "select-stamp-\(UUID().uuidString)",
+            event: .userPromptSubmitted,
+            status: "processing",
+            userPrompt: "hello"
+        ))
+
+        store.selectSession(session.sessionKey)
+        XCTAssertNotNil(store.selectedAt)
+
+        store.clearSelectedSession()
+        XCTAssertNil(store.selectedAt)
+    }
+
+    func testLatestSessionHonorsSelectionPinUntilAnotherSessionActs() {
+        let store = SessionStore.shared
+        let first = store.process(makeEvent(
+            sessionId: "pin-first-\(UUID().uuidString)",
+            event: .userPromptSubmitted,
+            status: "processing",
+            userPrompt: "first"
+        ))
+        let secondSessionId = "pin-second-\(UUID().uuidString)"
+        let second = store.process(makeEvent(
+            sessionId: secondSessionId,
+            provider: .codex,
+            event: .userPromptSubmitted,
+            status: "processing",
+            userPrompt: "second"
+        ))
+
+        XCTAssertEqual(store.latestSession(excluding: nil)?.id, second.id)
+
+        store.selectSession(first.sessionKey)
+        XCTAssertEqual(store.latestSession(excluding: nil)?.id, first.id)
+
+        _ = store.process(makeEvent(
+            sessionId: secondSessionId,
+            provider: .codex,
+            event: .userPromptSubmitted,
+            status: "processing",
+            userPrompt: "second again"
+        ))
+        XCTAssertEqual(store.latestSession(excluding: nil)?.id, second.id)
+    }
+
     private func makeEvent(
         sessionId: String,
         provider: AgentProvider = .claude,

--- a/notchi/Tests/UsageDetailViewTests.swift
+++ b/notchi/Tests/UsageDetailViewTests.swift
@@ -12,6 +12,10 @@ final class UsageDetailViewTests: XCTestCase {
             UsageDetailView.resolvedProvider(selected: .codex, claudeHasData: true, codexHasData: true),
             .codex
         )
+        XCTAssertEqual(
+            UsageDetailView.resolvedProvider(selected: .codex, claudeHasData: false, codexHasData: true),
+            .codex
+        )
     }
 
     func testResolvedProviderReroutesDatalessClaudeToCodexWithData() {
@@ -22,10 +26,6 @@ final class UsageDetailViewTests: XCTestCase {
     }
 
     func testResolvedProviderReroutesDatalessCodexToClaudeWithData() {
-        XCTAssertEqual(
-            UsageDetailView.resolvedProvider(selected: .codex, claudeHasData: false, codexHasData: true),
-            .codex
-        )
         XCTAssertEqual(
             UsageDetailView.resolvedProvider(selected: .codex, claudeHasData: true, codexHasData: false),
             .claude

--- a/notchi/Tests/UsageDetailViewTests.swift
+++ b/notchi/Tests/UsageDetailViewTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import notchi
+
+@MainActor
+final class UsageDetailViewTests: XCTestCase {
+    func testResolvedProviderKeepsSelectionWhenItHasData() {
+        XCTAssertEqual(
+            UsageDetailView.resolvedProvider(selected: .claude, claudeHasData: true, codexHasData: true),
+            .claude
+        )
+        XCTAssertEqual(
+            UsageDetailView.resolvedProvider(selected: .codex, claudeHasData: true, codexHasData: true),
+            .codex
+        )
+    }
+
+    func testResolvedProviderReroutesDatalessClaudeToCodexWithData() {
+        XCTAssertEqual(
+            UsageDetailView.resolvedProvider(selected: .claude, claudeHasData: false, codexHasData: true),
+            .codex
+        )
+    }
+
+    func testResolvedProviderReroutesDatalessCodexToClaudeWithData() {
+        XCTAssertEqual(
+            UsageDetailView.resolvedProvider(selected: .codex, claudeHasData: false, codexHasData: true),
+            .codex
+        )
+        XCTAssertEqual(
+            UsageDetailView.resolvedProvider(selected: .codex, claudeHasData: true, codexHasData: false),
+            .claude
+        )
+    }
+
+    func testResolvedProviderKeepsSelectionWhenNoProviderHasData() {
+        XCTAssertEqual(
+            UsageDetailView.resolvedProvider(selected: .claude, claudeHasData: false, codexHasData: false),
+            .claude
+        )
+        XCTAssertEqual(
+            UsageDetailView.resolvedProvider(selected: .codex, claudeHasData: false, codexHasData: false),
+            .codex
+        )
+    }
+}

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -301,7 +301,7 @@ struct NotchContentView: View {
     }
 
     private var ringProvider: AgentProvider {
-        activeSession?.provider ?? .claude
+        activeSession?.provider ?? AppSettings.lastUsedAgentProvider
     }
 
     private var ringIsStale: Bool {
@@ -638,17 +638,18 @@ struct NotchContentView: View {
                 .opacity(collapsedHeaderSpriteVisuals.opacity)
                 .animation(collapsedHeaderSpriteVisibilityAnimation, value: isExpanded)
                 .frame(width: sideWidth)
-                .scaleEffect(collapsedHeaderSpriteScale, anchor: .bottom)
-                .offset(x: ringOffsetX(side: side), y: collapsedUsageRingOffsetY)
                 .contentShape(Rectangle())
                 .simultaneousGesture(
                     DragGesture(minimumDistance: 0)
                         .onChanged { _ in
-                            guard !isExpanded, !showingUsageDetail else { return }
+                            guard !isExpanded else { return }
                             isActivityCollapsed = false
                             showingUsageDetail = true
+                            panelManager.expand()
                         }
                 )
+                .scaleEffect(collapsedHeaderSpriteScale, anchor: .bottom)
+                .offset(x: ringOffsetX(side: side), y: collapsedUsageRingOffsetY)
         } else {
             Color.clear.frame(width: sideWidth)
         }

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -95,6 +95,7 @@ struct NotchContentView: View {
     @State private var showingPanelSettings = false
     @State private var showingPanelSettingsDetail = false
     @State private var showingUsageDetail = false
+    @State private var usageDetailProvider: AgentProvider?
     @State private var showingSessionActivity = false
     @State private var isMuted = AppSettings.isMuted
     @State private var isActivityCollapsed = false
@@ -300,8 +301,25 @@ struct NotchContentView: View {
         max(0, notchSize.height - 12) + 24
     }
 
+    private var collapsedSpriteSession: SessionData? {
+        sessionForSprite(leftContent, excluding: rightContent.spriteProvider)
+            ?? sessionForSprite(rightContent, excluding: leftContent.spriteProvider)
+    }
+
     private var ringProvider: AgentProvider {
-        activeSession?.provider ?? AppSettings.lastUsedAgentProvider
+        Self.collapsedRingProvider(
+            spriteSession: collapsedSpriteSession,
+            effectiveSession: activeSession,
+            lastUsedProvider: AppSettings.lastUsedAgentProvider
+        )
+    }
+
+    static func collapsedRingProvider(
+        spriteSession: SessionData?,
+        effectiveSession: SessionData?,
+        lastUsedProvider: AgentProvider
+    ) -> AgentProvider {
+        (spriteSession ?? effectiveSession)?.provider ?? lastUsedProvider
     }
 
     private var ringIsStale: Bool {
@@ -470,6 +488,7 @@ struct NotchContentView: View {
                 showingPanelSettingsDetail = false
                 showingSessionActivity = false
                 showingUsageDetail = false
+                usageDetailProvider = nil
                 hoveredSessionId = nil
             }
         }
@@ -492,6 +511,7 @@ struct NotchContentView: View {
                         sessionStore: sessionStore,
                         usageService: usageService,
                         codexUsageService: CodexUsageService.shared,
+                        usageDetailProvider: usageDetailProvider,
                         showingSettings: $showingPanelSettings,
                         showingSettingsDetail: $showingPanelSettingsDetail,
                         showingSessionActivity: $showingSessionActivity,
@@ -581,6 +601,7 @@ struct NotchContentView: View {
             }
         } else if showingUsageDetail {
             showingUsageDetail = false
+            usageDetailProvider = nil
         } else if showingSessionActivity {
             showingSessionActivity = false
             sessionStore.clearSelectedSession()
@@ -589,6 +610,7 @@ struct NotchContentView: View {
 
     private func selectGrassSession(_ sessionId: String) {
         showingUsageDetail = false
+        usageDetailProvider = nil
         guard sessionStore.activeSessionCount >= 2 else { return }
 
         let shouldPlayHaptic = sessionStore.selectedSessionId != sessionId || !showingSessionActivity
@@ -628,7 +650,20 @@ struct NotchContentView: View {
             ringSlot(side: side)
         case .latest, .claude, .codex:
             spriteSlot(content: spriteContent(for: content, side: side), side: side)
+                .simultaneousGesture(collapsedSpriteGesture(for: content, side: side))
         }
+    }
+
+    private func collapsedSpriteGesture(for content: NotchSlotContent, side: NotchSide) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { _ in
+                guard !isExpanded else { return }
+                let excluded = (side == .left ? rightContent : leftContent).spriteProvider
+                guard let session = sessionForSprite(content, excluding: excluded) else { return }
+                sessionStore.selectSession(matchingStableId: session.id)
+                showingSessionActivity = true
+                panelManager.expand()
+            }
     }
 
     @ViewBuilder
@@ -644,6 +679,7 @@ struct NotchContentView: View {
                         .onChanged { _ in
                             guard !isExpanded else { return }
                             isActivityCollapsed = false
+                            usageDetailProvider = ringProvider
                             showingUsageDetail = true
                             panelManager.expand()
                         }

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -469,6 +469,7 @@ struct NotchContentView: View {
                 showingPanelSettings = false
                 showingPanelSettingsDetail = false
                 showingSessionActivity = false
+                showingUsageDetail = false
                 hoveredSessionId = nil
             }
         }
@@ -639,6 +640,15 @@ struct NotchContentView: View {
                 .frame(width: sideWidth)
                 .scaleEffect(collapsedHeaderSpriteScale, anchor: .bottom)
                 .offset(x: ringOffsetX(side: side), y: collapsedUsageRingOffsetY)
+                .contentShape(Rectangle())
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { _ in
+                            guard !isExpanded, !showingUsageDetail else { return }
+                            isActivityCollapsed = false
+                            showingUsageDetail = true
+                        }
+                )
         } else {
             Color.clear.frame(width: sideWidth)
         }

--- a/notchi/notchi/Services/ClaudeUsageService.swift
+++ b/notchi/notchi/Services/ClaudeUsageService.swift
@@ -695,6 +695,14 @@ final class ClaudeUsageService {
     var isConnected = false
     var isUsageStale = false
     var isUsingHeadersFallback: Bool { isHeadersFallbackActive }
+    var hasUsageData: Bool {
+        UsageMetrics.claudeHasData(
+            usage: currentUsage,
+            weeklyUsage: currentWeeklyUsage,
+            modelUsage: currentModelUsage,
+            extraUsage: currentExtraUsage
+        )
+    }
     var lastObservedAt: Date?
     var recoveryAction: ClaudeUsageRecoveryAction = .none
 

--- a/notchi/notchi/Services/CodexUsageService.swift
+++ b/notchi/notchi/Services/CodexUsageService.swift
@@ -52,6 +52,9 @@ final class CodexUsageService {
     var isUsageStale = false
     var statusMessage: String?
     var lastObservedAt: Date?
+    var hasUsageData: Bool {
+        UsageMetrics.codexHasData(usage: currentUsage, weeklyUsage: currentWeeklyUsage)
+    }
 
     private static let staleObservationInterval: TimeInterval = 15 * 60
 

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -11,6 +11,7 @@ final class SessionStore {
 
     private(set) var sessions: [ProviderSessionKey: SessionData] = [:]
     private(set) var selectedSessionKey: ProviderSessionKey?
+    private(set) var selectedAt: Date?
     private var displaySessionNumbersById: [String: Int] = [:]
     private var resolveCodexMetadata: @Sendable ([String]) -> [String: CodexThreadMetadata] = { transcriptPaths in
         CodexThreadMetadataResolver.metadata(forTranscriptPaths: transcriptPaths)
@@ -58,12 +59,38 @@ final class SessionStore {
     }
 
     func latestSession(excluding provider: AgentProvider?) -> SessionData? {
-        sortedSessions.first { $0.provider != provider }
+        if let pinned = pinnedSelectedSession, pinned.provider != provider {
+            return pinned
+        }
+        return sortedSessions.first { $0.provider != provider }
+    }
+
+    private var pinnedSelectedSession: SessionData? {
+        guard let selected = selectedSession else { return nil }
+        let otherActivities = sessions.values
+            .filter { $0.sessionKey != selected.sessionKey }
+            .map(\.lastActivity)
+        return Self.pinnedSession(
+            selected: selected,
+            selectedAt: selectedAt,
+            otherSessionActivities: otherActivities
+        )
+    }
+
+    static func pinnedSession(
+        selected: SessionData?,
+        selectedAt: Date?,
+        otherSessionActivities: [Date]
+    ) -> SessionData? {
+        guard let selected, let selectedAt else { return nil }
+        let overridden = otherSessionActivities.contains { $0 > selectedAt }
+        return overridden ? nil : selected
     }
 
     func selectSession(_ sessionKey: ProviderSessionKey) {
         guard sessions[sessionKey] != nil else { return }
         selectedSessionKey = sessionKey
+        selectedAt = Date()
     }
 
     @discardableResult
@@ -75,6 +102,7 @@ final class SessionStore {
 
     func clearSelectedSession() {
         selectedSessionKey = nil
+        selectedAt = nil
     }
 
     func process(_ event: HookEvent, sessionStartTimeOverride: Date? = nil) -> SessionData {
@@ -220,8 +248,10 @@ final class SessionStore {
 
         if activeSessionCount == 1 {
             selectedSessionKey = session.sessionKey
+            selectedAt = Date()
         } else {
             selectedSessionKey = nil
+            selectedAt = nil
         }
 
         return session
@@ -234,10 +264,12 @@ final class SessionStore {
 
         if selectedSessionKey == sessionKey {
             selectedSessionKey = nil
+            selectedAt = nil
         }
 
         if selectedSessionKey == nil, activeSessionCount == 1 {
             selectedSessionKey = sessions.keys.first
+            selectedAt = Date()
         }
     }
 

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -205,20 +205,32 @@ struct ExpandedPanelView: View {
     }
 
     private var usageDetailDefaultProvider: AgentProvider {
-        usageContextSession?.provider ?? sharedUsageBarState?.provider ?? .claude
+        Self.usageDetailDefaultProvider(
+            contextSession: usageContextSession,
+            lastUsedProvider: AppSettings.lastUsedAgentProvider,
+            claudeHasData: claudeHasUsageData,
+            codexHasData: codexHasUsageData
+        )
     }
 
-    private var hasUsageDetailData: Bool {
+    private var claudeHasUsageData: Bool {
         UsageMetrics.claudeHasData(
             usage: usageService.currentUsage,
             weeklyUsage: usageService.currentWeeklyUsage,
             modelUsage: usageService.currentModelUsage,
             extraUsage: usageService.currentExtraUsage
         )
-            || UsageMetrics.codexHasData(
-                usage: codexUsageService.currentUsage,
-                weeklyUsage: codexUsageService.currentWeeklyUsage
-            )
+    }
+
+    private var codexHasUsageData: Bool {
+        UsageMetrics.codexHasData(
+            usage: codexUsageService.currentUsage,
+            weeklyUsage: codexUsageService.currentWeeklyUsage
+        )
+    }
+
+    private var hasUsageDetailData: Bool {
+        claudeHasUsageData || codexHasUsageData
     }
 
     private var state: NotchiState {
@@ -556,6 +568,25 @@ struct ExpandedPanelView: View {
         appUsageEnabled: Bool = AppSettings.isUsageEnabled
     ) -> Bool {
         provider == .codex || appUsageEnabled
+    }
+
+    static func usageDetailDefaultProvider(
+        contextSession: SessionData?,
+        lastUsedProvider: AgentProvider,
+        claudeHasData: Bool,
+        codexHasData: Bool
+    ) -> AgentProvider {
+        if let contextSession {
+            return contextSession.provider
+        }
+        switch lastUsedProvider {
+        case .claude where claudeHasData, .codex where codexHasData:
+            return lastUsedProvider
+        default:
+            if claudeHasData { return .claude }
+            if codexHasData { return .codex }
+            return lastUsedProvider
+        }
     }
 
     static func sharedUsageBarState(

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -162,6 +162,7 @@ struct ExpandedPanelView: View {
     let sessionStore: SessionStore
     let usageService: ClaudeUsageService
     let codexUsageService: CodexUsageService
+    let usageDetailProvider: AgentProvider?
     @Binding var showingSettings: Bool
     @Binding var showingSettingsDetail: Bool
     @Binding var showingSessionActivity: Bool
@@ -173,6 +174,7 @@ struct ExpandedPanelView: View {
         sessionStore: SessionStore,
         usageService: ClaudeUsageService,
         codexUsageService: CodexUsageService,
+        usageDetailProvider: AgentProvider?,
         showingSettings: Binding<Bool>,
         showingSettingsDetail: Binding<Bool>,
         showingSessionActivity: Binding<Bool>,
@@ -183,6 +185,7 @@ struct ExpandedPanelView: View {
         self.sessionStore = sessionStore
         self.usageService = usageService
         self.codexUsageService = codexUsageService
+        self.usageDetailProvider = usageDetailProvider
         _showingSettings = showingSettings
         _showingSettingsDetail = showingSettingsDetail
         _showingSessionActivity = showingSessionActivity
@@ -206,6 +209,7 @@ struct ExpandedPanelView: View {
 
     private var usageDetailDefaultProvider: AgentProvider {
         Self.usageDetailDefaultProvider(
+            requestedProvider: usageDetailProvider,
             contextSession: usageContextSession,
             lastUsedProvider: AppSettings.lastUsedAgentProvider,
             claudeHasData: claudeHasUsageData,
@@ -571,11 +575,15 @@ struct ExpandedPanelView: View {
     }
 
     static func usageDetailDefaultProvider(
+        requestedProvider: AgentProvider?,
         contextSession: SessionData?,
         lastUsedProvider: AgentProvider,
         claudeHasData: Bool,
         codexHasData: Bool
     ) -> AgentProvider {
+        if let requestedProvider {
+            return requestedProvider
+        }
         if let contextSession {
             return contextSession.provider
         }

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -211,30 +211,12 @@ struct ExpandedPanelView: View {
         Self.usageDetailDefaultProvider(
             requestedProvider: usageDetailProvider,
             contextSession: usageContextSession,
-            lastUsedProvider: AppSettings.lastUsedAgentProvider,
-            claudeHasData: claudeHasUsageData,
-            codexHasData: codexHasUsageData
-        )
-    }
-
-    private var claudeHasUsageData: Bool {
-        UsageMetrics.claudeHasData(
-            usage: usageService.currentUsage,
-            weeklyUsage: usageService.currentWeeklyUsage,
-            modelUsage: usageService.currentModelUsage,
-            extraUsage: usageService.currentExtraUsage
-        )
-    }
-
-    private var codexHasUsageData: Bool {
-        UsageMetrics.codexHasData(
-            usage: codexUsageService.currentUsage,
-            weeklyUsage: codexUsageService.currentWeeklyUsage
+            lastUsedProvider: AppSettings.lastUsedAgentProvider
         )
     }
 
     private var hasUsageDetailData: Bool {
-        claudeHasUsageData || codexHasUsageData
+        usageService.hasUsageData || codexUsageService.hasUsageData
     }
 
     private var state: NotchiState {
@@ -577,24 +559,9 @@ struct ExpandedPanelView: View {
     static func usageDetailDefaultProvider(
         requestedProvider: AgentProvider?,
         contextSession: SessionData?,
-        lastUsedProvider: AgentProvider,
-        claudeHasData: Bool,
-        codexHasData: Bool
+        lastUsedProvider: AgentProvider
     ) -> AgentProvider {
-        if let requestedProvider {
-            return requestedProvider
-        }
-        if let contextSession {
-            return contextSession.provider
-        }
-        switch lastUsedProvider {
-        case .claude where claudeHasData, .codex where codexHasData:
-            return lastUsedProvider
-        default:
-            if claudeHasData { return .claude }
-            if codexHasData { return .codex }
-            return lastUsedProvider
-        }
+        requestedProvider ?? contextSession?.provider ?? lastUsedProvider
     }
 
     static func sharedUsageBarState(

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -25,19 +25,11 @@ struct UsageDetailView: View {
     }
 
     private var claudeHasData: Bool {
-        UsageMetrics.claudeHasData(
-            usage: claudeUsage.currentUsage,
-            weeklyUsage: claudeUsage.currentWeeklyUsage,
-            modelUsage: claudeUsage.currentModelUsage,
-            extraUsage: claudeUsage.currentExtraUsage
-        )
+        claudeUsage.hasUsageData
     }
 
     private var codexHasData: Bool {
-        UsageMetrics.codexHasData(
-            usage: codexUsage.currentUsage,
-            weeklyUsage: codexUsage.currentWeeklyUsage
-        )
+        codexUsage.hasUsageData
     }
 
     private var showsToggle: Bool {
@@ -45,10 +37,22 @@ struct UsageDetailView: View {
     }
 
     private var resolvedProvider: AgentProvider {
-        switch selectedProvider {
+        Self.resolvedProvider(
+            selected: selectedProvider,
+            claudeHasData: claudeHasData,
+            codexHasData: codexHasData
+        )
+    }
+
+    static func resolvedProvider(
+        selected: AgentProvider,
+        claudeHasData: Bool,
+        codexHasData: Bool
+    ) -> AgentProvider {
+        switch selected {
         case .claude where !claudeHasData && codexHasData: return .codex
         case .codex where !codexHasData && claudeHasData: return .claude
-        default: return selectedProvider
+        default: return selected
         }
     }
 


### PR DESCRIPTION
## Summary

The collapsed notch now behaves as a coherent unit — what it displays, what clicking it does, and what the expanded panel opens to all agree.

- **Ring click → usage detail.** Clicking the usage ring expands the panel directly to the usage view, on the ring's own provider. Plain notch clicks always open the activity view (the panel no longer remembers the usage view across collapse).
- **Mascot click → its session.** With multiple sessions, clicking the mascot selects that session and opens its activity directly instead of the session picker.
- **Ring pairs with the mascot.** The ring shows usage for the session the sprite slot actually displays (previously it followed the sticky selected session, so a Codex ring could sit next to a Claude mascot). When idle, both fall back to the last-used agent provider.
- **Last-viewed session pins the collapsed notch.** After viewing a session in the panel and collapsing, the notch keeps showing it until another session produces a newer event.
- **Usage detail defaults to last-used provider** when idle, with the dataless-provider reroute consolidated in `UsageDetailView.resolvedProvider`; both usage services now expose a shared `hasUsageData`.

## Fixes found in review

- Ring tap target didn't track the ring visually (`contentShape`/gesture sat outside the `offset` transform).
- The deep link depended on the mouse monitor's deferred-Task timing; the gesture now requests expansion itself.

## Testing

- 17 new/updated unit tests across `ExpandedPanelViewTests`, `NotchContentViewTests`, `UsageDetailViewTests`, `SessionStoreTests` (provider defaults, reroute rule, ring pairing, selection pin incl. boundary cases).
- `./scripts/test.sh focused` and the touched suites all pass; manually verified ring/mascot click-through, provider pairing, and the pin flow.