### PR TITLE
perf: reduce Codex refresh churn and sprite render overhead

### DIFF
--- a/notchi/Tests/CodexSQLiteURLCacheTests.swift
+++ b/notchi/Tests/CodexSQLiteURLCacheTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import notchi
+
+nonisolated final class CodexSQLiteURLCacheTests: XCTestCase {
+    private static let ttl: TimeInterval = 60
+
+    private nonisolated final class Recorder: @unchecked Sendable {
+        var listedPrefixes: [String] = []
+        var urlsByPrefix: [String: URL] = [:]
+        var existingPaths: Set<String> = []
+        var now = Date(timeIntervalSinceReferenceDate: 1_000)
+        private let lock = NSLock()
+
+        func list(_ prefix: String) -> URL? {
+            lock.lock()
+            defer { lock.unlock() }
+            listedPrefixes.append(prefix)
+            return urlsByPrefix[prefix]
+        }
+
+        func fileExists(_ url: URL) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return existingPaths.contains(url.path)
+        }
+
+        func listCount(for prefix: String) -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return listedPrefixes.count { $0 == prefix }
+        }
+    }
+
+    private func makeCache(recorder: Recorder) -> CodexSQLiteURLCache {
+        CodexSQLiteURLCache(
+            ttl: Self.ttl,
+            list: { recorder.list($0) },
+            fileExists: { recorder.fileExists($0) },
+            now: { recorder.now }
+        )
+    }
+
+    private func registerURL(_ recorder: Recorder, prefix: String, path: String) {
+        let url = URL(fileURLWithPath: path)
+        recorder.urlsByPrefix[prefix] = url
+        recorder.existingPaths.insert(url.path)
+    }
+
+    func testSecondLookupWithinTTLReturnsCachedURLWithoutRelisting() {
+        let recorder = Recorder()
+        registerURL(recorder, prefix: "state_", path: "/tmp/codex/state_3.sqlite")
+        let cache = makeCache(recorder: recorder)
+
+        let first = cache.url(prefix: "state_")
+        recorder.now = recorder.now.addingTimeInterval(Self.ttl - 1)
+        let second = cache.url(prefix: "state_")
+
+        XCTAssertEqual(first?.path, "/tmp/codex/state_3.sqlite")
+        XCTAssertEqual(second?.path, "/tmp/codex/state_3.sqlite")
+        XCTAssertEqual(recorder.listCount(for: "state_"), 1)
+    }
+
+    func testLookupAfterTTLExpiryRelistsAndPicksUpNewerDatabase() {
+        let recorder = Recorder()
+        registerURL(recorder, prefix: "state_", path: "/tmp/codex/state_3.sqlite")
+        let cache = makeCache(recorder: recorder)
+
+        _ = cache.url(prefix: "state_")
+        registerURL(recorder, prefix: "state_", path: "/tmp/codex/state_4.sqlite")
+        recorder.now = recorder.now.addingTimeInterval(Self.ttl + 1)
+        let refreshed = cache.url(prefix: "state_")
+
+        XCTAssertEqual(refreshed?.path, "/tmp/codex/state_4.sqlite")
+        XCTAssertEqual(recorder.listCount(for: "state_"), 2)
+    }
+
+    func testLookupRelistsWhenCachedFileDisappears() {
+        let recorder = Recorder()
+        registerURL(recorder, prefix: "logs_", path: "/tmp/codex/logs_1.sqlite")
+        let cache = makeCache(recorder: recorder)
+
+        _ = cache.url(prefix: "logs_")
+        recorder.existingPaths.remove("/tmp/codex/logs_1.sqlite")
+        registerURL(recorder, prefix: "logs_", path: "/tmp/codex/logs_2.sqlite")
+        let refreshed = cache.url(prefix: "logs_")
+
+        XCTAssertEqual(refreshed?.path, "/tmp/codex/logs_2.sqlite")
+        XCTAssertEqual(recorder.listCount(for: "logs_"), 2)
+    }
+
+    func testPrefixesAreCachedIndependently() {
+        let recorder = Recorder()
+        registerURL(recorder, prefix: "state_", path: "/tmp/codex/state_3.sqlite")
+        registerURL(recorder, prefix: "logs_", path: "/tmp/codex/logs_1.sqlite")
+        let cache = makeCache(recorder: recorder)
+
+        XCTAssertEqual(cache.url(prefix: "state_")?.path, "/tmp/codex/state_3.sqlite")
+        XCTAssertEqual(cache.url(prefix: "logs_")?.path, "/tmp/codex/logs_1.sqlite")
+        XCTAssertEqual(cache.url(prefix: "state_")?.path, "/tmp/codex/state_3.sqlite")
+        XCTAssertEqual(recorder.listCount(for: "state_"), 1)
+        XCTAssertEqual(recorder.listCount(for: "logs_"), 1)
+    }
+
+    func testMissingDatabaseIsNotCachedAndRelistsOnNextLookup() {
+        let recorder = Recorder()
+        let cache = makeCache(recorder: recorder)
+
+        XCTAssertNil(cache.url(prefix: "state_"))
+        registerURL(recorder, prefix: "state_", path: "/tmp/codex/state_1.sqlite")
+        let found = cache.url(prefix: "state_")
+
+        XCTAssertEqual(found?.path, "/tmp/codex/state_1.sqlite")
+        XCTAssertEqual(recorder.listCount(for: "state_"), 2)
+    }
+}

--- a/notchi/Tests/CodexUsageScannerTests.swift
+++ b/notchi/Tests/CodexUsageScannerTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import notchi
+
+@MainActor
+final class CodexUsageScannerTests: XCTestCase {
+    private var rolloutURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        rolloutURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-scanner-\(UUID().uuidString).jsonl")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: rolloutURL)
+        super.tearDown()
+    }
+
+    func testFirstScanReadsWholeFileAndSubsequentScanReadsOnlyAppendedBytes() throws {
+        let firstLine = tokenCountLine(usedPercent: 11, timestamp: "2026-04-25T07:01:00.000Z")
+        let appendedLine = tokenCountLine(usedPercent: 23, timestamp: "2026-04-25T07:03:14.886Z")
+        try firstLine.write(to: rolloutURL, atomically: true, encoding: .utf8)
+        let scanner = CodexUsageScanner()
+
+        let initial = scanner.latestSnapshot(transcriptPaths: [rolloutURL.path])
+        XCTAssertEqual(initial?.usage.usagePercentage, 11)
+        XCTAssertEqual(scanner.bytesReadForTesting, UInt64(firstLine.utf8.count))
+
+        try append(appendedLine, to: rolloutURL)
+        let updated = scanner.latestSnapshot(transcriptPaths: [rolloutURL.path])
+
+        XCTAssertEqual(updated?.usage.usagePercentage, 23)
+        XCTAssertEqual(
+            scanner.bytesReadForTesting,
+            UInt64(firstLine.utf8.count + appendedLine.utf8.count)
+        )
+    }
+
+    func testScanOfUnchangedFileReadsNoBytesAndReturnsCachedSnapshot() throws {
+        let line = tokenCountLine(usedPercent: 42, timestamp: "2026-04-25T07:03:14.886Z")
+        try line.write(to: rolloutURL, atomically: true, encoding: .utf8)
+        let scanner = CodexUsageScanner()
+
+        let first = scanner.latestSnapshot(transcriptPaths: [rolloutURL.path])
+        let bytesAfterFirstScan = scanner.bytesReadForTesting
+        let second = scanner.latestSnapshot(transcriptPaths: [rolloutURL.path])
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(second?.usage.usagePercentage, 42)
+        XCTAssertEqual(scanner.bytesReadForTesting, bytesAfterFirstScan)
+    }
+
+    func testTruncatedFileIsRescannedFromScratch() throws {
+        let longLine = tokenCountLine(usedPercent: 55, timestamp: "2026-04-25T07:01:00.000Z")
+        let shortLine = tokenCountLine(usedPercent: 8, timestamp: "2026-04-25T06:00:00.000Z")
+        try (longLine + longLine).write(to: rolloutURL, atomically: true, encoding: .utf8)
+        let scanner = CodexUsageScanner()
+
+        XCTAssertEqual(scanner.latestSnapshot(transcriptPaths: [rolloutURL.path])?.usage.usagePercentage, 55)
+
+        try shortLine.write(to: rolloutURL, atomically: true, encoding: .utf8)
+        let rescanned = scanner.latestSnapshot(transcriptPaths: [rolloutURL.path])
+
+        XCTAssertEqual(rescanned?.usage.usagePercentage, 8)
+        XCTAssertEqual(
+            rescanned?.observedAt.timeIntervalSince1970 ?? 0,
+            parseISO("2026-04-25T06:00:00.000Z").timeIntervalSince1970,
+            accuracy: 0.001
+        )
+    }
+
+    func testAppendedLinesWithoutTokenCountKeepPreviousSnapshot() throws {
+        let line = tokenCountLine(usedPercent: 33, timestamp: "2026-04-25T07:03:14.886Z")
+        try line.write(to: rolloutURL, atomically: true, encoding: .utf8)
+        let scanner = CodexUsageScanner()
+
+        XCTAssertEqual(scanner.latestSnapshot(transcriptPaths: [rolloutURL.path])?.usage.usagePercentage, 33)
+
+        try append("{\"timestamp\":\"2026-04-25T07:04:00.000Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\"}}\n", to: rolloutURL)
+        let after = scanner.latestSnapshot(transcriptPaths: [rolloutURL.path])
+
+        XCTAssertEqual(after?.usage.usagePercentage, 33)
+    }
+
+    func testUnterminatedFinalLineIsNotSkippedOnceCompleted() throws {
+        let firstLine = tokenCountLine(usedPercent: 11, timestamp: "2026-04-25T07:01:00.000Z")
+        let secondLine = tokenCountLine(usedPercent: 77, timestamp: "2026-04-25T07:05:00.000Z")
+        let splitIndex = secondLine.index(secondLine.startIndex, offsetBy: 40)
+        try (firstLine + String(secondLine[..<splitIndex])).write(to: rolloutURL, atomically: true, encoding: .utf8)
+        let scanner = CodexUsageScanner()
+
+        XCTAssertEqual(scanner.latestSnapshot(transcriptPaths: [rolloutURL.path])?.usage.usagePercentage, 11)
+
+        try append(String(secondLine[splitIndex...]), to: rolloutURL)
+        let completed = scanner.latestSnapshot(transcriptPaths: [rolloutURL.path])
+
+        XCTAssertEqual(completed?.usage.usagePercentage, 77)
+    }
+
+    func testLatestSnapshotAcrossPathsPicksMostRecentObservation() throws {
+        let olderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-scanner-older-\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: olderURL) }
+        try tokenCountLine(usedPercent: 5, timestamp: "2026-04-25T06:00:00.000Z")
+            .write(to: olderURL, atomically: true, encoding: .utf8)
+        try tokenCountLine(usedPercent: 61, timestamp: "2026-04-25T07:05:00.000Z")
+            .write(to: rolloutURL, atomically: true, encoding: .utf8)
+        let scanner = CodexUsageScanner()
+
+        let snapshot = scanner.latestSnapshot(transcriptPaths: [olderURL.path, rolloutURL.path])
+
+        XCTAssertEqual(snapshot?.usage.usagePercentage, 61)
+    }
+
+    private func tokenCountLine(usedPercent: Double, timestamp: String) -> String {
+        "{\"timestamp\":\"\(timestamp)\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"rate_limits\":{\"primary\":{\"used_percent\":\(usedPercent),\"window_minutes\":300,\"resets_at\":1777103326}}}}\n"
+    }
+
+    private func append(_ text: String, to url: URL) throws {
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(text.utf8))
+    }
+
+    private func parseISO(_ value: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: value)!
+    }
+}

--- a/notchi/Tests/GrassSpriteMotionTests.swift
+++ b/notchi/Tests/GrassSpriteMotionTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import notchi
+
+@MainActor
+final class GrassSpriteMotionTests: XCTestCase {
+    func testReduceMotionZeroesAllMotionAndPausesTheClock() {
+        for task in [NotchiTask.idle, .working, .waiting] {
+            let motion = GrassSpriteMotion(state: NotchiState(task: task), reduceMotion: true)
+
+            XCTAssertEqual(motion.bobAmplitude, 0, task.rawValue)
+            XCTAssertEqual(motion.swayAmplitude, 0, task.rawValue)
+            XCTAssertEqual(motion.trembleAmplitude, 0, task.rawValue)
+            XCTAssertFalse(motion.isAnimating, task.rawValue)
+        }
+    }
+
+    func testMotionClockRunsAtFullCadenceForAllTasks() {
+        for task in [NotchiTask.idle, .working, .waiting, .sleeping] {
+            let motion = GrassSpriteMotion(state: NotchiState(task: task), reduceMotion: false)
+
+            XCTAssertEqual(motion.frameInterval, 1.0 / 30.0, accuracy: 0.0001, task.rawValue)
+        }
+    }
+
+    func testAmplitudesMatchLegacyGrassValuesWithoutReduceMotion() {
+        let idle = GrassSpriteMotion(state: NotchiState(task: .idle), reduceMotion: false)
+        let working = GrassSpriteMotion(state: NotchiState(task: .working), reduceMotion: false)
+        let sleeping = GrassSpriteMotion(state: NotchiState(task: .sleeping), reduceMotion: false)
+
+        XCTAssertEqual(idle.bobAmplitude, 1)
+        XCTAssertEqual(working.bobAmplitude, 1.5)
+        XCTAssertEqual(working.bobDuration, 1.0)
+        XCTAssertEqual(idle.bobDuration, 1.5)
+        XCTAssertEqual(sleeping.bobAmplitude, 0)
+        XCTAssertEqual(sleeping.swayAmplitude, 0)
+        XCTAssertFalse(sleeping.isAnimating)
+        XCTAssertTrue(idle.isAnimating)
+    }
+
+    func testSobTremblesAtFullCadenceUnlessReduceMotion() {
+        var sobState = NotchiState(task: .working)
+        sobState.emotion = .sob
+        let sob = GrassSpriteMotion(state: sobState, reduceMotion: false)
+        let calmedSob = GrassSpriteMotion(state: sobState, reduceMotion: true)
+
+        XCTAssertEqual(sob.trembleAmplitude, 0.3)
+        XCTAssertTrue(sob.isAnimating)
+        XCTAssertEqual(calmedSob.trembleAmplitude, 0)
+        XCTAssertFalse(calmedSob.isAnimating)
+    }
+}

--- a/notchi/Tests/NotchiStateMachineTests.swift
+++ b/notchi/Tests/NotchiStateMachineTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import XCTest
 @testable import notchi
 
@@ -462,6 +463,96 @@ final class NotchiStateMachineTests: XCTestCase {
 
         XCTAssertGreaterThan(endedHookCalls, 0)
         XCTAssertEqual(CodexUsageService.shared.currentUsage?.usagePercentage, 15)
+    }
+
+    func testCodexCompactionRefreshDelayUsesDebounceWhenNoRecentRefresh() {
+        XCTAssertEqual(
+            NotchiStateMachine.codexCompactionRefreshDelay(sinceLastRefresh: nil),
+            .milliseconds(150)
+        )
+        XCTAssertEqual(
+            NotchiStateMachine.codexCompactionRefreshDelay(sinceLastRefresh: .seconds(3)),
+            .milliseconds(150)
+        )
+    }
+
+    func testCodexCompactionRefreshDelayEnforcesMinimumIntervalAfterRecentRefresh() {
+        XCTAssertEqual(
+            NotchiStateMachine.codexCompactionRefreshDelay(sinceLastRefresh: .zero),
+            .seconds(2)
+        )
+        XCTAssertEqual(
+            NotchiStateMachine.codexCompactionRefreshDelay(sinceLastRefresh: .milliseconds(500)),
+            .milliseconds(1500)
+        )
+        XCTAssertEqual(
+            NotchiStateMachine.codexCompactionRefreshDelay(sinceLastRefresh: .milliseconds(1900)),
+            .milliseconds(150)
+        )
+    }
+
+    func testTranscriptWriteBurstCoalescesIntoSingleCompactionRefresh() async throws {
+        let stateMachine = NotchiStateMachine.shared
+        stateMachine.setCodexThreadMetadataAutoRefreshEnabledForTesting(false)
+        let resolverCalls = OSAllocatedUnfairLock(initialState: 0)
+        SessionStore.shared.setCodexCompactionSignalResolverForTesting { _ in
+            resolverCalls.withLock { $0 += 1 }
+            return [:]
+        }
+        let sessionId = "codex-write-burst-\(UUID().uuidString)"
+        _ = SessionStore.shared.process(makeEvent(
+            sessionId: sessionId,
+            provider: .codex,
+            transcriptPath: "/tmp/write-burst-rollout.jsonl",
+            event: .userPromptSubmitted,
+            status: "processing",
+            userPrompt: "hello"
+        ))
+
+        for _ in 0..<8 {
+            stateMachine.requestCodexCompactionSignalRefreshForTesting()
+            try await Task.sleep(for: .milliseconds(60))
+        }
+
+        XCTAssertEqual(resolverCalls.withLock { $0 }, 1)
+    }
+
+    func testCompactionRefreshCanRunAgainAfterPreviousCycleCompletes() async throws {
+        let stateMachine = NotchiStateMachine.shared
+        stateMachine.setCodexThreadMetadataAutoRefreshEnabledForTesting(false)
+        let resolverCalls = OSAllocatedUnfairLock(initialState: 0)
+        SessionStore.shared.setCodexCompactionSignalResolverForTesting { _ in
+            resolverCalls.withLock { $0 += 1 }
+            return [:]
+        }
+        let sessionId = "codex-second-cycle-\(UUID().uuidString)"
+        _ = SessionStore.shared.process(makeEvent(
+            sessionId: sessionId,
+            provider: .codex,
+            transcriptPath: "/tmp/second-cycle-rollout.jsonl",
+            event: .userPromptSubmitted,
+            status: "processing",
+            userPrompt: "hello"
+        ))
+
+        stateMachine.requestCodexCompactionSignalRefreshForTesting()
+        let firstCycleRan = await waitUntil(timeout: 1.0) { resolverCalls.withLock { $0 } == 1 }
+        XCTAssertTrue(firstCycleRan)
+
+        stateMachine.requestCodexCompactionSignalRefreshForTesting()
+        let secondCycleRan = await waitUntil(timeout: 3.0) { resolverCalls.withLock { $0 } == 2 }
+
+        XCTAssertTrue(secondCycleRan)
+        XCTAssertEqual(resolverCalls.withLock { $0 }, 2)
+    }
+
+    private func waitUntil(timeout: TimeInterval, condition: @escaping () -> Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        return condition()
     }
 
     private func makeInteractiveSession(sessionId: String) -> SessionData {

--- a/notchi/Tests/NotchiStateTests.swift
+++ b/notchi/Tests/NotchiStateTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import notchi
+
+@MainActor
+final class NotchiStateTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        NotchiState.resetSpriteSheetMetadataCacheForTesting()
+    }
+
+    override func tearDown() {
+        NotchiState.resetSpriteSheetMetadataCacheForTesting()
+        super.tearDown()
+    }
+
+    func testRepeatedMetadataAccessDoesNotReprobeSpriteSheets() {
+        let state = NotchiState(task: .working)
+        _ = state.spriteSheetName
+        _ = state.frameCount
+        _ = state.columns
+        _ = state.animationFPS
+        let probesAfterFirstResolution = NotchiState.spriteSheetProbeCountForTesting
+        XCTAssertGreaterThan(probesAfterFirstResolution, 0)
+
+        _ = state.spriteSheetName
+        _ = state.frameCount
+        _ = state.columns
+        _ = state.animationFPS
+
+        XCTAssertEqual(NotchiState.spriteSheetProbeCountForTesting, probesAfterFirstResolution)
+    }
+
+    func testCachedSheetNamesAreKeyedByFamilyTaskAndEmotion() {
+        var claudeIdle = NotchiState(task: .idle)
+        claudeIdle.spriteFamily = .claude
+        var codexIdle = NotchiState(task: .idle)
+        codexIdle.spriteFamily = .codex
+        var claudeIdleHappy = NotchiState(task: .idle)
+        claudeIdleHappy.emotion = .happy
+
+        XCTAssertEqual(claudeIdle.spriteSheetName, "claude_idle_neutral")
+        XCTAssertEqual(codexIdle.spriteSheetName, "codex_idle_neutral")
+        XCTAssertEqual(claudeIdleHappy.spriteSheetName, "claude_idle_happy")
+        XCTAssertEqual(claudeIdle.spriteSheetName, "claude_idle_neutral")
+    }
+
+    func testEmotionFallbackResolutionSurvivesCaching() {
+        var workingElated = NotchiState(task: .working)
+        workingElated.emotion = .elated
+
+        XCTAssertEqual(workingElated.spriteSheetName, "claude_working_happy")
+        XCTAssertEqual(workingElated.spriteSheetName, "claude_working_happy")
+
+        var workingNeutral = NotchiState(task: .working)
+        workingNeutral.emotion = .neutral
+        XCTAssertEqual(workingNeutral.spriteSheetName, "claude_working_neutral")
+    }
+
+    func testFrameCountIsStableAcrossRepeatedAccess() {
+        let waving = NotchiState(task: .waving)
+        let idle = NotchiState(task: .idle)
+
+        XCTAssertEqual(waving.frameCount, 25)
+        XCTAssertEqual(idle.frameCount, 6)
+        XCTAssertEqual(waving.frameCount, 25)
+        XCTAssertEqual(idle.columns, 6)
+    }
+}

--- a/notchi/notchi/Models/NotchiState.swift
+++ b/notchi/notchi/Models/NotchiState.swift
@@ -1,4 +1,5 @@
 import AppKit
+import os
 
 enum NotchiTask: String, CaseIterable {
     case idle, working, sleeping, compacting, waiting, waving
@@ -140,8 +141,52 @@ struct NotchiState: Equatable {
     var spriteFamily: NotchiSpriteFamily = .claude
     private static var flippedSpriteSheetAvailability: [String: Bool] = [:]
 
+    private struct SpriteSheetMetadataKey: Hashable {
+        let family: NotchiSpriteFamily
+        let task: NotchiTask
+        let emotion: NotchiEmotion
+    }
+
+    private struct SpriteSheetMetadataCache {
+        var namesByKey: [SpriteSheetMetadataKey: String] = [:]
+        var frameCountsBySheet: [String: Int?] = [:]
+        var probeCount = 0
+    }
+
+    private static let spriteSheetMetadataCache = OSAllocatedUnfairLock(initialState: SpriteSheetMetadataCache())
+
+    private static func probeSpriteSheetImage(named name: String) -> NSImage? {
+#if DEBUG
+        spriteSheetMetadataCache.withLock { $0.probeCount += 1 }
+#endif
+        return NSImage(named: name)
+    }
+
+#if DEBUG
+    static var spriteSheetProbeCountForTesting: Int {
+        spriteSheetMetadataCache.withLock { $0.probeCount }
+    }
+
+    @MainActor
+    static func resetSpriteSheetMetadataCacheForTesting() {
+        spriteSheetMetadataCache.withLock { $0 = SpriteSheetMetadataCache() }
+        flippedSpriteSheetAvailability = [:]
+    }
+#endif
+
     /// Resolves the sprite sheet name with fallback chain: exact emotion -> nearby base emotion -> neutral -> idle.
     var spriteSheetName: String {
+        let key = SpriteSheetMetadataKey(family: spriteFamily, task: task, emotion: emotion)
+        if let cached = Self.spriteSheetMetadataCache.withLock({ $0.namesByKey[key] }) {
+            return cached
+        }
+
+        let resolved = resolvedSpriteSheetName()
+        Self.spriteSheetMetadataCache.withLock { $0.namesByKey[key] = resolved }
+        return resolved
+    }
+
+    private func resolvedSpriteSheetName() -> String {
         if let availableName = availableSpriteSheetName(for: task, emotion: emotion) {
             return availableName
         }
@@ -155,18 +200,18 @@ struct NotchiState: Equatable {
 
     private func availableSpriteSheetName(for task: NotchiTask, emotion: NotchiEmotion) -> String? {
         let name = spriteSheetName(for: task, emotion: emotion)
-        if NSImage(named: name) != nil { return name }
+        if Self.probeSpriteSheetImage(named: name) != nil { return name }
         if emotion == .elated {
             let happyName = spriteSheetName(for: task, emotion: .happy)
-            if NSImage(named: happyName) != nil { return happyName }
+            if Self.probeSpriteSheetImage(named: happyName) != nil { return happyName }
         }
         if emotion == .sob {
             let sadName = spriteSheetName(for: task, emotion: .sad)
-            if NSImage(named: sadName) != nil { return sadName }
+            if Self.probeSpriteSheetImage(named: sadName) != nil { return sadName }
         }
 
         let neutralName = spriteSheetName(for: task, emotion: .neutral)
-        return NSImage(named: neutralName) != nil ? neutralName : nil
+        return Self.probeSpriteSheetImage(named: neutralName) != nil ? neutralName : nil
     }
 
     private func spriteSheetName(for task: NotchiTask, emotion: NotchiEmotion) -> String {
@@ -249,13 +294,24 @@ struct NotchiState: Equatable {
             return cached
         }
 
-        let exists = NSImage(named: name) != nil
+        let exists = Self.probeSpriteSheetImage(named: name) != nil
         flippedSpriteSheetAvailability[name] = exists
         return exists
     }
 
     private var inferredFrameCount: Int? {
-        guard let image = NSImage(named: spriteSheetName), image.size.height > 0 else {
+        let sheetName = spriteSheetName
+        if let cached = Self.spriteSheetMetadataCache.withLock({ $0.frameCountsBySheet[sheetName] }) {
+            return cached
+        }
+
+        let inferred = Self.inferFrameCount(sheetName: sheetName)
+        Self.spriteSheetMetadataCache.withLock { $0.frameCountsBySheet[sheetName] = .some(inferred) }
+        return inferred
+    }
+
+    private static func inferFrameCount(sheetName: String) -> Int? {
+        guard let image = probeSpriteSheetImage(named: sheetName), image.size.height > 0 else {
             return nil
         }
 

--- a/notchi/notchi/Services/CodexUsageService.swift
+++ b/notchi/notchi/Services/CodexUsageService.swift
@@ -178,7 +178,8 @@ nonisolated final class CodexUsageScanner: @unchecked Sendable {
     func latestSnapshot(transcriptPaths: [String]) -> CodexUsageSnapshot? {
         lock.lock()
         defer { lock.unlock() }
-        states = states.filter { transcriptPaths.contains($0.key) }
+        let requestedPaths = Set(transcriptPaths)
+        states = states.filter { requestedPaths.contains($0.key) }
         return transcriptPaths
             .compactMap { scan(path: $0) }
             .max { lhs, rhs in lhs.observedAt < rhs.observedAt }

--- a/notchi/notchi/Services/CodexUsageService.swift
+++ b/notchi/notchi/Services/CodexUsageService.swift
@@ -13,7 +13,7 @@ nonisolated struct CodexUsageServiceDependencies: Sendable {
 
     static let live = CodexUsageServiceDependencies(
         resolveUsage: { transcriptPaths in
-            CodexUsageSnapshotResolver.latestSnapshot(transcriptPaths: transcriptPaths)
+            CodexUsageScanner.shared.latestSnapshot(transcriptPaths: transcriptPaths)
         },
         fetchAPIUsage: { await CodexUsageAPIClient.fetchLive() },
         now: { Date() }
@@ -154,6 +154,115 @@ final class CodexUsageService {
     }
 }
 
+// WHY: The periodic refresh re-read up to a full tail window per transcript
+// every 5 seconds. Tracking a per-path offset keeps steady-state refreshes to
+// only the bytes appended since the previous scan, with the tail window as the
+// fallback for first sight, truncation, and oversized append bursts.
+nonisolated final class CodexUsageScanner: @unchecked Sendable {
+    private struct PathScanState {
+        var offset: UInt64
+        var snapshot: CodexUsageSnapshot?
+    }
+
+    static let shared = CodexUsageScanner()
+
+    private let maxTailBytes: Int
+    private let lock = NSLock()
+    private var states: [String: PathScanState] = [:]
+    private var bytesRead: UInt64 = 0
+
+    init(maxTailBytes: Int = CodexUsageSnapshotResolver.defaultMaxTailBytes) {
+        self.maxTailBytes = maxTailBytes
+    }
+
+    func latestSnapshot(transcriptPaths: [String]) -> CodexUsageSnapshot? {
+        lock.lock()
+        defer { lock.unlock() }
+        states = states.filter { transcriptPaths.contains($0.key) }
+        return transcriptPaths
+            .compactMap { scan(path: $0) }
+            .max { lhs, rhs in lhs.observedAt < rhs.observedAt }
+    }
+
+    private func scan(path: String) -> CodexUsageSnapshot? {
+        guard let handle = FileHandle(forReadingAtPath: path) else {
+            states[path] = nil
+            return nil
+        }
+        defer { try? handle.close() }
+        guard let fileSize = try? handle.seekToEnd() else {
+            return states[path]?.snapshot
+        }
+
+        let previous = states[path]
+        let isIncremental = previous.map {
+            $0.offset <= fileSize && fileSize - $0.offset <= UInt64(maxTailBytes)
+        } ?? false
+
+        if isIncremental, previous?.offset == fileSize {
+            return previous?.snapshot
+        }
+
+        let tailStart = fileSize > UInt64(maxTailBytes) ? fileSize - UInt64(maxTailBytes) : 0
+        let readStart = isIncremental ? previous!.offset : tailStart
+        guard (try? handle.seek(toOffset: readStart)) != nil,
+              let readData = try? handle.readToEnd() else {
+            return previous?.snapshot
+        }
+        bytesRead += UInt64(readData.count)
+
+        var lineStart = readStart
+        var data = readData
+        if !isIncremental, readStart > 0,
+           !CodexUsageSnapshotResolver.tailBeginsOnLineBoundary(handle, tailOffset: readStart) {
+            guard let firstNewline = data.firstIndex(of: UInt8(ascii: "\n")) else {
+                states[path] = PathScanState(offset: readStart, snapshot: nil)
+                return nil
+            }
+            let droppedCount = data.distance(from: data.startIndex, to: firstNewline) + 1
+            lineStart += UInt64(droppedCount)
+            data = Data(data[data.index(after: firstNewline)...])
+        }
+
+        // The trailing unterminated line is scanned but the offset stays before
+        // it, so a line completed by a later write is parsed again in full.
+        let scanned = CodexUsageSnapshotResolver.snapshot(scanningLines: data)
+        let carried = isIncremental ? previous?.snapshot : nil
+        let best = latest(of: scanned, carried)
+
+        let newOffset: UInt64
+        if let lastNewline = data.lastIndex(of: UInt8(ascii: "\n")) {
+            newOffset = lineStart + UInt64(data.distance(from: data.startIndex, to: lastNewline) + 1)
+        } else {
+            newOffset = lineStart
+        }
+
+        states[path] = PathScanState(offset: newOffset, snapshot: best)
+        return best
+    }
+
+    private func latest(of lhs: CodexUsageSnapshot?, _ rhs: CodexUsageSnapshot?) -> CodexUsageSnapshot? {
+        switch (lhs, rhs) {
+        case let (lhs?, rhs?):
+            return lhs.observedAt >= rhs.observedAt ? lhs : rhs
+        case let (lhs?, nil):
+            return lhs
+        case let (nil, rhs?):
+            return rhs
+        case (nil, nil):
+            return nil
+        }
+    }
+
+#if DEBUG
+    var bytesReadForTesting: UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return bytesRead
+    }
+#endif
+}
+
 nonisolated enum CodexUsageSnapshotResolver {
     private static let isoFractional: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
@@ -161,12 +270,6 @@ nonisolated enum CodexUsageSnapshotResolver {
         return f
     }()
     private static let isoBasic = ISO8601DateFormatter()
-
-    static func latestSnapshot(transcriptPaths: [String]) -> CodexUsageSnapshot? {
-        transcriptPaths
-            .compactMap { latestSnapshot(transcriptPath: $0) }
-            .max { lhs, rhs in lhs.observedAt < rhs.observedAt }
-    }
 
     // WHY: Rollout files grow unbounded (>100MB in long sessions) and Codex
     // appends fresh token_count events near EOF, so the periodic refresh only
@@ -183,10 +286,14 @@ nonisolated enum CodexUsageSnapshotResolver {
             return nil
         }
 
+        return snapshot(scanningLines: tail)
+    }
+
+    static func snapshot(scanningLines data: Data) -> CodexUsageSnapshot? {
         var latestSnapshot: CodexUsageSnapshot?
         let decoder = JSONDecoder()
         let tokenCountMarker = Data(#""token_count""#.utf8)
-        for line in tail.split(separator: UInt8(ascii: "\n")) {
+        for line in data.split(separator: UInt8(ascii: "\n")) {
             guard line.range(of: tokenCountMarker) != nil,
                   let event = try? decoder.decode(CodexTokenCountEvent.self, from: Data(line)),
                   event.payload?.type == "token_count",
@@ -241,7 +348,7 @@ nonisolated enum CodexUsageSnapshotResolver {
         return data[data.index(after: firstNewline)...]
     }
 
-    private static func tailBeginsOnLineBoundary(_ fileHandle: FileHandle, tailOffset: UInt64) -> Bool {
+    static func tailBeginsOnLineBoundary(_ fileHandle: FileHandle, tailOffset: UInt64) -> Bool {
         guard (try? fileHandle.seek(toOffset: tailOffset - 1)) != nil,
               let previousByte = try? fileHandle.read(upToCount: 1) else {
             return false

--- a/notchi/notchi/Services/NotchiStateMachine.swift
+++ b/notchi/notchi/Services/NotchiStateMachine.swift
@@ -20,6 +20,7 @@ final class NotchiStateMachine {
     private var codexThreadMetadataRefreshTask: Task<Void, Never>?
     private var codexCompactionSignalRefreshTask: Task<Void, Never>?
     private var codexCompactionSignalRefreshGeneration = 0
+    private var lastCodexCompactionSignalRefreshAt: ContinuousClock.Instant?
     private var codexThreadMetadataImmediateRefreshKeys: Set<ProviderSessionKey> = []
     private var codexThreadMetadataAutoRefreshEnabled = true
     private var codexProcessMissCounts: [ProviderSessionKey: Int] = [:]
@@ -37,6 +38,7 @@ final class NotchiStateMachine {
     private static let codexProcessMonitorInterval: Duration = .seconds(2)
     private static let codexThreadMetadataMonitorInterval: Duration = .seconds(5)
     private static let codexCompactionSignalRefreshDebounce: Duration = .milliseconds(150)
+    private static let codexCompactionSignalMinRefreshInterval: Duration = .seconds(2)
     private static let codexProcessMissLimit = 2
     private static let pendingSessionStartMaxAge: TimeInterval = 10 * 60
 
@@ -477,6 +479,9 @@ final class NotchiStateMachine {
             defer { self.codexThreadMetadataRefreshTask = nil }
 
             let compactionRequests = self.sessionStore.codexCompactionSignalRequests()
+            if !compactionRequests.isEmpty {
+                self.lastCodexCompactionSignalRefreshAt = .now
+            }
             async let metadataUpdates = self.sessionStore.resolveCodexThreadMetadata(requests)
             async let compactionUpdates = self.sessionStore.resolveCodexCompactionSignals(compactionRequests)
             async let usageRefresh: Void = CodexUsageService.shared.refresh(transcriptPaths: transcriptPaths)
@@ -493,12 +498,28 @@ final class NotchiStateMachine {
     }
 
     private func scheduleCodexCompactionSignalRefresh() {
-        scheduleCodexCompactionSignalRefresh(after: Self.codexCompactionSignalRefreshDebounce)
+        guard codexThreadMetadataAutoRefreshEnabled else { return }
+        requestCodexCompactionSignalRefresh()
+    }
+
+    // WHY: Transcript writes arrive in sub-second bursts while Codex streams.
+    // Each compaction refresh spawns a sqlite3 process, so pending refreshes
+    // absorb later writes and refreshes are spaced out by a minimum interval
+    // instead of re-arming the debounce on every write.
+    private func requestCodexCompactionSignalRefresh() {
+        guard codexCompactionSignalRefreshTask == nil else { return }
+        let sinceLastRefresh = lastCodexCompactionSignalRefreshAt.map { ContinuousClock.now - $0 }
+        scheduleCodexCompactionSignalRefresh(after: Self.codexCompactionRefreshDelay(sinceLastRefresh: sinceLastRefresh))
+    }
+
+    nonisolated static func codexCompactionRefreshDelay(sinceLastRefresh: Duration?) -> Duration {
+        guard let sinceLastRefresh, sinceLastRefresh < codexCompactionSignalMinRefreshInterval else {
+            return codexCompactionSignalRefreshDebounce
+        }
+        return max(codexCompactionSignalRefreshDebounce, codexCompactionSignalMinRefreshInterval - sinceLastRefresh)
     }
 
     private func scheduleCodexCompactionSignalRefresh(after delay: Duration) {
-        guard codexThreadMetadataAutoRefreshEnabled else { return }
-
         codexCompactionSignalRefreshGeneration += 1
         let generation = codexCompactionSignalRefreshGeneration
         codexCompactionSignalRefreshTask?.cancel()
@@ -517,6 +538,7 @@ final class NotchiStateMachine {
             return
         }
 
+        lastCodexCompactionSignalRefreshAt = .now
         let signals = await sessionStore.resolveCodexCompactionSignals(requests)
         guard !Task.isCancelled else {
             clearCodexCompactionSignalRefreshTask(generation: generation)
@@ -565,6 +587,7 @@ final class NotchiStateMachine {
         codexThreadMetadataRefreshTask?.cancel()
         codexThreadMetadataRefreshTask = nil
         cancelCodexCompactionSignalRefresh()
+        lastCodexCompactionSignalRefreshAt = nil
         codexThreadMetadataImmediateRefreshKeys.removeAll()
         codexThreadMetadataAutoRefreshEnabled = true
         codexProcessMissCounts.removeAll()
@@ -585,6 +608,10 @@ final class NotchiStateMachine {
 
     func setCodexThreadMetadataAutoRefreshEnabledForTesting(_ enabled: Bool) {
         codexThreadMetadataAutoRefreshEnabled = enabled
+    }
+
+    func requestCodexCompactionSignalRefreshForTesting() {
+        requestCodexCompactionSignalRefresh()
     }
 
     func setPendingSessionStartTimeForTesting(_ startTime: Date, sessionKey: ProviderSessionKey) {

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 extension Notification.Name {
     static let sessionStoreActiveSessionCountDidChange = Notification.Name("sessionStoreActiveSessionCountDidChange")
@@ -729,6 +730,57 @@ nonisolated struct CodexCompactionSignalUpdate: Sendable, Equatable {
     let signal: CodexCompactionSignal?
 }
 
+// WHY: The metadata and compaction resolvers each re-listed ~/.codex on every
+// refresh tick just to find the newest versioned sqlite file. The cached URL is
+// revalidated cheaply and re-listed only on expiry or when the file disappears,
+// so database rotation is still picked up within the TTL.
+nonisolated final class CodexSQLiteURLCache: Sendable {
+    private struct Entry {
+        let url: URL
+        let cachedAt: Date
+    }
+
+    static let shared = CodexSQLiteURLCache(
+        ttl: 60,
+        list: { CodexFileSystem.scanLatestSQLiteURL(prefix: $0) },
+        fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+        now: { Date() }
+    )
+
+    private let ttl: TimeInterval
+    private let list: @Sendable (String) -> URL?
+    private let fileExists: @Sendable (URL) -> Bool
+    private let now: @Sendable () -> Date
+    private let entries = OSAllocatedUnfairLock<[String: Entry]>(initialState: [:])
+
+    init(
+        ttl: TimeInterval,
+        list: @escaping @Sendable (String) -> URL?,
+        fileExists: @escaping @Sendable (URL) -> Bool,
+        now: @escaping @Sendable () -> Date
+    ) {
+        self.ttl = ttl
+        self.list = list
+        self.fileExists = fileExists
+        self.now = now
+    }
+
+    func url(prefix: String) -> URL? {
+        let currentTime = now()
+        if let entry = entries.withLock({ $0[prefix] }),
+           currentTime.timeIntervalSince(entry.cachedAt) < ttl,
+           fileExists(entry.url) {
+            return entry.url
+        }
+
+        let resolved = list(prefix)
+        entries.withLock { state in
+            state[prefix] = resolved.map { Entry(url: $0, cachedAt: currentTime) }
+        }
+        return resolved
+    }
+}
+
 nonisolated enum CodexFileSystem {
     static let sqliteSeparator = "\u{1F}"
 
@@ -738,6 +790,10 @@ nonisolated enum CodexFileSystem {
     }
 
     static func latestSQLiteURL(prefix: String) -> URL? {
+        CodexSQLiteURLCache.shared.url(prefix: prefix)
+    }
+
+    static func scanLatestSQLiteURL(prefix: String) -> URL? {
         guard let entries = try? FileManager.default.contentsOfDirectory(
             at: codexDirectoryURL,
             includingPropertiesForKeys: nil

--- a/notchi/notchi/Views/GrassIslandView.swift
+++ b/notchi/notchi/Views/GrassIslandView.swift
@@ -197,6 +197,38 @@ private struct SpriteTapTarget: View {
     }
 }
 
+struct GrassSpriteMotion {
+    let state: NotchiState
+    let reduceMotion: Bool
+
+    static let sobTrembleAmplitude: CGFloat = 0.3
+
+    var bobAmplitude: CGFloat {
+        guard !reduceMotion, state.bobAmplitude > 0 else { return 0 }
+        return state.task == .working ? 1.5 : 1
+    }
+
+    var swayAmplitude: Double {
+        guard !reduceMotion else { return 0 }
+        return (state.task == .sleeping || state.task == .compacting) ? 0 : state.swayAmplitude
+    }
+
+    var trembleAmplitude: CGFloat {
+        guard !reduceMotion, state.emotion == .sob else { return 0 }
+        return Self.sobTrembleAmplitude
+    }
+
+    var isAnimating: Bool {
+        bobAmplitude > 0 || swayAmplitude > 0 || trembleAmplitude > 0
+    }
+
+    var frameInterval: Double { 1.0 / 30 }
+
+    var bobDuration: Double {
+        state.task == .working ? 1.0 : state.bobDuration
+    }
+}
+
 private struct GrassSpriteView: View {
     let state: NotchiState
     let sessionId: String
@@ -205,39 +237,27 @@ private struct GrassSpriteView: View {
     let totalWidth: CGFloat
     var glowOpacity: Double = 0
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var stateMirrorKey: String?
     @State private var stateMirrored = false
 
     private let swayDuration: Double = 2.0
-    private var bobAmplitude: CGFloat {
-        guard state.bobAmplitude > 0 else { return 0 }
-        return state.task == .working ? 1.5 : 1
-    }
     private let glowColor = Color(red: 0.4, green: 0.7, blue: 1.0)
 
-    private var swayAmplitude: Double {
-        (state.task == .sleeping || state.task == .compacting) ? 0 : state.swayAmplitude
-    }
-
-    private var isAnimatingMotion: Bool {
-        bobAmplitude > 0 || swayAmplitude > 0 || state.emotion == .sob
-    }
-
-    private var bobDuration: Double {
-        state.task == .working ? 1.0 : state.bobDuration
+    private var motion: GrassSpriteMotion {
+        GrassSpriteMotion(state: state, reduceMotion: reduceMotion)
     }
 
     private func swayDegrees(at date: Date) -> Double {
+        let swayAmplitude = motion.swayAmplitude
         guard swayAmplitude > 0 else { return 0 }
         let t = date.timeIntervalSinceReferenceDate
         let phase = (t / swayDuration).truncatingRemainder(dividingBy: 1.0)
         return sin(phase * .pi * 2) * swayAmplitude
     }
 
-    private static let sobTrembleAmplitude: CGFloat = 0.3
-
     var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 30, paused: !isAnimatingMotion)) { timeline in
+        TimelineView(.animation(minimumInterval: motion.frameInterval, paused: !motion.isAnimating)) { timeline in
             let presentation = spriteSheetPresentation(at: timeline.date)
             SpriteSheetView(
                 spriteSheet: presentation.spriteSheetName,
@@ -261,8 +281,8 @@ private struct GrassSpriteView: View {
             .rotationEffect(.degrees(swayDegrees(at: timeline.date)), anchor: .bottom)
             .offset(
                 x: SpriteLayout.xOffset(xPosition: xPosition, totalWidth: totalWidth)
-                    + trembleOffset(at: timeline.date, amplitude: state.emotion == .sob ? Self.sobTrembleAmplitude : 0),
-                y: yOffset + bobOffset(at: timeline.date, duration: bobDuration, amplitude: bobAmplitude)
+                    + trembleOffset(at: timeline.date, amplitude: motion.trembleAmplitude),
+                y: yOffset + bobOffset(at: timeline.date, duration: motion.bobDuration, amplitude: motion.bobAmplitude)
             )
         }
         .onAppear(perform: updateStateMirroring)

--- a/notchi/notchi/Views/GrassIslandView.swift
+++ b/notchi/notchi/Views/GrassIslandView.swift
@@ -244,20 +244,16 @@ private struct GrassSpriteView: View {
     private let swayDuration: Double = 2.0
     private let glowColor = Color(red: 0.4, green: 0.7, blue: 1.0)
 
-    private var motion: GrassSpriteMotion {
-        GrassSpriteMotion(state: state, reduceMotion: reduceMotion)
-    }
-
-    private func swayDegrees(at date: Date) -> Double {
-        let swayAmplitude = motion.swayAmplitude
-        guard swayAmplitude > 0 else { return 0 }
+    private func swayDegrees(at date: Date, amplitude: Double) -> Double {
+        guard amplitude > 0 else { return 0 }
         let t = date.timeIntervalSinceReferenceDate
         let phase = (t / swayDuration).truncatingRemainder(dividingBy: 1.0)
-        return sin(phase * .pi * 2) * swayAmplitude
+        return sin(phase * .pi * 2) * amplitude
     }
 
     var body: some View {
-        TimelineView(.animation(minimumInterval: motion.frameInterval, paused: !motion.isAnimating)) { timeline in
+        let motion = GrassSpriteMotion(state: state, reduceMotion: reduceMotion)
+        return TimelineView(.animation(minimumInterval: motion.frameInterval, paused: !motion.isAnimating)) { timeline in
             let presentation = spriteSheetPresentation(at: timeline.date)
             SpriteSheetView(
                 spriteSheet: presentation.spriteSheetName,
@@ -278,7 +274,7 @@ private struct GrassSpriteView: View {
                         .offset(y: 4)
                 }
             }
-            .rotationEffect(.degrees(swayDegrees(at: timeline.date)), anchor: .bottom)
+            .rotationEffect(.degrees(swayDegrees(at: timeline.date, amplitude: motion.swayAmplitude)), anchor: .bottom)
             .offset(
                 x: SpriteLayout.xOffset(xPosition: xPosition, totalWidth: totalWidth)
                     + trembleOffset(at: timeline.date, amplitude: motion.trembleAmplitude),


### PR DESCRIPTION
## Summary

Four performance fixes from the profiling backlog, each verified test-first:

- **Coalesce Codex compaction signal refreshes** — transcript writes during
  streaming re-armed a 150ms debounce on every write, spawning a sqlite3
  process per burst (and starving refreshes entirely under continuous
  sub-150ms writes). Pending refreshes now absorb later writes and successive
  refreshes are spaced by a 2s minimum; the 5s metadata tick counts toward
  that spacing. The newest `~/.codex` sqlite path is cached for 60s with
  existence revalidation instead of re-listing the directory per resolver call.
- **Incremental Codex usage scanning** — the 5s refresh re-read up to a 4MB
  tail per transcript on every tick. `CodexUsageScanner` tracks a per-path
  byte offset so steady-state refreshes read only appended bytes, falling
  back to the tail window on first sight, truncation, or oversized bursts.
  Offsets only advance past complete lines, so a line finished by a later
  write is re-parsed in full.
- **Sprite sheet metadata cache** — `spriteSheetName` probed `NSImage(named:)`
  up to 4x per read and `frameCount`/`columns` re-inferred sheet geometry
  from image size, all reachable from per-frame `TimelineView` bodies.
  Resolution is now memoized per (family, task, emotion), frame counts per
  resolved sheet name.
- **Reduce Motion for grass sprites** — the expanded panel's sprites ignored
  the accessibility setting; bob/sway/tremble now zero out and the motion
  clock pauses under Reduce Motion. The 30fps cadence is deliberately kept
  (15fps read as choppy at grass sprite sizes, and grass only animates while
  the panel is open).

## Behavior changes

- Compaction signal latency: first write still refreshes after 150ms; writes
  landing within 2s of a refresh wait for the spacing interval (previously
  could starve indefinitely under continuous writes).
- Codex sqlite rotation is picked up within 60s instead of immediately.
- Grass sprites hold still under Reduce Motion (frames keep animating).

## Validation

- Full suite green (`./scripts/test.sh all`, ~500 tests) plus 18 new tests
  covering refresh coalescing/spacing, a starvation regression guard, URL
  cache TTL/rotation, incremental scan byte accounting, truncation reset,
  unterminated-line handling, sprite cache keying/fallbacks, and grass
  motion parameters.
- Adversarial review of the full diff found no defects; known theoretical
  limits are documented in the commit messages (same-size in-place transcript
  rewrites are invisible to the offset scanner — unreachable for append-only
  rollouts).
- Manual QA: expanded grass panel eyeballed across states.

https://claude.ai/code/session_01Coa6K9AWf43ruqWhVv7qJ8