### PR TITLE
fix: repair pricing refresh and polish the cost dashboard

### DIFF
--- a/notchi/Tests/CodexModelPricingTests.swift
+++ b/notchi/Tests/CodexModelPricingTests.swift
@@ -131,6 +131,134 @@ final class CodexModelPricingTests: XCTestCase {
         XCTAssertEqual(p!.cacheReadPerToken, 0.5 / 1_000_000, accuracy: 1e-15)
     }
 
+    func testModelsDevEntryMissingCacheFieldsStillDecodes() {
+        let json = """
+        {
+          "openai": {
+            "models": {
+              "gpt-5-codex": {
+                "cost": { "input": 1.25, "output": 10.0, "cache_read": 0.125 }
+              },
+              "gpt-5.6-sol": {
+                "cost": { "input": 7.0, "output": 42.0 }
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let catalog = PricingCatalog(config: .codex, fallbackBundle: .main)
+        catalog.processNetworkData(json)
+
+        let codexPricing = catalog.pricing(model: "gpt-5-codex", on: Date())
+        XCTAssertEqual(codexPricing?.inputPerToken ?? 0, 1.25 / 1_000_000, accuracy: 1e-15)
+        XCTAssertEqual(codexPricing?.cacheReadPerToken ?? -1, 0.125 / 1_000_000, accuracy: 1e-15)
+        XCTAssertEqual(codexPricing?.cacheCreationPerToken ?? -1, 0, accuracy: 1e-15)
+
+        let solPricing = catalog.pricing(model: "gpt-5.6-sol", on: Date())
+        XCTAssertEqual(solPricing?.inputPerToken ?? 0, 7.0 / 1_000_000, accuracy: 1e-15)
+        XCTAssertEqual(solPricing?.outputPerToken ?? 0, 42.0 / 1_000_000, accuracy: 1e-15)
+        XCTAssertEqual(solPricing?.cacheReadPerToken ?? -1, 0, accuracy: 1e-15)
+        XCTAssertEqual(solPricing?.cacheCreationPerToken ?? -1, 0, accuracy: 1e-15)
+    }
+
+    func testMalformedModelEntryDoesNotDiscardOtherModels() {
+        let json = """
+        {
+          "openai": {
+            "models": {
+              "gpt-broken": {
+                "cost": { "input": "not-a-number", "output": 1.0 }
+              },
+              "gpt-5.6-sol": {
+                "cost": { "input": 7.0, "output": 42.0, "cache_read": 0.7, "cache_write": 0.0 }
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let catalog = PricingCatalog(config: .codex, fallbackBundle: .main)
+        catalog.processNetworkData(json)
+
+        let solPricing = catalog.pricing(model: "gpt-5.6-sol", on: Date())
+        XCTAssertEqual(solPricing?.inputPerToken ?? 0, 7.0 / 1_000_000, accuracy: 1e-15)
+        XCTAssertNil(catalog.pricing(model: "gpt-broken", on: Date()))
+    }
+
+    func testBrokenOpenAIEntriesDoNotBreakAnthropicRefresh() {
+        let json = """
+        {
+          "anthropic": {
+            "models": {
+              "claude-sonnet-4-5": {
+                "cost": { "input": 3.5, "output": 17.5, "cache_read": 0.35, "cache_write": 4.375 }
+              },
+              "claude-opus-4-6": {
+                "cost": { "input": 6.0, "output": 30.0, "cache_read": 0.6, "cache_write": 7.5 }
+              }
+            }
+          },
+          "openai": {
+            "models": {
+              "gpt-5.4": {
+                "cost": { "input": 1.25, "output": 10.0, "cache_read": 0.125 }
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let catalog = PricingCatalog(config: .claude, fallbackBundle: .main)
+        catalog.processNetworkData(json)
+
+        let sonnetPricing = catalog.pricing(model: "claude-sonnet-4-5", on: Date())
+        XCTAssertEqual(sonnetPricing?.inputPerToken ?? 0, 3.5 / 1_000_000, accuracy: 1e-15)
+        XCTAssertEqual(sonnetPricing?.cacheCreationPerToken ?? 0, 4.375 / 1_000_000, accuracy: 1e-15)
+    }
+
+    func testTierMissingCacheFieldsStillDecodesThresholdPricing() {
+        let json = """
+        {
+          "openai": {
+            "models": {
+              "gpt-5.6-sol": {
+                "cost": {
+                  "input": 7.0, "output": 42.0, "cache_read": 0.7, "cache_write": 0.0,
+                  "tiers": [
+                    { "input": 14.0, "output": 84.0, "cache_read": 1.4, "tier": { "type": "context", "size": 272000 } }
+                  ]
+                }
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let catalog = PricingCatalog(config: .codex, fallbackBundle: .main)
+        catalog.processNetworkData(json)
+
+        let solPricing = catalog.pricing(model: "gpt-5.6-sol", on: Date())
+        XCTAssertEqual(solPricing?.thresholdTokens, 272_000)
+        XCTAssertEqual(solPricing?.inputPerTokenAboveThreshold ?? 0, 14.0 / 1_000_000, accuracy: 1e-15)
+        XCTAssertEqual(solPricing?.cacheCreationPerTokenAboveThreshold ?? -1, 0, accuracy: 1e-15)
+    }
+
+    func testCodexFallbackPricesGpt56Family() {
+        let catalog = PricingCatalog(config: .codex, fallbackBundle: .main)
+
+        let sol = catalog.pricing(model: "gpt-5.6-sol", on: Date())
+        XCTAssertEqual(sol?.inputPerToken ?? 0, 5e-6, accuracy: 1e-15)
+        XCTAssertEqual(sol?.outputPerToken ?? 0, 3e-5, accuracy: 1e-15)
+        XCTAssertEqual(sol?.cacheReadPerToken ?? 0, 5e-7, accuracy: 1e-15)
+        XCTAssertEqual(sol?.cacheCreationPerToken ?? 0, 6.25e-6, accuracy: 1e-15)
+        XCTAssertEqual(sol?.thresholdTokens, 272_000)
+
+        XCTAssertNotNil(catalog.pricing(model: "gpt-5.6", on: Date()))
+        XCTAssertNotNil(catalog.pricing(model: "gpt-5.6-luna", on: Date()))
+        XCTAssertNotNil(catalog.pricing(model: "gpt-5.6-terra", on: Date()))
+    }
+
     func testCodexGpt55ProCostBillsCachedInputAtInputRate() {
         let catalog = PricingCatalog(config: .codex, fallbackBundle: .main)
         let p = catalog.pricing(model: "gpt-5.5-pro", on: Date())

--- a/notchi/Tests/DailyCostReportTests.swift
+++ b/notchi/Tests/DailyCostReportTests.swift
@@ -97,6 +97,29 @@ final class DailyCostReportTests: XCTestCase {
         XCTAssertEqual(identicalReport.topModel, "gpt-5.4", "lowest name must win an exact tie")
     }
 
+    func testEntriesCarryTheirOwnTopModel() {
+        var buckets: DayModelBuckets = [:]
+        buckets["2026-06-22"] = [
+            "claude-sonnet-4": ModelTokenTotals(
+                input: 100, output: 50, costNanos: 8_000_000_000, requestCount: 1, pricedCount: 1),
+            "claude-opus-4": ModelTokenTotals(
+                input: 10, output: 5, costNanos: 1_000_000_000, requestCount: 1, pricedCount: 1)]
+        buckets["2026-06-24"] = [
+            "claude-opus-4": ModelTokenTotals(
+                input: 300, output: 100, costNanos: 9_000_000_000, requestCount: 2, pricedCount: 2)]
+
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let report = DailyCostReport.make(
+            provider: .claude, buckets: buckets,
+            windowStart: day("2026-06-20"), today: day("2026-06-24"), calendar: cal)
+
+        XCTAssertEqual(report.entries[2].topModel, "claude-sonnet-4")
+        XCTAssertEqual(report.entries[4].topModel, "claude-opus-4")
+        XCTAssertNil(report.entries[1].topModel)
+        XCTAssertEqual(report.topModel, "claude-opus-4")
+    }
+
     func testTodayTokensAreZeroWhenTodayHasNoActivity() {
         var buckets: DayModelBuckets = [:]
         buckets["2026-06-24"] = ["gpt-5.5": ModelTokenTotals(

--- a/notchi/Tests/DailyCostReportTests.swift
+++ b/notchi/Tests/DailyCostReportTests.swift
@@ -70,6 +70,33 @@ final class DailyCostReportTests: XCTestCase {
         XCTAssertEqual(report.topModel, "claude-opus-4")              // highest cost across window
     }
 
+    func testTopModelTieOnCostIsBrokenByTokensThenName() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+
+        var unpriced: DayModelBuckets = [:]
+        unpriced["2026-06-24"] = [
+            "gpt-5.6-sol": ModelTokenTotals(input: 900, output: 100, costNanos: 0,
+                                            requestCount: 3, pricedCount: 0),
+            "gpt-5.6-luna": ModelTokenTotals(input: 100, output: 50, costNanos: 0,
+                                             requestCount: 1, pricedCount: 0)]
+        let unpricedReport = DailyCostReport.make(
+            provider: .codex, buckets: unpriced,
+            windowStart: day("2026-06-20"), today: day("2026-06-24"), calendar: cal)
+        XCTAssertEqual(unpricedReport.topModel, "gpt-5.6-sol", "more tokens must win a cost tie")
+
+        var identical: DayModelBuckets = [:]
+        identical["2026-06-24"] = [
+            "gpt-5.5": ModelTokenTotals(input: 100, output: 50, costNanos: 5_000,
+                                        requestCount: 1, pricedCount: 1),
+            "gpt-5.4": ModelTokenTotals(input: 100, output: 50, costNanos: 5_000,
+                                        requestCount: 1, pricedCount: 1)]
+        let identicalReport = DailyCostReport.make(
+            provider: .codex, buckets: identical,
+            windowStart: day("2026-06-20"), today: day("2026-06-24"), calendar: cal)
+        XCTAssertEqual(identicalReport.topModel, "gpt-5.4", "lowest name must win an exact tie")
+    }
+
     func testTodayTokensAreZeroWhenTodayHasNoActivity() {
         var buckets: DayModelBuckets = [:]
         buckets["2026-06-24"] = ["gpt-5.5": ModelTokenTotals(

--- a/notchi/Tests/DailyCostReportTests.swift
+++ b/notchi/Tests/DailyCostReportTests.swift
@@ -120,6 +120,29 @@ final class DailyCostReportTests: XCTestCase {
         XCTAssertEqual(report.topModel, "claude-opus-4")
     }
 
+    @MainActor
+    func testSizingCoversEveryHoverStateAndTheModelReference() {
+        var buckets: DayModelBuckets = [:]
+        buckets["2026-06-22"] = ["gpt-5.6-sol": ModelTokenTotals(
+            input: 100, output: 50, costNanos: 8_000_000_000, requestCount: 1, pricedCount: 1)]
+        buckets["2026-06-24"] = ["gpt-5.5": ModelTokenTotals(
+            input: 300, output: 100, costNanos: 9_000_000_000, requestCount: 2, pricedCount: 2)]
+
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let report = DailyCostReport.make(
+            provider: .codex, buckets: buckets,
+            windowStart: day("2026-06-20"), today: day("2026-06-24"), calendar: cal)
+
+        let sets = CostDashboardView.sizingValueSets(report)
+        let modelColumn = sets.map { $0[$0.count - 1] }
+
+        XCTAssertTrue(modelColumn.contains("Opus 4.8"))
+        XCTAssertTrue(modelColumn.contains("5.6-sol"))
+        XCTAssertTrue(modelColumn.contains("GPT-5.5"))
+        XCTAssertEqual(sets.count, 4, "unselected + reference + one per active day")
+    }
+
     func testTodayTokensAreZeroWhenTodayHasNoActivity() {
         var buckets: DayModelBuckets = [:]
         buckets["2026-06-24"] = ["gpt-5.5": ModelTokenTotals(

--- a/notchi/Tests/UsageDisplayTests.swift
+++ b/notchi/Tests/UsageDisplayTests.swift
@@ -121,4 +121,21 @@ final class UsageDisplayTests: XCTestCase {
         XCTAssertEqual(CostStatFormatter.usd(3638.66), "$3,638.66")
         XCTAssertEqual(CostStatFormatter.usd(174.41), "$174.41")
     }
+
+    func testGptNamesLongerThanBaselineDropThePrefix() {
+        XCTAssertEqual(CostStatFormatter.modelName("gpt-5.6-sol"), "5.6-sol")
+        XCTAssertEqual(CostStatFormatter.modelName("gpt-5.5-pro"), "5.5-pro")
+        XCTAssertEqual(CostStatFormatter.modelName("gpt-5-codex"), "5-codex")
+    }
+
+    func testShortGptNamesKeepThePrefix() {
+        XCTAssertEqual(CostStatFormatter.modelName("gpt-5.5"), "GPT-5.5")
+        XCTAssertEqual(CostStatFormatter.modelName("gpt-5.4"), "GPT-5.4")
+        XCTAssertEqual(CostStatFormatter.modelName("gpt-5"), "GPT-5")
+    }
+
+    func testClaudeNamesAreUnaffectedByGptShortening() {
+        XCTAssertEqual(CostStatFormatter.modelName("claude-opus-4-8"), "Opus 4.8")
+        XCTAssertEqual(CostStatFormatter.modelName("claude-fable-5"), "Fable 5")
+    }
 }

--- a/notchi/notchi/Models/CostUsageModels.swift
+++ b/notchi/notchi/Models/CostUsageModels.swift
@@ -38,6 +38,7 @@ nonisolated struct DailyCostReport: Equatable, Sendable {
         let totalTokens: Int
         let requestCount: Int
         let pricedFraction: Double
+        let topModel: String?
         var id: String { day }
     }
 
@@ -75,7 +76,7 @@ nonisolated struct DailyCostReport: Equatable, Sendable {
             entries.append(DayEntry(
                 day: key, date: cursor, costUSD: totals.costUSD,
                 totalTokens: totals.totalTokens, requestCount: totals.requestCount,
-                pricedFraction: priced))
+                pricedFraction: priced, topModel: topModel(in: models)))
             cursor = calendar.date(byAdding: .day, value: 1, to: cursor)!
         }
         return DailyCostReport(

--- a/notchi/notchi/Models/CostUsageModels.swift
+++ b/notchi/notchi/Models/CostUsageModels.swift
@@ -62,14 +62,14 @@ nonisolated struct DailyCostReport: Equatable, Sendable {
         var entries: [DayEntry] = []
         var cursor = calendar.startOfDay(for: windowStart)
         let last = calendar.startOfDay(for: today)
-        var modelCostNanos: [String: Int] = [:]
+        var windowTotalsByModel: [String: ModelTokenTotals] = [:]
         while cursor <= last {
             let key = dayKey(cursor, calendar: calendar)
             let models = buckets[key] ?? [:]
             var totals = ModelTokenTotals()
             for (m, t) in models {
                 totals = totals + t
-                modelCostNanos[m, default: 0] += t.costNanos
+                windowTotalsByModel[m] = (windowTotalsByModel[m] ?? ModelTokenTotals()) + t
             }
             let priced = totals.requestCount == 0 ? 1 : Double(totals.pricedCount) / Double(totals.requestCount)
             entries.append(DayEntry(
@@ -78,7 +78,22 @@ nonisolated struct DailyCostReport: Equatable, Sendable {
                 pricedFraction: priced))
             cursor = calendar.date(byAdding: .day, value: 1, to: cursor)!
         }
-        let topModel = modelCostNanos.max(by: { $0.value < $1.value })?.key
-        return DailyCostReport(provider: provider, entries: entries, topModel: topModel)
+        return DailyCostReport(
+            provider: provider, entries: entries,
+            topModel: topModel(in: windowTotalsByModel))
+    }
+
+    static func topModel(in totalsByModel: [String: ModelTokenTotals]) -> String? {
+        totalsByModel
+            .max { lhs, rhs in
+                if lhs.value.costNanos != rhs.value.costNanos {
+                    return lhs.value.costNanos < rhs.value.costNanos
+                }
+                if lhs.value.totalTokens != rhs.value.totalTokens {
+                    return lhs.value.totalTokens < rhs.value.totalTokens
+                }
+                return lhs.key > rhs.key
+            }?
+            .key
     }
 }

--- a/notchi/notchi/Models/NotchiState.swift
+++ b/notchi/notchi/Models/NotchiState.swift
@@ -141,13 +141,13 @@ struct NotchiState: Equatable {
     var spriteFamily: NotchiSpriteFamily = .claude
     private static var flippedSpriteSheetAvailability: [String: Bool] = [:]
 
-    private struct SpriteSheetMetadataKey: Hashable {
+    private nonisolated struct SpriteSheetMetadataKey: Hashable {
         let family: NotchiSpriteFamily
         let task: NotchiTask
         let emotion: NotchiEmotion
     }
 
-    private struct SpriteSheetMetadataCache {
+    private nonisolated struct SpriteSheetMetadataCache {
         var namesByKey: [SpriteSheetMetadataKey: String] = [:]
         var frameCountsBySheet: [String: Int?] = [:]
         var probeCount = 0

--- a/notchi/notchi/Resources/codex-pricing-fallback.json
+++ b/notchi/notchi/Resources/codex-pricing-fallback.json
@@ -2,62 +2,106 @@
   "version": 1,
   "models": {
     "gpt-5": {
-      "inputPerToken": 0.00000125,
-      "outputPerToken": 0.00001,
+      "inputPerToken": 1.25e-06,
+      "outputPerToken": 1e-05,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 0.000000125
+      "cacheReadPerToken": 1.25e-07
     },
     "gpt-5-codex": {
-      "inputPerToken": 0.00000125,
-      "outputPerToken": 0.00001,
+      "inputPerToken": 1.25e-06,
+      "outputPerToken": 1e-05,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 0.000000125
+      "cacheReadPerToken": 1.25e-07
     },
     "gpt-5-mini": {
-      "inputPerToken": 0.00000025,
-      "outputPerToken": 0.000002,
+      "inputPerToken": 2.5e-07,
+      "outputPerToken": 2e-06,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 0.000000025
+      "cacheReadPerToken": 2.5e-08
     },
     "gpt-5.3-codex": {
-      "inputPerToken": 0.00000175,
-      "outputPerToken": 0.000014,
+      "inputPerToken": 1.75e-06,
+      "outputPerToken": 1.4e-05,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 0.000000175
+      "cacheReadPerToken": 1.75e-07
     },
     "gpt-5.4": {
-      "inputPerToken": 0.0000025,
-      "outputPerToken": 0.000015,
+      "inputPerToken": 2.5e-06,
+      "outputPerToken": 1.5e-05,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 0.00000025,
+      "cacheReadPerToken": 2.5e-07,
       "thresholdTokens": 272000,
-      "inputPerTokenAboveThreshold": 0.000005,
-      "outputPerTokenAboveThreshold": 0.0000225,
+      "inputPerTokenAboveThreshold": 5e-06,
+      "outputPerTokenAboveThreshold": 2.25e-05,
       "cacheCreationPerTokenAboveThreshold": 0,
-      "cacheReadPerTokenAboveThreshold": 0.0000005
+      "cacheReadPerTokenAboveThreshold": 5e-07
     },
     "gpt-5.4-mini": {
-      "inputPerToken": 0.00000075,
-      "outputPerToken": 0.0000045,
+      "inputPerToken": 7.5e-07,
+      "outputPerToken": 4.5e-06,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 0.000000075
+      "cacheReadPerToken": 7.5e-08
     },
     "gpt-5.5": {
-      "inputPerToken": 0.000005,
-      "outputPerToken": 0.00003,
+      "inputPerToken": 5e-06,
+      "outputPerToken": 3e-05,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 0.0000005,
+      "cacheReadPerToken": 5e-07,
       "thresholdTokens": 272000,
-      "inputPerTokenAboveThreshold": 0.00001,
-      "outputPerTokenAboveThreshold": 0.000045,
+      "inputPerTokenAboveThreshold": 1e-05,
+      "outputPerTokenAboveThreshold": 4.5e-05,
       "cacheCreationPerTokenAboveThreshold": 0,
-      "cacheReadPerTokenAboveThreshold": 0.000001
+      "cacheReadPerTokenAboveThreshold": 1e-06
     },
     "gpt-5.5-pro": {
-      "inputPerToken": 0.00003,
+      "inputPerToken": 3e-05,
       "outputPerToken": 0.00018,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 0.00003
+      "cacheReadPerToken": 3e-05
+    },
+    "gpt-5.6": {
+      "inputPerToken": 5e-06,
+      "outputPerToken": 3e-05,
+      "cacheCreationPerToken": 6.25e-06,
+      "cacheReadPerToken": 5e-07,
+      "thresholdTokens": 272000,
+      "inputPerTokenAboveThreshold": 1e-05,
+      "outputPerTokenAboveThreshold": 4.5e-05,
+      "cacheCreationPerTokenAboveThreshold": 1.25e-05,
+      "cacheReadPerTokenAboveThreshold": 1e-06
+    },
+    "gpt-5.6-sol": {
+      "inputPerToken": 5e-06,
+      "outputPerToken": 3e-05,
+      "cacheCreationPerToken": 6.25e-06,
+      "cacheReadPerToken": 5e-07,
+      "thresholdTokens": 272000,
+      "inputPerTokenAboveThreshold": 1e-05,
+      "outputPerTokenAboveThreshold": 4.5e-05,
+      "cacheCreationPerTokenAboveThreshold": 1.25e-05,
+      "cacheReadPerTokenAboveThreshold": 1e-06
+    },
+    "gpt-5.6-luna": {
+      "inputPerToken": 1e-06,
+      "outputPerToken": 6e-06,
+      "cacheCreationPerToken": 1.25e-06,
+      "cacheReadPerToken": 1.0000000000000001e-07,
+      "thresholdTokens": 272000,
+      "inputPerTokenAboveThreshold": 2e-06,
+      "outputPerTokenAboveThreshold": 9e-06,
+      "cacheCreationPerTokenAboveThreshold": 2.5e-06,
+      "cacheReadPerTokenAboveThreshold": 2.0000000000000002e-07
+    },
+    "gpt-5.6-terra": {
+      "inputPerToken": 2.5e-06,
+      "outputPerToken": 1.5e-05,
+      "cacheCreationPerToken": 3.125e-06,
+      "cacheReadPerToken": 2.5e-07,
+      "thresholdTokens": 272000,
+      "inputPerTokenAboveThreshold": 5e-06,
+      "outputPerTokenAboveThreshold": 2.25e-05,
+      "cacheCreationPerTokenAboveThreshold": 6.25e-06,
+      "cacheReadPerTokenAboveThreshold": 5e-07
     }
   }
 }

--- a/notchi/notchi/Resources/codex-pricing-fallback.json
+++ b/notchi/notchi/Resources/codex-pricing-fallback.json
@@ -2,106 +2,106 @@
   "version": 1,
   "models": {
     "gpt-5": {
-      "inputPerToken": 1.25e-06,
-      "outputPerToken": 1e-05,
+      "inputPerToken": 0.00000125,
+      "outputPerToken": 0.00001,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 1.25e-07
+      "cacheReadPerToken": 0.000000125
     },
     "gpt-5-codex": {
-      "inputPerToken": 1.25e-06,
-      "outputPerToken": 1e-05,
+      "inputPerToken": 0.00000125,
+      "outputPerToken": 0.00001,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 1.25e-07
+      "cacheReadPerToken": 0.000000125
     },
     "gpt-5-mini": {
-      "inputPerToken": 2.5e-07,
-      "outputPerToken": 2e-06,
+      "inputPerToken": 0.00000025,
+      "outputPerToken": 0.000002,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 2.5e-08
+      "cacheReadPerToken": 0.000000025
     },
     "gpt-5.3-codex": {
-      "inputPerToken": 1.75e-06,
-      "outputPerToken": 1.4e-05,
+      "inputPerToken": 0.00000175,
+      "outputPerToken": 0.000014,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 1.75e-07
+      "cacheReadPerToken": 0.000000175
     },
     "gpt-5.4": {
-      "inputPerToken": 2.5e-06,
-      "outputPerToken": 1.5e-05,
+      "inputPerToken": 0.0000025,
+      "outputPerToken": 0.000015,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 2.5e-07,
+      "cacheReadPerToken": 0.00000025,
       "thresholdTokens": 272000,
-      "inputPerTokenAboveThreshold": 5e-06,
-      "outputPerTokenAboveThreshold": 2.25e-05,
+      "inputPerTokenAboveThreshold": 0.000005,
+      "outputPerTokenAboveThreshold": 0.0000225,
       "cacheCreationPerTokenAboveThreshold": 0,
-      "cacheReadPerTokenAboveThreshold": 5e-07
+      "cacheReadPerTokenAboveThreshold": 0.0000005
     },
     "gpt-5.4-mini": {
-      "inputPerToken": 7.5e-07,
-      "outputPerToken": 4.5e-06,
+      "inputPerToken": 0.00000075,
+      "outputPerToken": 0.0000045,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 7.5e-08
+      "cacheReadPerToken": 0.000000075
     },
     "gpt-5.5": {
-      "inputPerToken": 5e-06,
-      "outputPerToken": 3e-05,
+      "inputPerToken": 0.000005,
+      "outputPerToken": 0.00003,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 5e-07,
+      "cacheReadPerToken": 0.0000005,
       "thresholdTokens": 272000,
-      "inputPerTokenAboveThreshold": 1e-05,
-      "outputPerTokenAboveThreshold": 4.5e-05,
+      "inputPerTokenAboveThreshold": 0.00001,
+      "outputPerTokenAboveThreshold": 0.000045,
       "cacheCreationPerTokenAboveThreshold": 0,
-      "cacheReadPerTokenAboveThreshold": 1e-06
+      "cacheReadPerTokenAboveThreshold": 0.000001
     },
     "gpt-5.5-pro": {
-      "inputPerToken": 3e-05,
+      "inputPerToken": 0.00003,
       "outputPerToken": 0.00018,
       "cacheCreationPerToken": 0,
-      "cacheReadPerToken": 3e-05
+      "cacheReadPerToken": 0.00003
     },
     "gpt-5.6": {
-      "inputPerToken": 5e-06,
-      "outputPerToken": 3e-05,
-      "cacheCreationPerToken": 6.25e-06,
-      "cacheReadPerToken": 5e-07,
+      "inputPerToken": 0.000005,
+      "outputPerToken": 0.00003,
+      "cacheCreationPerToken": 0.00000625,
+      "cacheReadPerToken": 0.0000005,
       "thresholdTokens": 272000,
-      "inputPerTokenAboveThreshold": 1e-05,
-      "outputPerTokenAboveThreshold": 4.5e-05,
-      "cacheCreationPerTokenAboveThreshold": 1.25e-05,
-      "cacheReadPerTokenAboveThreshold": 1e-06
-    },
-    "gpt-5.6-sol": {
-      "inputPerToken": 5e-06,
-      "outputPerToken": 3e-05,
-      "cacheCreationPerToken": 6.25e-06,
-      "cacheReadPerToken": 5e-07,
-      "thresholdTokens": 272000,
-      "inputPerTokenAboveThreshold": 1e-05,
-      "outputPerTokenAboveThreshold": 4.5e-05,
-      "cacheCreationPerTokenAboveThreshold": 1.25e-05,
-      "cacheReadPerTokenAboveThreshold": 1e-06
+      "inputPerTokenAboveThreshold": 0.00001,
+      "outputPerTokenAboveThreshold": 0.000045,
+      "cacheCreationPerTokenAboveThreshold": 0.0000125,
+      "cacheReadPerTokenAboveThreshold": 0.000001
     },
     "gpt-5.6-luna": {
-      "inputPerToken": 1e-06,
-      "outputPerToken": 6e-06,
-      "cacheCreationPerToken": 1.25e-06,
-      "cacheReadPerToken": 1.0000000000000001e-07,
+      "inputPerToken": 0.000001,
+      "outputPerToken": 0.000006,
+      "cacheCreationPerToken": 0.00000125,
+      "cacheReadPerToken": 0.0000001,
       "thresholdTokens": 272000,
-      "inputPerTokenAboveThreshold": 2e-06,
-      "outputPerTokenAboveThreshold": 9e-06,
-      "cacheCreationPerTokenAboveThreshold": 2.5e-06,
-      "cacheReadPerTokenAboveThreshold": 2.0000000000000002e-07
+      "inputPerTokenAboveThreshold": 0.000002,
+      "outputPerTokenAboveThreshold": 0.000009,
+      "cacheCreationPerTokenAboveThreshold": 0.0000025,
+      "cacheReadPerTokenAboveThreshold": 0.0000002
+    },
+    "gpt-5.6-sol": {
+      "inputPerToken": 0.000005,
+      "outputPerToken": 0.00003,
+      "cacheCreationPerToken": 0.00000625,
+      "cacheReadPerToken": 0.0000005,
+      "thresholdTokens": 272000,
+      "inputPerTokenAboveThreshold": 0.00001,
+      "outputPerTokenAboveThreshold": 0.000045,
+      "cacheCreationPerTokenAboveThreshold": 0.0000125,
+      "cacheReadPerTokenAboveThreshold": 0.000001
     },
     "gpt-5.6-terra": {
-      "inputPerToken": 2.5e-06,
-      "outputPerToken": 1.5e-05,
-      "cacheCreationPerToken": 3.125e-06,
-      "cacheReadPerToken": 2.5e-07,
+      "inputPerToken": 0.0000025,
+      "outputPerToken": 0.000015,
+      "cacheCreationPerToken": 0.000003125,
+      "cacheReadPerToken": 0.00000025,
       "thresholdTokens": 272000,
-      "inputPerTokenAboveThreshold": 5e-06,
-      "outputPerTokenAboveThreshold": 2.25e-05,
-      "cacheCreationPerTokenAboveThreshold": 6.25e-06,
-      "cacheReadPerTokenAboveThreshold": 5e-07
+      "inputPerTokenAboveThreshold": 0.000005,
+      "outputPerTokenAboveThreshold": 0.0000225,
+      "cacheCreationPerTokenAboveThreshold": 0.00000625,
+      "cacheReadPerTokenAboveThreshold": 0.0000005
     }
   }
 }

--- a/notchi/notchi/Services/CodexUsageService.swift
+++ b/notchi/notchi/Services/CodexUsageService.swift
@@ -154,10 +154,6 @@ final class CodexUsageService {
     }
 }
 
-// WHY: The periodic refresh re-read up to a full tail window per transcript
-// every 5 seconds. Tracking a per-path offset keeps steady-state refreshes to
-// only the bytes appended since the previous scan, with the tail window as the
-// fallback for first sight, truncation, and oversized append bursts.
 nonisolated final class CodexUsageScanner: @unchecked Sendable {
     private struct PathScanState {
         var offset: UInt64
@@ -225,8 +221,6 @@ nonisolated final class CodexUsageScanner: @unchecked Sendable {
             data = Data(data[data.index(after: firstNewline)...])
         }
 
-        // The trailing unterminated line is scanned but the offset stays before
-        // it, so a line completed by a later write is parsed again in full.
         let scanned = CodexUsageSnapshotResolver.snapshot(scanningLines: data)
         let carried = isIncremental ? previous?.snapshot : nil
         let best = latest(of: scanned, carried)

--- a/notchi/notchi/Services/Cost/PricingCatalog.swift
+++ b/notchi/notchi/Services/Cost/PricingCatalog.swift
@@ -78,10 +78,6 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
             let models: [String: ModelsDev.LenientEntry]
         }
 
-        // WHY: models.dev omits cache fields for models that don't bill them,
-        // and its shape drifts over time. A strict decoder made one unexpected
-        // entry silently kill the refresh for every provider; unparseable
-        // entries must degrade to "that model missing", nothing more.
         struct LenientEntry: Decodable {
             let entry: ModelEntry?
 

--- a/notchi/notchi/Services/Cost/PricingCatalog.swift
+++ b/notchi/notchi/Services/Cost/PricingCatalog.swift
@@ -75,7 +75,19 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
         let openai: ModelsDev.Provider?
 
         struct Provider: Decodable {
-            let models: [String: ModelsDev.ModelEntry]
+            let models: [String: ModelsDev.LenientEntry]
+        }
+
+        // WHY: models.dev omits cache fields for models that don't bill them,
+        // and its shape drifts over time. A strict decoder made one unexpected
+        // entry silently kill the refresh for every provider; unparseable
+        // entries must degrade to "that model missing", nothing more.
+        struct LenientEntry: Decodable {
+            let entry: ModelEntry?
+
+            init(from decoder: any Decoder) {
+                entry = try? ModelEntry(from: decoder)
+            }
         }
 
         struct ModelEntry: Decodable {
@@ -85,16 +97,16 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
         struct Cost: Decodable {
             let input: Double
             let output: Double
-            let cache_read: Double
-            let cache_write: Double
+            let cache_read: Double?
+            let cache_write: Double?
             let tiers: [ModelsDev.Tier]?
         }
 
         struct Tier: Decodable {
             let input: Double
             let output: Double
-            let cache_read: Double
-            let cache_write: Double
+            let cache_read: Double?
+            let cache_write: Double?
             let tier: ModelsDev.TierSpec?
         }
 
@@ -173,8 +185,8 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
         let perMillion = 1_000_000.0
         var updated: [String: ClaudeModelPricing] = [:]
 
-        for (rawId, entry) in provider.models {
-            guard let cost = entry.cost else { continue }
+        for (rawId, lenient) in provider.models {
+            guard let cost = lenient.entry?.cost else { continue }
             let key = config.normalize(rawId)
 
             let firstTier = cost.tiers?.first(where: { $0.tier?.type == "context" })
@@ -183,14 +195,14 @@ nonisolated final class PricingCatalog: ClaudePricingProviding, @unchecked Senda
             updated[key] = ClaudeModelPricing(
                 inputPerToken: cost.input / perMillion,
                 outputPerToken: cost.output / perMillion,
-                cacheCreationPerToken: cost.cache_write / perMillion,
-                cacheReadPerToken: cost.cache_read / perMillion,
+                cacheCreationPerToken: (cost.cache_write ?? 0) / perMillion,
+                cacheReadPerToken: (cost.cache_read ?? 0) / perMillion,
                 cacheCreation1hPerToken: nil,
                 thresholdTokens: thresholdTokens,
                 inputPerTokenAboveThreshold: firstTier.map { $0.input / perMillion },
                 outputPerTokenAboveThreshold: firstTier.map { $0.output / perMillion },
-                cacheCreationPerTokenAboveThreshold: firstTier.map { $0.cache_write / perMillion },
-                cacheReadPerTokenAboveThreshold: firstTier.map { $0.cache_read / perMillion })
+                cacheCreationPerTokenAboveThreshold: firstTier.map { ($0.cache_write ?? 0) / perMillion },
+                cacheReadPerTokenAboveThreshold: firstTier.map { ($0.cache_read ?? 0) / perMillion })
         }
 
         guard Self.isPlausibleRefresh(updated, anchors: config.plausibilityAnchors) else { return }

--- a/notchi/notchi/Services/NotchiStateMachine.swift
+++ b/notchi/notchi/Services/NotchiStateMachine.swift
@@ -502,10 +502,6 @@ final class NotchiStateMachine {
         requestCodexCompactionSignalRefresh()
     }
 
-    // WHY: Transcript writes arrive in sub-second bursts while Codex streams.
-    // Each compaction refresh spawns a sqlite3 process, so pending refreshes
-    // absorb later writes and refreshes are spaced out by a minimum interval
-    // instead of re-arming the debounce on every write.
     private func requestCodexCompactionSignalRefresh() {
         guard codexCompactionSignalRefreshTask == nil else { return }
         let sinceLastRefresh = lastCodexCompactionSignalRefreshAt.map { ContinuousClock.now - $0 }

--- a/notchi/notchi/Services/NotchiStateMachine.swift
+++ b/notchi/notchi/Services/NotchiStateMachine.swift
@@ -37,8 +37,8 @@ final class NotchiStateMachine {
     private static let waitingClearGuard: TimeInterval = 2.0
     private static let codexProcessMonitorInterval: Duration = .seconds(2)
     private static let codexThreadMetadataMonitorInterval: Duration = .seconds(5)
-    private static let codexCompactionSignalRefreshDebounce: Duration = .milliseconds(150)
-    private static let codexCompactionSignalMinRefreshInterval: Duration = .seconds(2)
+    private nonisolated static let codexCompactionSignalRefreshDebounce: Duration = .milliseconds(150)
+    private nonisolated static let codexCompactionSignalMinRefreshInterval: Duration = .seconds(2)
     private static let codexProcessMissLimit = 2
     private static let pendingSessionStartMaxAge: TimeInterval = 10 * 60
 

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -730,10 +730,6 @@ nonisolated struct CodexCompactionSignalUpdate: Sendable, Equatable {
     let signal: CodexCompactionSignal?
 }
 
-// WHY: The metadata and compaction resolvers each re-listed ~/.codex on every
-// refresh tick just to find the newest versioned sqlite file. The cached URL is
-// revalidated cheaply and re-listed only on expiry or when the file disappears,
-// so database rotation is still picked up within the TTL.
 nonisolated final class CodexSQLiteURLCache: Sendable {
     private struct Entry {
         let url: URL

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -22,10 +22,19 @@ enum CostStatFormatter {
         usdFormatter.string(from: NSNumber(value: amount)) ?? String(format: "$%.2f", amount)
     }
 
+    private static let gptPrefix = "GPT-"
+    private static let longestPrefixedGptName = "GPT-5.5"
+
     static func modelName(_ raw: String) -> String {
         var s = raw
         if let slash = s.lastIndex(of: "/") { s = String(s[s.index(after: slash)...]) }
-        if s.lowercased().hasPrefix("gpt") { return "GPT" + s.dropFirst(3) }
+        if s.lowercased().hasPrefix("gpt") {
+            let named = "GPT" + s.dropFirst(3)
+            guard named.count > longestPrefixedGptName.count, named.hasPrefix(gptPrefix) else {
+                return named
+            }
+            return String(named.dropFirst(gptPrefix.count))
+        }
         if s.hasPrefix("claude-") { s.removeFirst("claude-".count) }
         let parts = s.split(separator: "-").map(String.init)
         guard let family = parts.first, !family.isEmpty else { return raw }
@@ -86,14 +95,28 @@ struct CostDashboardView: View {
         ]
     }
 
+    private static let modelSizingReference = "Opus 4.8"
+
+    static func sizingValueSets(_ r: DailyCostReport) -> [[String]] {
+        let unselected = statItems(r, selected: nil).map(\.value)
+        var reference = unselected
+        reference[reference.count - 1] = modelSizingReference
+
+        let hoverStates = r.entries
+            .filter { $0.requestCount > 0 }
+            .map { statItems(r, selected: $0).map(\.value) }
+
+        return [unselected, reference] + hoverStates
+    }
+
     @ViewBuilder private func statsRow(_ r: DailyCostReport) -> some View {
         let items = Self.statItems(r, selected: selected)
-        let peerValues = sizingPeerStore?.report.map { Self.statItems($0, selected: nil).map(\.value) } ?? []
+        let peerValues = sizingPeerStore?.report.map { Self.sizingValueSets($0) } ?? []
         GeometryReader { geo in
             let available = geo.size.width - Self.statSpacing * CGFloat(items.count - 1)
             let widths = Self.statColumnWeights.map { $0 * available }
             let valueSize = Self.fittedValueFontSize(
-                valueSets: [items.map(\.value), peerValues],
+                valueSets: Self.sizingValueSets(r) + peerValues,
                 widths: widths
             )
             HStack(alignment: .top, spacing: Self.statSpacing) {

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -79,7 +79,10 @@ struct CostDashboardView: View {
             ),
             (String(localized: "30d"), CostStatFormatter.usd(r.windowCostUSD)),
             (String(localized: "30d toks"), CostStatFormatter.tokens(r.windowTokens)),
-            (String(localized: "Top model"), r.topModel.map(CostStatFormatter.modelName) ?? "—"),
+            (
+                String(localized: "Top model"),
+                (selected.map(\.topModel) ?? r.topModel).map(CostStatFormatter.modelName) ?? "—"
+            ),
         ]
     }
 


### PR DESCRIPTION
## Summary

Started as a "why is cost partial?" investigation and grew to cover the
root cause plus the dashboard issues it exposed.

### The pricing bug (the reason cost was partial)

`PricingCatalog` decoded models.dev with non-optional `cache_read` /
`cache_write`, but ~10 OpenAI models omit `cache_write` because they
don't bill it. One missing field failed that model's decode, which
failed the whole models dictionary, which failed the entire top-level
decode — and since that decode covers both providers, **one OpenAI entry
also killed the Claude refresh**. A `try?` swallowed it silently, so the
app had been falling back to bundled pricing since v1.2.0: the Codex
snapshot was never written and the Claude snapshot was frozen at Jun 25.

Cache fields are now optional (absent = not billed = 0) and each entry
decodes failably, so a bad entry costs you that one model instead of
everything. The bundled Codex fallback also gains the gpt-5.6 family;
existing fallback values are numerically unchanged.

### Dashboard

- **Top model follows the hovered day.** Hovering a bar already swapped
  the first two stat columns; the model column now does too, reverting
  to the 30-day leader on exit.
- **Top-model ties were non-deterministic.** Ranking on cost alone let
  `Dictionary` iteration order pick the winner on a tie, so it could
  flip between scans — guaranteed on any day where nothing was priced
  (every model at zero cost). Now ranked by cost, then tokens, then
  name. The regression test failed 2 of 3 runs before the fix.
- **Stat values no longer resize on hover.** The font size was fitted to
  whatever was on screen, so each hover rescaled the row. It is now
  fitted across every state the row can display, plus an `Opus 4.8`
  reference for the model column so short names can't render oversized.
- **Long GPT names drop the prefix** (`GPT-5.6-sol` → `5.6-sol`) so they
  fit their column; `GPT-5.5` and shorter keep it.

### Also

- Swift 6 concurrency warnings from the merged perf work: a `nonisolated`
  helper and an `OSAllocatedUnfairLock`'s state inherited the project's
  `@MainActor` default. Warnings today, errors under Swift 6.
- Dropped the explanatory comments added in that perf work.

## Validation

- Full suite green (`./scripts/test.sh all`), clean build with no
  concurrency warnings.
- 12 new tests: lenient decoding (missing cache fields, malformed entry
  isolation, cross-provider independence, tier fallbacks), gpt-5.6
  fallback pricing, tie-break determinism, per-day top model, sizing
  coverage, and GPT name shortening.
- Each commit was built and tested at its own intermediate state, so
  they stand alone rather than being a split of the final diff.

https://claude.ai/code/session_01Coa6K9AWf43ruqWhVv7qJ8