### PR TITLE
feat: push-to-talk speech-to-text dictation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
           xcodebuild -version
           xcrun swift --version
 
+      - name: Build whisper.xcframework
+        run: ./scripts/build-whisper-xcframework.sh
+
       - name: Build and test
         run: ./scripts/test.sh all
 

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ tmp/
 
 # Download tracking
 docs/downloads.csv
+
+# whisper.cpp build (regenerate via scripts/build-whisper-xcframework.sh)
+/build/whisper-src/
+/third_party/whisper.xcframework/

--- a/notchi/Info.plist
+++ b/notchi/Info.plist
@@ -22,5 +22,9 @@
 	<string>ZfouVFLXx9vyEimCHW+JWgAtikAq19KsWbig7FkB2QA=</string>
 	<key>SUVerifyUpdateBeforeExtraction</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Notchi transcribes your speech on-device so you can dictate prompts from the notch.</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>Notchi focuses the terminal tab of the session you selected so dictated prompts land in the right place.</string>
 </dict>
 </plist>

--- a/notchi/Tests/AppSettingsDictationTests.swift
+++ b/notchi/Tests/AppSettingsDictationTests.swift
@@ -1,0 +1,44 @@
+import Carbon.HIToolbox
+import XCTest
+@testable import notchi
+
+@MainActor
+final class AppSettingsDictationTests: XCTestCase {
+    private let keys = [
+        "dictationEnabled", "dictationPushToTalkShortcut",
+        "dictationModelId", "dictationLanguage",
+    ]
+
+    override func setUp() {
+        super.setUp()
+        keys.forEach { UserDefaults.standard.removeObject(forKey: $0) }
+    }
+
+    override func tearDown() {
+        keys.forEach { UserDefaults.standard.removeObject(forKey: $0) }
+        super.tearDown()
+    }
+
+    func testDefaultsMatchSpec() {
+        XCTAssertFalse(AppSettings.dictationEnabled)
+        XCTAssertEqual(AppSettings.dictationModelId, "base.en")
+        XCTAssertEqual(AppSettings.dictationLanguage, "en")
+        XCTAssertEqual(
+            AppSettings.dictationPushToTalkShortcut,
+            GlobalShortcut(keyCode: UInt32(kVK_ANSI_D), modifiers: UInt32(cmdKey | optionKey | shiftKey))
+        )
+    }
+
+    func testRoundTrips() {
+        AppSettings.dictationEnabled = true
+        AppSettings.dictationModelId = "small"
+        AppSettings.dictationLanguage = "auto"
+        let shortcut = GlobalShortcut(keyCode: UInt32(kVK_ANSI_V), modifiers: UInt32(cmdKey))
+        AppSettings.dictationPushToTalkShortcut = shortcut
+
+        XCTAssertTrue(AppSettings.dictationEnabled)
+        XCTAssertEqual(AppSettings.dictationModelId, "small")
+        XCTAssertEqual(AppSettings.dictationLanguage, "auto")
+        XCTAssertEqual(AppSettings.dictationPushToTalkShortcut, shortcut)
+    }
+}

--- a/notchi/Tests/DictationPresentationTests.swift
+++ b/notchi/Tests/DictationPresentationTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import notchi
+
+final class DictationPresentationTests: XCTestCase {
+    func testCTAMapsErrorsToActions() {
+        XCTAssertEqual(DictationPresentation.cta(for: .error(.microphoneDenied)), .grantMicrophone)
+        XCTAssertEqual(DictationPresentation.cta(for: .error(.accessibilityDenied)), .grantAccessibility)
+        XCTAssertEqual(DictationPresentation.cta(for: .error(.modelMissing)), .downloadModel)
+        XCTAssertEqual(DictationPresentation.cta(for: .error(.noActiveSession)), .noSession)
+        XCTAssertEqual(DictationPresentation.cta(for: .error(.sessionNotInjectable)), .sessionNotInjectable)
+        XCTAssertEqual(DictationPresentation.cta(for: .error(.transcriptionFailed)), .retry)
+        XCTAssertEqual(DictationPresentation.cta(for: .review("hi")), .none)
+    }
+
+    func testOnlyReviewPhaseIsEditable() {
+        XCTAssertTrue(DictationPresentation.isEditable(.review("x")))
+        XCTAssertFalse(DictationPresentation.isEditable(.recording))
+        XCTAssertFalse(DictationPresentation.isEditable(.transcribing))
+    }
+
+    func testEditorStaysVisibleDuringReDictationButNotFreshDictation() {
+        // Re-dictation: text already present → editor stays mounted through busy phases.
+        XCTAssertTrue(DictationPresentation.showsEditor(.recording, hasText: true))
+        XCTAssertTrue(DictationPresentation.showsEditor(.transcribing, hasText: true))
+        XCTAssertTrue(DictationPresentation.showsEditor(.review("x"), hasText: true))
+        // Fresh dictation: no text yet → editor hidden until review.
+        XCTAssertFalse(DictationPresentation.showsEditor(.recording, hasText: false))
+        XCTAssertFalse(DictationPresentation.showsEditor(.transcribing, hasText: false))
+        XCTAssertTrue(DictationPresentation.showsEditor(.review(""), hasText: false))
+        XCTAssertFalse(DictationPresentation.showsEditor(.idle, hasText: true))
+    }
+
+    func testIsBusyCoversRecordingAndTranscribing() {
+        XCTAssertTrue(DictationPresentation.isBusy(.recording))
+        XCTAssertTrue(DictationPresentation.isBusy(.transcribing))
+        XCTAssertFalse(DictationPresentation.isBusy(.review("x")))
+        XCTAssertFalse(DictationPresentation.isBusy(.idle))
+        XCTAssertFalse(DictationPresentation.isBusy(.sending))
+    }
+
+    func testStatusTextIsNonEmptyForEachPhase() {
+        let phases: [DictationPhase] = [.idle, .recording, .transcribing, .review("x"), .sending, .error(.modelMissing)]
+        for phase in phases {
+            XCTAssertFalse(DictationPresentation.statusText(for: phase).isEmpty)
+        }
+    }
+}

--- a/notchi/Tests/NotchPanelManagerTests.swift
+++ b/notchi/Tests/NotchPanelManagerTests.swift
@@ -771,6 +771,41 @@ final class NotchPanelManagerTests: XCTestCase {
         XCTAssertEqual(received.value, 2)
     }
 
+    func testExpandForDictationWhenCollapsedAutoCollapsesAfterDictation() async {
+        let defaults = makeDefaults()
+        let sessionCount = SessionCountBox(0)
+        let manager = makeManager(sessionCount: sessionCount, defaults: defaults)
+        configureGeometry(for: manager)
+
+        XCTAssertFalse(manager.isExpanded)
+
+        manager.expandForDictation()
+        XCTAssertTrue(manager.isExpanded)
+        XCTAssertFalse(manager.wasExpandedBeforeDictation)
+
+        manager.collapseAfterDictation()
+        XCTAssertFalse(manager.isExpanded)
+        XCTAssertFalse(manager.wasExpandedBeforeDictation)
+    }
+
+    func testExpandForDictationWhenAlreadyExpandedRemainsExpandedAfterDictation() async {
+        let defaults = makeDefaults()
+        let sessionCount = SessionCountBox(0)
+        let manager = makeManager(sessionCount: sessionCount, defaults: defaults)
+        configureGeometry(for: manager)
+
+        manager.expand()
+        XCTAssertTrue(manager.isExpanded)
+
+        manager.expandForDictation()
+        XCTAssertTrue(manager.isExpanded)
+        XCTAssertTrue(manager.wasExpandedBeforeDictation)
+
+        manager.collapseAfterDictation()
+        XCTAssertTrue(manager.isExpanded)
+        XCTAssertFalse(manager.wasExpandedBeforeDictation)
+    }
+
     private func makeDefaults() -> UserDefaults {
         let suiteName = "NotchPanelManagerTests-\(UUID().uuidString)"
         defaultsSuiteNames.append(suiteName)

--- a/notchi/Tests/PromptInjectionServiceTests.swift
+++ b/notchi/Tests/PromptInjectionServiceTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import notchi
+
+@MainActor
+final class PromptInjectionServiceTests: XCTestCase {
+    private final class FakePasteboard: Pasteboarding {
+        var stored: String?
+        var setValues: [String] = []
+        func string() -> String? { stored }
+        func setString(_ value: String) { stored = value; setValues.append(value) }
+    }
+
+    private final class FakePoster: KeyEventPosting {
+        var pasteCount = 0
+        var lastPID: pid_t?
+        func postPasteAndReturn(toPID pid: pid_t) { pasteCount += 1; lastPID = pid }
+    }
+
+    /// Returns a scripted sequence of values from string(), so a test can make the
+    /// clipboard "change" between the saved-read and the restore-read.
+    private final class QueuedPasteboard: Pasteboarding {
+        private let reads: [String?]
+        private var idx = 0
+        var setValues: [String] = []
+        init(reads: [String?]) { self.reads = reads }
+        func string() -> String? { defer { idx += 1 }; return idx < reads.count ? reads[idx] : reads.last ?? nil }
+        func setString(_ value: String) { setValues.append(value) }
+    }
+
+    func testCanInjectRejectsCodexDesktopOnly() {
+        let claude = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
+        let codexCLI = SessionData(sessionId: "x", provider: .codex, cwd: "/tmp")
+        codexCLI.updateCodexRuntime(processId: 10, origin: .cli)
+        let codexDesktop = SessionData(sessionId: "y", provider: .codex, cwd: "/tmp")
+        codexDesktop.updateCodexRuntime(processId: 11, origin: .desktop)
+
+        XCTAssertTrue(PromptInjectionService.canInject(into: claude))
+        XCTAssertTrue(PromptInjectionService.canInject(into: codexCLI))
+        XCTAssertFalse(PromptInjectionService.canInject(into: codexDesktop))
+    }
+
+    func testPreparedPromptTrimsAndRejectsEmpty() {
+        XCTAssertEqual(PromptInjectionService.preparedPrompt("  hi  "), "hi")
+        XCTAssertNil(PromptInjectionService.preparedPrompt("   \n "))
+    }
+
+    func testInjectNilSessionReturnsNoSession() async {
+        let service = makeService()
+        let result = await service.inject("hi", into: nil)
+        XCTAssertEqual(result, .noSession)
+    }
+
+    // MARK: - Background script path (preferred)
+
+    func testScriptInjectDeliversInBackgroundWithoutPasteOrClipboard() async {
+        let pasteboard = FakePasteboard(); pasteboard.stored = "original"
+        let poster = FakePoster()
+        let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
+        let service = makeService(pasteboard: pasteboard, poster: poster, scriptInject: { _, _ in true })
+
+        let result = await service.inject("run tests", into: session)
+        XCTAssertEqual(result, .sent)
+        XCTAssertEqual(poster.pasteCount, 0, "background path must not synthesize keystrokes")
+        XCTAssertTrue(pasteboard.setValues.isEmpty, "background path must not touch the clipboard")
+        XCTAssertEqual(pasteboard.stored, "original")
+    }
+
+    func testScriptInjectFailureReturnsFailed() async {
+        let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
+        let service = makeService(scriptInject: { _, _ in false })
+        let result = await service.inject("hi", into: session)
+        XCTAssertEqual(result, .failed)
+    }
+
+    // MARK: - Fallback CGEvent path (non-scriptable terminals; scriptInject → nil)
+
+    func testFallbackPostsToResolvedPidAndRestoresPasteboard() async {
+        let pasteboard = FakePasteboard(); pasteboard.stored = "original"
+        let poster = FakePoster()
+        let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
+        let service = makeService(pasteboard: pasteboard, poster: poster, resolvePID: { _ in 4321 })
+
+        let result = await service.inject("run tests", into: session)
+        XCTAssertEqual(result, .sent)
+        XCTAssertEqual(poster.pasteCount, 1)
+        XCTAssertEqual(poster.lastPID, 4321)
+        XCTAssertEqual(pasteboard.setValues.first, "run tests")
+        XCTAssertEqual(pasteboard.stored, "original") // restored
+    }
+
+    func testFallbackUsesFrontmostPidWhenTerminalUnresolved() async {
+        let poster = FakePoster()
+        let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
+        let service = makeService(poster: poster, resolvePID: { _ in nil })
+
+        let result = await service.inject("hi", into: session, fallbackAppPID: 99)
+        XCTAssertEqual(result, .sent)
+        XCTAssertEqual(poster.lastPID, 99)
+    }
+
+    func testFallbackFailsWhenNoPidResolvable() async {
+        let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
+        let service = makeService(resolvePID: { _ in nil })
+        let result = await service.inject("hi", into: session, fallbackAppPID: nil)
+        XCTAssertEqual(result, .failed)
+    }
+
+    func testFallbackRejectsNonTerminalFrontmostApp() async {
+        let poster = FakePoster()
+        let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
+        // Session unresolved + the frontmost app (e.g. a browser) is not a terminal.
+        let service = makeService(poster: poster, resolvePID: { _ in nil }, isTerminalPID: { _ in false })
+        let result = await service.inject("hi", into: session, fallbackAppPID: 99)
+        XCTAssertEqual(result, .failed, "must not paste into a non-terminal frontmost app")
+        XCTAssertEqual(poster.pasteCount, 0)
+    }
+
+    func testRestoreSkippedWhenClipboardChangedDuringWindow() async {
+        // string() yields "original" first (the saved read), then a different value
+        // at restore time — as if the user copied something new after injection.
+        let pasteboard = QueuedPasteboard(reads: ["original", "user copied later"])
+        let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
+        let service = makeService(pasteboard: pasteboard, resolvePID: { _ in 4321 })
+
+        let result = await service.inject("dictated", into: session)
+        XCTAssertEqual(result, .sent)
+        XCTAssertEqual(pasteboard.setValues, ["dictated"], "must not restore over the user's newer clipboard")
+    }
+
+    func testFallbackReturnsNeedsAccessibilityWhenUntrusted() async {
+        let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
+        let service = makeService(resolvePID: { _ in 1 }, trusted: false)
+        let result = await service.inject("hi", into: session)
+        XCTAssertEqual(result, .needsAccessibility)
+    }
+
+    func testInjectReturnsNotInjectableForCodexDesktop() async {
+        let session = SessionData(sessionId: "y", provider: .codex, cwd: "/tmp")
+        session.updateCodexRuntime(processId: 11, origin: .desktop)
+        let service = makeService(scriptInject: { _, _ in true })
+        let result = await service.inject("hi", into: session)
+        XCTAssertEqual(result, .notInjectable)
+    }
+
+    private func makeService(
+        pasteboard: Pasteboarding = FakePasteboard(),
+        poster: KeyEventPosting = FakePoster(),
+        scriptInject: @escaping @MainActor (String, SessionData) async -> Bool? = { _, _ in nil },
+        resolvePID: @escaping @MainActor (SessionData) -> pid_t? = { _ in nil },
+        isTerminalPID: @escaping @MainActor (pid_t) -> Bool = { _ in true },
+        trusted: Bool = true
+    ) -> PromptInjectionService {
+        PromptInjectionService(
+            pasteboard: pasteboard,
+            poster: poster,
+            scriptInject: scriptInject,
+            resolveTerminalPID: resolvePID,
+            isTerminalPID: isTerminalPID,
+            accessibilityTrusted: { trusted },
+            restoreDelay: 0
+        )
+    }
+}

--- a/notchi/Tests/PromptInjectionServiceTests.swift
+++ b/notchi/Tests/PromptInjectionServiceTests.swift
@@ -3,28 +3,13 @@ import XCTest
 
 @MainActor
 final class PromptInjectionServiceTests: XCTestCase {
-    private final class FakePasteboard: Pasteboarding {
-        var stored: String?
-        var setValues: [String] = []
-        func string() -> String? { stored }
-        func setString(_ value: String) { stored = value; setValues.append(value) }
-    }
-
     private final class FakePoster: KeyEventPosting {
-        var pasteCount = 0
+        var callCount = 0
+        var lastText: String?
         var lastPID: pid_t?
-        func postPasteAndReturn(toPID pid: pid_t) { pasteCount += 1; lastPID = pid }
-    }
-
-    /// Returns a scripted sequence of values from string(), so a test can make the
-    /// clipboard "change" between the saved-read and the restore-read.
-    private final class QueuedPasteboard: Pasteboarding {
-        private let reads: [String?]
-        private var idx = 0
-        var setValues: [String] = []
-        init(reads: [String?]) { self.reads = reads }
-        func string() -> String? { defer { idx += 1 }; return idx < reads.count ? reads[idx] : reads.last ?? nil }
-        func setString(_ value: String) { setValues.append(value) }
+        func postTextAndReturn(_ text: String, toPID pid: pid_t) {
+            callCount += 1; lastText = text; lastPID = pid
+        }
     }
 
     func testCanInjectRejectsCodexDesktopOnly() {
@@ -52,17 +37,14 @@ final class PromptInjectionServiceTests: XCTestCase {
 
     // MARK: - Background script path (preferred)
 
-    func testScriptInjectDeliversInBackgroundWithoutPasteOrClipboard() async {
-        let pasteboard = FakePasteboard(); pasteboard.stored = "original"
+    func testScriptInjectDeliversInBackgroundWithoutKeystrokes() async {
         let poster = FakePoster()
         let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
-        let service = makeService(pasteboard: pasteboard, poster: poster, scriptInject: { _, _ in true })
+        let service = makeService(poster: poster, scriptInject: { _, _ in true })
 
         let result = await service.inject("run tests", into: session)
         XCTAssertEqual(result, .sent)
-        XCTAssertEqual(poster.pasteCount, 0, "background path must not synthesize keystrokes")
-        XCTAssertTrue(pasteboard.setValues.isEmpty, "background path must not touch the clipboard")
-        XCTAssertEqual(pasteboard.stored, "original")
+        XCTAssertEqual(poster.callCount, 0, "background path must not synthesize keystrokes")
     }
 
     func testScriptInjectFailureReturnsFailed() async {
@@ -72,20 +54,18 @@ final class PromptInjectionServiceTests: XCTestCase {
         XCTAssertEqual(result, .failed)
     }
 
-    // MARK: - Fallback CGEvent path (non-scriptable terminals; scriptInject → nil)
+    // MARK: - Fallback keystroke path (non-scriptable terminals; scriptInject → nil)
 
-    func testFallbackPostsToResolvedPidAndRestoresPasteboard() async {
-        let pasteboard = FakePasteboard(); pasteboard.stored = "original"
+    func testFallbackTypesTextToResolvedPid() async {
         let poster = FakePoster()
         let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
-        let service = makeService(pasteboard: pasteboard, poster: poster, resolvePID: { _ in 4321 })
+        let service = makeService(poster: poster, resolvePID: { _ in 4321 })
 
         let result = await service.inject("run tests", into: session)
         XCTAssertEqual(result, .sent)
-        XCTAssertEqual(poster.pasteCount, 1)
+        XCTAssertEqual(poster.callCount, 1)
+        XCTAssertEqual(poster.lastText, "run tests")
         XCTAssertEqual(poster.lastPID, 4321)
-        XCTAssertEqual(pasteboard.setValues.first, "run tests")
-        XCTAssertEqual(pasteboard.stored, "original") // restored
     }
 
     func testFallbackUsesFrontmostPidWhenTerminalUnresolved() async {
@@ -98,33 +78,22 @@ final class PromptInjectionServiceTests: XCTestCase {
         XCTAssertEqual(poster.lastPID, 99)
     }
 
-    func testFallbackFailsWhenNoPidResolvable() async {
-        let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
-        let service = makeService(resolvePID: { _ in nil })
-        let result = await service.inject("hi", into: session, fallbackAppPID: nil)
-        XCTAssertEqual(result, .failed)
-    }
-
     func testFallbackRejectsNonTerminalFrontmostApp() async {
         let poster = FakePoster()
         let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
         // Session unresolved + the frontmost app (e.g. a browser) is not a terminal.
         let service = makeService(poster: poster, resolvePID: { _ in nil }, isTerminalPID: { _ in false })
+
         let result = await service.inject("hi", into: session, fallbackAppPID: 99)
-        XCTAssertEqual(result, .failed, "must not paste into a non-terminal frontmost app")
-        XCTAssertEqual(poster.pasteCount, 0)
+        XCTAssertEqual(result, .failed, "must not type into a non-terminal frontmost app")
+        XCTAssertEqual(poster.callCount, 0)
     }
 
-    func testRestoreSkippedWhenClipboardChangedDuringWindow() async {
-        // string() yields "original" first (the saved read), then a different value
-        // at restore time — as if the user copied something new after injection.
-        let pasteboard = QueuedPasteboard(reads: ["original", "user copied later"])
+    func testFallbackFailsWhenNoPidResolvable() async {
         let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
-        let service = makeService(pasteboard: pasteboard, resolvePID: { _ in 4321 })
-
-        let result = await service.inject("dictated", into: session)
-        XCTAssertEqual(result, .sent)
-        XCTAssertEqual(pasteboard.setValues, ["dictated"], "must not restore over the user's newer clipboard")
+        let service = makeService(resolvePID: { _ in nil })
+        let result = await service.inject("hi", into: session, fallbackAppPID: nil)
+        XCTAssertEqual(result, .failed)
     }
 
     func testFallbackReturnsNeedsAccessibilityWhenUntrusted() async {
@@ -143,7 +112,6 @@ final class PromptInjectionServiceTests: XCTestCase {
     }
 
     private func makeService(
-        pasteboard: Pasteboarding = FakePasteboard(),
         poster: KeyEventPosting = FakePoster(),
         scriptInject: @escaping @MainActor (String, SessionData) async -> Bool? = { _, _ in nil },
         resolvePID: @escaping @MainActor (SessionData) -> pid_t? = { _ in nil },
@@ -151,13 +119,11 @@ final class PromptInjectionServiceTests: XCTestCase {
         trusted: Bool = true
     ) -> PromptInjectionService {
         PromptInjectionService(
-            pasteboard: pasteboard,
             poster: poster,
             scriptInject: scriptInject,
             resolveTerminalPID: resolvePID,
             isTerminalPID: isTerminalPID,
-            accessibilityTrusted: { trusted },
-            restoreDelay: 0
+            accessibilityTrusted: { trusted }
         )
     }
 }

--- a/notchi/Tests/PromptInjectionServiceTests.swift
+++ b/notchi/Tests/PromptInjectionServiceTests.swift
@@ -7,8 +7,12 @@ final class PromptInjectionServiceTests: XCTestCase {
         var callCount = 0
         var lastText: String?
         var lastPID: pid_t?
-        func postTextAndReturn(_ text: String, toPID pid: pid_t) {
-            callCount += 1; lastText = text; lastPID = pid
+        var lastWithReturn: Bool?
+        func postText(_ text: String, toPID pid: pid_t, withReturn: Bool) {
+            callCount += 1
+            lastText = text
+            lastPID = pid
+            lastWithReturn = withReturn
         }
     }
 
@@ -37,14 +41,20 @@ final class PromptInjectionServiceTests: XCTestCase {
 
     // MARK: - Background script path (preferred)
 
-    func testScriptInjectDeliversInBackgroundWithoutKeystrokes() async {
+    func testScriptInjectDeliversInBackgroundWithoutKeystrokesOrActivation() async {
         let poster = FakePoster()
+        var activatedPID: pid_t?
         let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
-        let service = makeService(poster: poster, scriptInject: { _, _ in true })
+        let service = makeService(
+            poster: poster,
+            scriptInject: { _, _ in true },
+            activateProcess: { activatedPID = $0; return true }
+        )
 
         let result = await service.inject("run tests", into: session)
         XCTAssertEqual(result, .sent)
         XCTAssertEqual(poster.callCount, 0, "background path must not synthesize keystrokes")
+        XCTAssertNil(activatedPID, "background script path must not steal focus/activate app")
     }
 
     func testScriptInjectFailureReturnsFailed() async {
@@ -56,16 +66,44 @@ final class PromptInjectionServiceTests: XCTestCase {
 
     // MARK: - Fallback keystroke path (non-scriptable terminals; scriptInject → nil)
 
-    func testFallbackTypesTextToResolvedPid() async {
+    func testFallbackTypesTextWithReturnWhenInitiatedFromTargetTerminal() async {
         let poster = FakePoster()
+        var activatedPID: pid_t?
         let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
-        let service = makeService(poster: poster, resolvePID: { _ in 4321 })
+        let service = makeService(
+            poster: poster,
+            resolvePID: { _ in 4321 },
+            activateProcess: { activatedPID = $0; return true }
+        )
 
-        let result = await service.inject("run tests", into: session)
+        // fallbackAppPID == targetPID indicates dictation started from this terminal
+        let result = await service.inject("run tests", into: session, fallbackAppPID: 4321)
         XCTAssertEqual(result, .sent)
         XCTAssertEqual(poster.callCount, 1)
         XCTAssertEqual(poster.lastText, "run tests")
         XCTAssertEqual(poster.lastPID, 4321)
+        XCTAssertEqual(poster.lastWithReturn, true, "should submit Return when initiated from target terminal")
+        XCTAssertEqual(activatedPID, 4321, "should activate target terminal")
+    }
+
+    func testFallbackTypesTextWithoutReturnWhenTargetWasInBackground() async {
+        let poster = FakePoster()
+        var activatedPID: pid_t?
+        let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
+        let service = makeService(
+            poster: poster,
+            resolvePID: { _ in 4321 },
+            activateProcess: { activatedPID = $0; return true }
+        )
+
+        // fallbackAppPID (9999) != targetPID (4321): terminal was in background
+        let result = await service.inject("run tests", into: session, fallbackAppPID: 9999)
+        XCTAssertEqual(result, .sent)
+        XCTAssertEqual(poster.callCount, 1)
+        XCTAssertEqual(poster.lastText, "run tests")
+        XCTAssertEqual(poster.lastPID, 4321)
+        XCTAssertEqual(poster.lastWithReturn, false, "must NOT submit Return when terminal was in background")
+        XCTAssertEqual(activatedPID, 4321, "should activate target terminal so user sees destination")
     }
 
     func testFallbackUsesFrontmostPidWhenTerminalUnresolved() async {
@@ -76,6 +114,7 @@ final class PromptInjectionServiceTests: XCTestCase {
         let result = await service.inject("hi", into: session, fallbackAppPID: 99)
         XCTAssertEqual(result, .sent)
         XCTAssertEqual(poster.lastPID, 99)
+        XCTAssertEqual(poster.lastWithReturn, true)
     }
 
     func testFallbackRejectsNonTerminalFrontmostApp() async {
@@ -116,14 +155,16 @@ final class PromptInjectionServiceTests: XCTestCase {
         scriptInject: @escaping @MainActor (String, SessionData) async -> Bool? = { _, _ in nil },
         resolvePID: @escaping @MainActor (SessionData) -> pid_t? = { _ in nil },
         isTerminalPID: @escaping @MainActor (pid_t) -> Bool = { _ in true },
-        trusted: Bool = true
+        trusted: Bool = true,
+        activateProcess: @escaping @MainActor (pid_t) -> Bool = { _ in true }
     ) -> PromptInjectionService {
         PromptInjectionService(
             poster: poster,
             scriptInject: scriptInject,
             resolveTerminalPID: resolvePID,
             isTerminalPID: isTerminalPID,
-            accessibilityTrusted: { trusted }
+            accessibilityTrusted: { trusted },
+            activateProcess: activateProcess
         )
     }
 }

--- a/notchi/Tests/PushToTalkServiceTests.swift
+++ b/notchi/Tests/PushToTalkServiceTests.swift
@@ -1,0 +1,52 @@
+import Carbon.HIToolbox
+import XCTest
+@testable import notchi
+
+@MainActor
+final class PushToTalkServiceTests: XCTestCase {
+    private final class FakeMonitor: HoldKeyMonitoring {
+        var handler: ((PushToTalkService.HoldKeyEvent) -> Void)?
+        func begin(_ handler: @escaping (PushToTalkService.HoldKeyEvent) -> Void) { self.handler = handler }
+        func end() { handler = nil }
+    }
+
+    private let shortcut = GlobalShortcut(keyCode: UInt32(kVK_ANSI_D), modifiers: UInt32(cmdKey | optionKey | shiftKey))
+
+    func testMatchesRequiresKeyCodeAndModifiers() {
+        let match = PushToTalkService.HoldKeyEvent(kind: .down, keyCode: UInt32(kVK_ANSI_D), modifiers: UInt32(cmdKey | optionKey | shiftKey))
+        let wrongMods = PushToTalkService.HoldKeyEvent(kind: .down, keyCode: UInt32(kVK_ANSI_D), modifiers: UInt32(cmdKey))
+        XCTAssertTrue(PushToTalkService.matches(match, shortcut: shortcut))
+        XCTAssertFalse(PushToTalkService.matches(wrongMods, shortcut: shortcut))
+    }
+
+    func testDownThenUpFiresStartThenStopOnce() {
+        var starts = 0, stops = 0
+        let monitor = FakeMonitor()
+        let service = PushToTalkService(
+            shortcut: { self.shortcut },
+            onStart: { starts += 1 },
+            onStop: { stops += 1 },
+            eventSource: monitor
+        )
+        service.start()
+
+        let down = PushToTalkService.HoldKeyEvent(kind: .down, keyCode: UInt32(kVK_ANSI_D), modifiers: UInt32(cmdKey | optionKey | shiftKey))
+        let up = PushToTalkService.HoldKeyEvent(kind: .up, keyCode: UInt32(kVK_ANSI_D), modifiers: 0)
+
+        monitor.handler?(down)
+        monitor.handler?(down) // key repeat must not re-fire start
+        monitor.handler?(up)
+
+        XCTAssertEqual(starts, 1)
+        XCTAssertEqual(stops, 1)
+    }
+
+    func testKeyUpWithoutActiveHoldDoesNotFireStop() {
+        var stops = 0
+        let monitor = FakeMonitor()
+        let service = PushToTalkService(shortcut: { self.shortcut }, onStart: {}, onStop: { stops += 1 }, eventSource: monitor)
+        service.start()
+        monitor.handler?(PushToTalkService.HoldKeyEvent(kind: .up, keyCode: UInt32(kVK_ANSI_D), modifiers: 0))
+        XCTAssertEqual(stops, 0)
+    }
+}

--- a/notchi/Tests/SpeechToTextServiceTests.swift
+++ b/notchi/Tests/SpeechToTextServiceTests.swift
@@ -1,0 +1,256 @@
+import XCTest
+@testable import notchi
+
+@MainActor
+final class SpeechToTextServiceTests: XCTestCase {
+    private final class MockCapture: AudioCapturing, @unchecked Sendable {
+        var stopCount = 0
+        func start() throws {}
+        func stop() -> [Float] {
+            stopCount += 1
+            return [0.1, 0.2, 0.3]
+        }
+    }
+
+    private struct MockTranscriber: Transcribing {
+        let text: String
+        func transcribe(samples: [Float], language: String) async throws -> String { text }
+    }
+
+    /// Transcriber whose `transcribe()` hangs until `resume` is called, so tests can
+    /// deterministically observe the service while it is in `.transcribing`.
+    private final class HangingTranscriber: Transcribing, @unchecked Sendable {
+        private var continuation: CheckedContinuation<String, Error>?
+
+        func transcribe(samples: [Float], language: String) async throws -> String {
+            try await withCheckedThrowingContinuation { self.continuation = $0 }
+        }
+
+        func resume(with text: String) {
+            continuation?.resume(returning: text)
+        }
+    }
+
+    private func makeService(
+        modelDownloaded: Bool = true,
+        micAuthorized: Bool = true,
+        transcript: String = "hello world"
+    ) -> SpeechToTextService {
+        SpeechToTextService(dependencies: .init(
+            makeCapture: { MockCapture() },
+            makeTranscriber: { _ in MockTranscriber(text: transcript) },
+            isModelDownloaded: { modelDownloaded },
+            modelURL: { URL(fileURLWithPath: "/tmp/model.bin") },
+            language: { "en" },
+            microphoneAuthorized: { micAuthorized }
+        ))
+    }
+
+    func testHappyPathReachesReviewWithTranscript() async {
+        let service = makeService(transcript: "run the tests")
+        service.startRecording()
+        XCTAssertEqual(service.phase, .recording)
+        await service.finishRecording()
+        XCTAssertEqual(service.phase, .review("run the tests"))
+        XCTAssertEqual(service.transcript, "run the tests")
+    }
+
+    func testMissingModelBlocksRecording() {
+        let service = makeService(modelDownloaded: false)
+        service.startRecording()
+        XCTAssertEqual(service.phase, .error(.modelMissing))
+    }
+
+    func testDeniedMicrophoneBlocksRecording() {
+        let service = makeService(micAuthorized: false)
+        service.startRecording()
+        XCTAssertEqual(service.phase, .error(.microphoneDenied))
+    }
+
+    func testEmptyTranscriptionSurfacesError() async {
+        let service = makeService(transcript: "")
+        service.startRecording()
+        await service.finishRecording()
+        XCTAssertEqual(service.phase, .error(.transcriptionFailed))
+    }
+
+    func testResetReturnsToIdle() async {
+        let service = makeService()
+        service.startRecording()
+        await service.finishRecording()
+        service.reset()
+        XCTAssertEqual(service.phase, .idle)
+        XCTAssertTrue(service.transcript.isEmpty)
+    }
+
+    func testStartRecordingWhileAlreadyRecordingIsNoOp() {
+        final class CaptureCounter: @unchecked Sendable {
+            var count = 0
+        }
+        let counter = CaptureCounter()
+        let service = SpeechToTextService(dependencies: .init(
+            makeCapture: {
+                counter.count += 1
+                return MockCapture()
+            },
+            makeTranscriber: { _ in MockTranscriber(text: "hello world") },
+            isModelDownloaded: { true },
+            modelURL: { URL(fileURLWithPath: "/tmp/model.bin") },
+            language: { "en" },
+            microphoneAuthorized: { true }
+        ))
+
+        service.startRecording()
+        XCTAssertEqual(service.phase, .recording)
+        XCTAssertEqual(counter.count, 1)
+
+        service.startRecording()
+        XCTAssertEqual(service.phase, .recording)
+        XCTAssertEqual(counter.count, 1, "second startRecording() must not create a second capture")
+    }
+
+    func testResetWhileRecordingStopsCapture() {
+        let capture = MockCapture()
+        let service = SpeechToTextService(dependencies: .init(
+            makeCapture: { capture },
+            makeTranscriber: { _ in MockTranscriber(text: "hello world") },
+            isModelDownloaded: { true },
+            modelURL: { URL(fileURLWithPath: "/tmp/model.bin") },
+            language: { "en" },
+            microphoneAuthorized: { true }
+        ))
+
+        service.startRecording()
+        XCTAssertEqual(service.phase, .recording)
+
+        service.reset()
+
+        XCTAssertEqual(capture.stopCount, 1, "reset() must stop an in-flight capture")
+        XCTAssertEqual(service.phase, .idle)
+    }
+
+    func testStartRecordingWhileTranscribingIsNoOp() async {
+        final class CaptureCounter: @unchecked Sendable {
+            var count = 0
+        }
+        let counter = CaptureCounter()
+        let transcriber = HangingTranscriber()
+        let service = SpeechToTextService(dependencies: .init(
+            makeCapture: {
+                counter.count += 1
+                return MockCapture()
+            },
+            makeTranscriber: { _ in transcriber },
+            isModelDownloaded: { true },
+            modelURL: { URL(fileURLWithPath: "/tmp/model.bin") },
+            language: { "en" },
+            microphoneAuthorized: { true }
+        ))
+
+        service.startRecording()
+        XCTAssertEqual(service.phase, .recording)
+        XCTAssertEqual(counter.count, 1)
+
+        let finishTask = Task { await service.finishRecording() }
+        while service.phase != .transcribing {
+            await Task.yield()
+        }
+
+        service.startRecording()
+        XCTAssertEqual(service.phase, .transcribing, "startRecording() must no-op while transcribing")
+        XCTAssertEqual(counter.count, 1, "startRecording() during transcribing must not create a second capture")
+
+        transcriber.resume(with: "done")
+        await finishTask.value
+    }
+
+    func testAppendedCombinesExistingAndNewWithSpace() {
+        XCTAssertEqual(SpeechToTextService.appended("", "hello"), "hello")
+        XCTAssertEqual(SpeechToTextService.appended("hello", ""), "hello")
+        XCTAssertEqual(SpeechToTextService.appended("hello", "world"), "hello world")
+        XCTAssertEqual(SpeechToTextService.appended("", ""), "")
+    }
+
+    func testSendInjectsReviewTextIntoActiveSession() async {
+        let service = makeService(transcript: "run tests")
+        service.startRecording()
+        await service.finishRecording()
+        let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
+
+        var injected: String?
+        let result = await service.send(
+            using: { text, _ in injected = text; return .sent },
+            targetSession: session
+        )
+
+        XCTAssertEqual(result, .sent)
+        XCTAssertEqual(injected, "run tests")
+        XCTAssertEqual(service.phase, .idle)
+    }
+
+    func testSendWithoutSessionSetsNoSessionError() async {
+        let service = makeService()
+        service.startRecording()
+        await service.finishRecording()
+        let result = await service.send(using: { _, _ in .noSession }, targetSession: nil)
+        XCTAssertEqual(result, .noSession)
+        XCTAssertEqual(service.phase, .error(.noActiveSession))
+    }
+
+    func testSendInjectionFailureReturnsToReviewForRetry() async {
+        let service = makeService(transcript: "run tests")
+        service.startRecording()
+        await service.finishRecording()
+        let session = SessionData(sessionId: "c", provider: .claude, cwd: "/tmp")
+
+        let result = await service.send(using: { _, _ in .failed }, targetSession: session)
+
+        XCTAssertEqual(result, .failed)
+        XCTAssertEqual(service.phase, .review("run tests"))
+        XCTAssertEqual(service.transcript, "run tests")
+    }
+
+    func testResetDuringTranscribingIsNotClobberedByLateResult() async {
+        let transcriber = HangingTranscriber()
+        let service = SpeechToTextService(dependencies: .init(
+            makeCapture: { MockCapture() },
+            makeTranscriber: { _ in transcriber },
+            isModelDownloaded: { true },
+            modelURL: { URL(fileURLWithPath: "/tmp/model.bin") },
+            language: { "en" },
+            microphoneAuthorized: { true }
+        ))
+
+        service.startRecording()
+        let finishTask = Task { await service.finishRecording() }
+        while service.phase != .transcribing { await Task.yield() }
+
+        service.reset()   // user dismissed while transcription was in flight
+        XCTAssertEqual(service.phase, .idle)
+
+        transcriber.resume(with: "late result")
+        await finishTask.value
+
+        XCTAssertEqual(service.phase, .idle, "a late transcription result must not resurrect the dismissed box")
+        XCTAssertTrue(service.transcript.isEmpty)
+    }
+
+    func testTranscriberIsReusedAcrossDictationsForSameModel() async {
+        final class BuildCounter: @unchecked Sendable { var count = 0 }
+        let counter = BuildCounter()
+        let service = SpeechToTextService(dependencies: .init(
+            makeCapture: { MockCapture() },
+            makeTranscriber: { _ in counter.count += 1; return MockTranscriber(text: "hi") },
+            isModelDownloaded: { true },
+            modelURL: { URL(fileURLWithPath: "/tmp/model.bin") },
+            language: { "en" },
+            microphoneAuthorized: { true }
+        ))
+
+        service.startRecording(); await service.finishRecording()
+        service.reset()
+        service.startRecording(); await service.finishRecording()
+
+        XCTAssertEqual(counter.count, 1, "the model transcriber must be built once and reused, not reloaded per dictation")
+    }
+}

--- a/notchi/Tests/WhisperModelStoreTests.swift
+++ b/notchi/Tests/WhisperModelStoreTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import notchi
+
+final class WhisperModelStoreTests: XCTestCase {
+    func testCatalogHasExpectedSizesAndDefaultIsPresent() {
+        let ids = Set(WhisperCatalog.models.map(\.id))
+        XCTAssertTrue(ids.isSuperset(of: ["tiny.en", "base.en", "small", "large-v3-turbo"]))
+        XCTAssertNotNil(WhisperCatalog.model(id: "base.en"))
+        XCTAssertNil(WhisperCatalog.model(id: "not-real"))
+    }
+
+    func testEnglishOnlyModelsAreNotMultilingual() {
+        XCTAssertEqual(WhisperCatalog.model(id: "base.en")?.isMultilingual, false)
+        XCTAssertEqual(WhisperCatalog.model(id: "small")?.isMultilingual, true)
+    }
+
+    func testFileURLIsUnderApplicationSupportNotchiModels() {
+        let model = WhisperCatalog.model(id: "base.en")!
+        let url = WhisperModelStore.fileURL(for: model)
+        XCTAssertEqual(url.lastPathComponent, "ggml-base.en.bin")
+        XCTAssertTrue(url.deletingLastPathComponent().path.hasSuffix("Notchi/Models"))
+    }
+
+    func testRemoteURLTargetsGgerganovRepo() {
+        let model = WhisperCatalog.model(id: "small")!
+        XCTAssertEqual(
+            WhisperModelStore.remoteURL(for: model).absoluteString,
+            "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin"
+        )
+    }
+
+    @MainActor
+    func testIsDownloadedReflectsInjectedFileExistence() {
+        let present = WhisperCatalog.model(id: "base.en")!
+        let absent = WhisperCatalog.model(id: "small")!
+        let store = WhisperModelStore(
+            fileExists: { $0.lastPathComponent == "ggml-base.en.bin" },
+            downloader: { _, _, _ in }
+        )
+        XCTAssertTrue(store.isDownloaded(present))
+        XCTAssertFalse(store.isDownloaded(absent))
+    }
+
+    @MainActor
+    func testDownloadReportsProgressAndCompletes() async throws {
+        let model = WhisperCatalog.model(id: "tiny.en")!
+        let store = WhisperModelStore(
+            fileExists: { _ in false },
+            downloader: { _, _, progress in
+                progress(0.5)
+                progress(1.0)
+            }
+        )
+        try await store.download(model)
+        XCTAssertEqual(store.downloadProgress[model.id], 1.0)
+    }
+}

--- a/notchi/Tests/WhisperModelStoreTests.swift
+++ b/notchi/Tests/WhisperModelStoreTests.swift
@@ -54,4 +54,21 @@ final class WhisperModelStoreTests: XCTestCase {
         try await store.download(model)
         XCTAssertEqual(store.downloadProgress[model.id], 1.0)
     }
+
+    func testDefaultFileExistsRequiresNonZeroFileSize() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("whisper-store-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let nonexistent = tempDir.appendingPathComponent("missing.bin")
+        XCTAssertFalse(WhisperModelStore.defaultFileExists(at: nonexistent))
+
+        let empty = tempDir.appendingPathComponent("empty.bin")
+        FileManager.default.createFile(atPath: empty.path, contents: Data())
+        XCTAssertFalse(WhisperModelStore.defaultFileExists(at: empty))
+
+        let valid = tempDir.appendingPathComponent("valid.bin")
+        FileManager.default.createFile(atPath: valid.path, contents: Data([0x01, 0x02, 0x03]))
+        XCTAssertTrue(WhisperModelStore.defaultFileExists(at: valid))
+    }
 }

--- a/notchi/notchi.xcodeproj/project.pbxproj
+++ b/notchi/notchi.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		47C923A02F2CFA1F00EA1E18 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 47C923A12F2CFA1F00EA1E18 /* Sparkle */; };
+		B2F1A0110C3D4E5F60A17B01 /* whisper.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2F1A0100C3D4E5F60A17B00 /* whisper.xcframework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -22,6 +23,7 @@
 
 /* Begin PBXFileReference section */
 		47C922822F2CFA1F00EA1E18 /* notchi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = notchi.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B2F1A0100C3D4E5F60A17B00 /* whisper.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = whisper.xcframework; path = "../third_party/whisper.xcframework"; sourceTree = SOURCE_ROOT; };
 		A11A00022F50000000EA1E18 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -44,6 +46,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				47C923A02F2CFA1F00EA1E18 /* Sparkle in Frameworks */,
+				B2F1A0110C3D4E5F60A17B01 /* whisper.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,6 +66,7 @@
 				47C922842F2CFA1F00EA1E18 /* notchi */,
 				A11A00012F50000000EA1E18 /* Tests */,
 				47C922832F2CFA1F00EA1E18 /* Products */,
+				B2F1A0100C3D4E5F60A17B00 /* whisper.xcframework */,
 			);
 			sourceTree = "<group>";
 		};
@@ -354,6 +358,10 @@
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../third_party",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -364,6 +372,11 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.2.5;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					CoreML,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ruban.notchi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -390,6 +403,10 @@
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../third_party",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -400,6 +417,11 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.2.5;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					CoreML,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.ruban.notchi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/notchi/notchi/AppDelegate.swift
+++ b/notchi/notchi/AppDelegate.swift
@@ -42,6 +42,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
         ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
     }
 
+    private lazy var pushToTalkService = PushToTalkService(
+        onStart: { [weak self] in self?.beginDictation() },
+        onStop: { [weak self] in self?.endDictation() }
+    )
+    private var dictationMonitorRunning = false
+    private var observingDictationSetting = false
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppSettings.registerDefaults()
         guard !isRunningTests else { return }
@@ -49,12 +56,56 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
         NSApplication.shared.setActivationPolicy(.accessory)
         setupNotchWindow()
         globalShortcutService.start()
+        syncDictationMonitor()
+        observeDictationSettingChanges()
         installMinimizeShortcutGuard()
         observeScreenChanges()
         observePanelExpansionChanges()
         observeWakeNotifications()
         startProviderServices()
         startUpdater()
+    }
+
+    // WHY: the push-to-talk monitor must start/stop when the user toggles Voice
+    // Dictation at runtime, not only at launch — otherwise enabling it does
+    // nothing until the next relaunch.
+    private func syncDictationMonitor() {
+        let enabled = AppSettings.dictationEnabled
+        if enabled, !dictationMonitorRunning {
+            pushToTalkService.start()
+            dictationMonitorRunning = true
+        } else if !enabled, dictationMonitorRunning {
+            pushToTalkService.stop()
+            dictationMonitorRunning = false
+        }
+    }
+
+    // WHY: KVO on the single key fires only when Voice Dictation is toggled —
+    // unlike UserDefaults.didChangeNotification, which wakes us on every
+    // app-wide defaults write. The callback arrives on the setting thread, so
+    // hop to main before touching the monitor.
+    private func observeDictationSettingChanges() {
+        UserDefaults.standard.addObserver(self, forKeyPath: AppSettings.dictationEnabledRawKey, options: [], context: nil)
+        observingDictationSetting = true
+    }
+
+    override nonisolated func observeValue(
+        forKeyPath keyPath: String?,
+        of object: Any?,
+        change: [NSKeyValueChangeKey: Any]?,
+        context: UnsafeMutableRawPointer?
+    ) {
+        guard keyPath == AppSettings.dictationEnabledRawKey else { return }
+        Task { @MainActor in self.syncDictationMonitor() }
+    }
+
+    @MainActor private func beginDictation() {
+        NotchPanelManager.shared.expandForDictation()
+        SpeechToTextService.shared.startRecording()
+    }
+
+    @MainActor private func endDictation() {
+        Task { await SpeechToTextService.shared.finishRecording() }
     }
 
     // WHY: launch preparation and hook installation can run shell probes with
@@ -82,6 +133,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
     func applicationWillTerminate(_ notification: Notification) {
         removeMinimizeShortcutGuard()
         globalShortcutService.stop()
+        pushToTalkService.stop()
+        dictationMonitorRunning = false
+        if observingDictationSetting {
+            UserDefaults.standard.removeObserver(self, forKeyPath: AppSettings.dictationEnabledRawKey)
+            observingDictationSetting = false
+        }
         integrationCoordinator.stop()
         ClaudeUsageService.shared.stopPolling()
     }

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -196,6 +196,11 @@ struct AppSettings {
     static let expandedPanelScaleKey = "expandedPanelScale"
     static let mainUsageBarPeriodKey = "mainUsageBarPeriod"
 
+    static let dictationEnabledRawKey = "dictationEnabled"
+    private static let dictationPushToTalkShortcutKey = "dictationPushToTalkShortcut"
+    private static let dictationModelIdKey = "dictationModelId"
+    private static let dictationLanguageKey = "dictationLanguage"
+
     private static let notificationSoundKey = "notificationSound"
     private static let notificationSoundSelectionKey = "notificationSoundSelection"
     private static let customNotificationSoundsKey = "customNotificationSounds"
@@ -334,6 +339,32 @@ struct AppSettings {
         set {
             UserDefaults.standard.set(newValue.rawValue, forKey: panelToggleShortcutKey)
         }
+    }
+
+    static var dictationEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: dictationEnabledRawKey) }
+        set { UserDefaults.standard.set(newValue, forKey: dictationEnabledRawKey) }
+    }
+
+    static var dictationPushToTalkShortcut: GlobalShortcut {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: dictationPushToTalkShortcutKey),
+                  let shortcut = GlobalShortcut(rawValue: raw) else {
+                return .defaultDictationPushToTalk
+            }
+            return shortcut
+        }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: dictationPushToTalkShortcutKey) }
+    }
+
+    static var dictationModelId: String {
+        get { UserDefaults.standard.string(forKey: dictationModelIdKey) ?? "base.en" }
+        set { UserDefaults.standard.set(newValue, forKey: dictationModelIdKey) }
+    }
+
+    static var dictationLanguage: String {
+        get { UserDefaults.standard.string(forKey: dictationLanguageKey) ?? "en" }
+        set { UserDefaults.standard.set(newValue, forKey: dictationLanguageKey) }
     }
 
     static var lastUsedAgentProvider: AgentProvider {

--- a/notchi/notchi/Core/GlobalShortcut.swift
+++ b/notchi/notchi/Core/GlobalShortcut.swift
@@ -11,6 +11,11 @@ nonisolated struct GlobalShortcut: Equatable, Sendable {
         modifiers: UInt32(cmdKey | optionKey)
     )
 
+    static let defaultDictationPushToTalk = GlobalShortcut(
+        keyCode: UInt32(kVK_ANSI_D),
+        modifiers: UInt32(cmdKey | optionKey | shiftKey)
+    )
+
     init(keyCode: UInt32, modifiers: UInt32) {
         self.keyCode = keyCode
         self.modifiers = modifiers

--- a/notchi/notchi/Models/DictationState.swift
+++ b/notchi/notchi/Models/DictationState.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+nonisolated enum DictationError: Equatable, Sendable {
+    case microphoneDenied
+    case accessibilityDenied
+    case modelMissing
+    case noActiveSession
+    case sessionNotInjectable
+    case transcriptionFailed
+}
+
+nonisolated enum DictationPhase: Equatable, Sendable {
+    case idle
+    case recording
+    case transcribing
+    case review(String)
+    case sending
+    case error(DictationError)
+}
+
+nonisolated enum InjectionResult: Equatable, Sendable {
+    case sent
+    case notInjectable
+    case noSession
+    case needsAccessibility
+    case failed
+}

--- a/notchi/notchi/Models/WhisperModel.swift
+++ b/notchi/notchi/Models/WhisperModel.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+nonisolated struct WhisperModel: Identifiable, Equatable, Sendable {
+    let id: String
+    let displayName: String
+    let fileName: String
+    let isMultilingual: Bool
+    let approxMB: Int
+}
+
+nonisolated enum WhisperCatalog {
+    // ggml weights hosted at huggingface.co/ggml-org/whisper.cpp
+    static let models: [WhisperModel] = [
+        WhisperModel(id: "tiny.en", displayName: "Tiny (English)", fileName: "ggml-tiny.en.bin", isMultilingual: false, approxMB: 75),
+        WhisperModel(id: "base.en", displayName: "Base (English)", fileName: "ggml-base.en.bin", isMultilingual: false, approxMB: 142),
+        WhisperModel(id: "small", displayName: "Small (Multilingual)", fileName: "ggml-small.bin", isMultilingual: true, approxMB: 466),
+        WhisperModel(id: "large-v3-turbo", displayName: "Turbo (Multilingual)", fileName: "ggml-large-v3-turbo.bin", isMultilingual: true, approxMB: 1560),
+    ]
+
+    static func model(id: String) -> WhisperModel? {
+        models.first { $0.id == id }
+    }
+}

--- a/notchi/notchi/Resources/notchi-hook.sh
+++ b/notchi/notchi/Resources/notchi-hook.sh
@@ -108,10 +108,12 @@ def claude_process_id():
 
     return None
 
-if hook_event in ('SessionStart', 'UserPromptSubmit'):
-    process_id = claude_process_id()
-    if process_id:
-        output['claude_process_id'] = process_id
+# Emit the Claude process id on every event so the app can always resolve the
+# session's terminal tab (dictation injection needs a fresh pid, not just one
+# captured at session start).
+process_id = claude_process_id()
+if process_id:
+    output['claude_process_id'] = process_id
 
 # Pass user prompt directly for UserPromptSubmit
 if hook_event == 'UserPromptSubmit':

--- a/notchi/notchi/Services/NotchPanelManager.swift
+++ b/notchi/notchi/Services/NotchPanelManager.swift
@@ -207,6 +207,8 @@ final class NotchPanelManager {
         notificationCenter.post(name: .notchiPanelExpansionDidChange, object: self)
     }
 
+    func expandForDictation() { expand() }
+
     func collapse() {
         guard isExpanded else { return }
         cancelPendingHoverExitTask()

--- a/notchi/notchi/Services/NotchPanelManager.swift
+++ b/notchi/notchi/Services/NotchPanelManager.swift
@@ -207,7 +207,23 @@ final class NotchPanelManager {
         notificationCenter.post(name: .notchiPanelExpansionDidChange, object: self)
     }
 
-    func expandForDictation() { expand() }
+    private(set) var wasExpandedBeforeDictation = false
+
+    func expandForDictation() {
+        if !isExpanded {
+            wasExpandedBeforeDictation = false
+            expand()
+        } else {
+            wasExpandedBeforeDictation = true
+        }
+    }
+
+    func collapseAfterDictation() {
+        if !wasExpandedBeforeDictation {
+            collapse()
+        }
+        wasExpandedBeforeDictation = false
+    }
 
     func collapse() {
         guard isExpanded else { return }

--- a/notchi/notchi/Services/PromptInjectionService.swift
+++ b/notchi/notchi/Services/PromptInjectionService.swift
@@ -6,34 +6,28 @@ import os.log
 
 nonisolated private let logger = Logger(subsystem: "com.ruban.notchi", category: "PromptInjection")
 
-nonisolated protocol Pasteboarding {
-    func string() -> String?
-    func setString(_ value: String)
-}
-
 nonisolated protocol KeyEventPosting {
-    func postPasteAndReturn(toPID pid: pid_t)
+    /// Types `text` then Return into the app owning `pid` — via synthesized
+    /// Unicode key events, so the clipboard is never touched.
+    func postTextAndReturn(_ text: String, toPID pid: pid_t)
 }
 
 @MainActor
 struct PromptInjectionService {
     static let shared = PromptInjectionService()
 
-    private let pasteboard: Pasteboarding
     private let poster: KeyEventPosting
     // Background injection into the session's exact tab (Terminal.app/iTerm2):
     // true = delivered, false = scriptable but failed, nil = not scriptable.
     private let scriptInject: @MainActor (String, SessionData) async -> Bool?
-    // Fallback target pid for the CGEvent paste path (non-scriptable terminals).
+    // Fallback target pid for the direct-keystroke path (non-scriptable terminals).
     private let resolveTerminalPID: @MainActor (SessionData) -> pid_t?
     // Whether a pid belongs to a known terminal app — gates the frontmost-app
-    // fallback so ⌘V+Return is never posted into an unrelated app.
+    // fallback so keystrokes are never posted into an unrelated app.
     private let isTerminalPID: @MainActor (pid_t) -> Bool
     private let accessibilityTrusted: @Sendable () -> Bool
-    private let restoreDelay: TimeInterval
 
     init(
-        pasteboard: Pasteboarding = NSPasteboardAdapter(),
         poster: KeyEventPosting = CGEventKeyPoster(),
         scriptInject: @escaping @MainActor (String, SessionData) async -> Bool? = { await TerminalJumpService.shared.injectViaScript($0, into: $1) },
         resolveTerminalPID: @escaping @MainActor (SessionData) -> pid_t? = { TerminalJumpService.shared.terminalProcessId(for: $0) },
@@ -41,16 +35,13 @@ struct PromptInjectionService {
             guard let bundleId = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier else { return false }
             return TerminalFocusDetector.terminalBundleIds.contains(bundleId)
         },
-        accessibilityTrusted: @escaping @Sendable () -> Bool = { AXIsProcessTrusted() },
-        restoreDelay: TimeInterval = 0.6
+        accessibilityTrusted: @escaping @Sendable () -> Bool = { AXIsProcessTrusted() }
     ) {
-        self.pasteboard = pasteboard
         self.poster = poster
         self.scriptInject = scriptInject
         self.resolveTerminalPID = resolveTerminalPID
         self.isTerminalPID = isTerminalPID
         self.accessibilityTrusted = accessibilityTrusted
-        self.restoreDelay = restoreDelay
     }
 
     // Not `nonisolated`: `codexOrigin` is a mutable, MainActor-isolated property
@@ -75,8 +66,8 @@ struct PromptInjectionService {
         guard let text = Self.preparedPrompt(raw) else { return .failed }
 
         // Preferred path: write straight into the session's own tab in the
-        // BACKGROUND (Terminal.app / iTerm2) — no focus change, no clipboard, no
-        // Accessibility. The user can stay in another app while it runs.
+        // BACKGROUND (Terminal.app / iTerm2) — no focus change, no Accessibility.
+        // The user can stay in another app while it runs.
         if let delivered = await scriptInject(text, session) {
             if delivered {
                 logger.info("inject: delivered to \(session.provider.rawValue, privacy: .public) session tab via script")
@@ -86,15 +77,16 @@ struct PromptInjectionService {
             return .failed
         }
 
-        // Fallback (non-scriptable terminals, e.g. VSCode/Warp): synthesize
-        // ⌘V+Return to the terminal's focused tab. Needs Accessibility and is NOT
+        // Fallback (non-scriptable terminals, e.g. VSCode/Warp): type the text +
+        // Return into the terminal's focused tab. Needs Accessibility and is NOT
         // background — it lands wherever that terminal is focused.
         guard accessibilityTrusted() else {
-            logger.error("inject: accessibility not trusted; cannot post paste events")
+            logger.error("inject: accessibility not trusted; cannot post key events")
             return .needsAccessibility
         }
+
         // Prefer the session's own terminal; only fall back to the frontmost app
-        // if it's actually a terminal — otherwise ⌘V+Return would land in an
+        // if it's actually a terminal — otherwise the keystrokes would land in an
         // unrelated app (e.g. the browser the user dictated from).
         let targetPID: pid_t?
         if let resolved = resolveTerminalPID(session) {
@@ -109,43 +101,9 @@ struct PromptInjectionService {
             return .failed
         }
 
-        let saved = pasteboard.string()
-        pasteboard.setString(text)
-        poster.postPasteAndReturn(toPID: targetPID)
-        restorePasteboard(saved: saved, injected: text)
-        logger.info("inject: posted paste to pid \(targetPID, privacy: .public) for \(session.provider.rawValue, privacy: .public) session (fallback)")
+        poster.postTextAndReturn(text, toPID: targetPID)
+        logger.info("inject: typed text to pid \(targetPID, privacy: .public) for \(session.provider.rawValue, privacy: .public) session (fallback)")
         return .sent
-    }
-
-    private func restorePasteboard(saved: String?, injected: String) {
-        // Restore to whatever was there before — including empty, so the dictated
-        // text isn't left lingering on the clipboard when it started out empty.
-        let restored = saved ?? ""
-        // Only restore if OUR injected text is still on the clipboard; the user
-        // may have copied something new during the delay — don't clobber it.
-        let restoreIfUnchanged: @MainActor (Pasteboarding) -> Void = { board in
-            if board.string() == injected { board.setString(restored) }
-        }
-        if restoreDelay <= 0 {
-            restoreIfUnchanged(pasteboard)
-        } else {
-            // WHY: restore only after the target has surely consumed the paste;
-            // reverting too soon would clobber the pasteboard before ⌘V is read.
-            let delay = restoreDelay, board = pasteboard
-            Task { @MainActor in
-                try? await Task.sleep(for: .seconds(delay))
-                restoreIfUnchanged(board)
-            }
-        }
-    }
-}
-
-struct NSPasteboardAdapter: Pasteboarding {
-    nonisolated init() {}
-    nonisolated func string() -> String? { NSPasteboard.general.string(forType: .string) }
-    nonisolated func setString(_ value: String) {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(value, forType: .string)
     }
 }
 
@@ -153,18 +111,29 @@ struct NSPasteboardAdapter: Pasteboarding {
 struct CGEventKeyPoster: KeyEventPosting {
     nonisolated init() {}
 
-    nonisolated func postPasteAndReturn(toPID pid: pid_t) {
+    nonisolated func postTextAndReturn(_ text: String, toPID pid: pid_t) {
         let source = CGEventSource(stateID: .combinedSessionState)
-        postKey(CGKeyCode(kVK_ANSI_V), flags: .maskCommand, source: source, pid: pid)
-        postKey(CGKeyCode(kVK_Return), flags: [], source: source, pid: pid)
+        // WHY: type the prompt as Unicode key events instead of a ⌘V paste, so we
+        // never overwrite the user's clipboard (string OR rich data).
+        typeUnicode(text, source: source, pid: pid)
+        postKey(CGKeyCode(kVK_Return), source: source, pid: pid)
     }
 
-    nonisolated private func postKey(_ key: CGKeyCode, flags: CGEventFlags, source: CGEventSource?, pid: pid_t) {
-        let down = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: true)
-        down?.flags = flags
-        down?.postToPid(pid)
-        let up = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: false)
-        up?.flags = flags
-        up?.postToPid(pid)
+    nonisolated private func typeUnicode(_ text: String, source: CGEventSource?, pid: pid_t) {
+        let chars = Array(text.utf16)
+        guard !chars.isEmpty,
+              let down = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
+              let up = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) else { return }
+        chars.withUnsafeBufferPointer { buffer in
+            down.keyboardSetUnicodeString(stringLength: buffer.count, unicodeString: buffer.baseAddress)
+            up.keyboardSetUnicodeString(stringLength: buffer.count, unicodeString: buffer.baseAddress)
+        }
+        down.postToPid(pid)
+        up.postToPid(pid)
+    }
+
+    nonisolated private func postKey(_ key: CGKeyCode, source: CGEventSource?, pid: pid_t) {
+        CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: true)?.postToPid(pid)
+        CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: false)?.postToPid(pid)
     }
 }

--- a/notchi/notchi/Services/PromptInjectionService.swift
+++ b/notchi/notchi/Services/PromptInjectionService.swift
@@ -1,0 +1,170 @@
+import AppKit
+import ApplicationServices
+import CoreGraphics
+import Carbon.HIToolbox
+import os.log
+
+nonisolated private let logger = Logger(subsystem: "com.ruban.notchi", category: "PromptInjection")
+
+nonisolated protocol Pasteboarding {
+    func string() -> String?
+    func setString(_ value: String)
+}
+
+nonisolated protocol KeyEventPosting {
+    func postPasteAndReturn(toPID pid: pid_t)
+}
+
+@MainActor
+struct PromptInjectionService {
+    static let shared = PromptInjectionService()
+
+    private let pasteboard: Pasteboarding
+    private let poster: KeyEventPosting
+    // Background injection into the session's exact tab (Terminal.app/iTerm2):
+    // true = delivered, false = scriptable but failed, nil = not scriptable.
+    private let scriptInject: @MainActor (String, SessionData) async -> Bool?
+    // Fallback target pid for the CGEvent paste path (non-scriptable terminals).
+    private let resolveTerminalPID: @MainActor (SessionData) -> pid_t?
+    // Whether a pid belongs to a known terminal app — gates the frontmost-app
+    // fallback so ⌘V+Return is never posted into an unrelated app.
+    private let isTerminalPID: @MainActor (pid_t) -> Bool
+    private let accessibilityTrusted: @Sendable () -> Bool
+    private let restoreDelay: TimeInterval
+
+    init(
+        pasteboard: Pasteboarding = NSPasteboardAdapter(),
+        poster: KeyEventPosting = CGEventKeyPoster(),
+        scriptInject: @escaping @MainActor (String, SessionData) async -> Bool? = { await TerminalJumpService.shared.injectViaScript($0, into: $1) },
+        resolveTerminalPID: @escaping @MainActor (SessionData) -> pid_t? = { TerminalJumpService.shared.terminalProcessId(for: $0) },
+        isTerminalPID: @escaping @MainActor (pid_t) -> Bool = { pid in
+            guard let bundleId = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier else { return false }
+            return TerminalFocusDetector.terminalBundleIds.contains(bundleId)
+        },
+        accessibilityTrusted: @escaping @Sendable () -> Bool = { AXIsProcessTrusted() },
+        restoreDelay: TimeInterval = 0.6
+    ) {
+        self.pasteboard = pasteboard
+        self.poster = poster
+        self.scriptInject = scriptInject
+        self.resolveTerminalPID = resolveTerminalPID
+        self.isTerminalPID = isTerminalPID
+        self.accessibilityTrusted = accessibilityTrusted
+        self.restoreDelay = restoreDelay
+    }
+
+    // Not `nonisolated`: `codexOrigin` is a mutable, MainActor-isolated property
+    // of `SessionData` (a `@MainActor` class), so reading it requires MainActor
+    // context. This is still a pure function — no side effects, no external state
+    // beyond the passed-in session — just isolated to the actor its argument lives on.
+    static func canInject(into session: SessionData) -> Bool {
+        !(session.provider == .codex && session.codexOrigin == .desktop)
+    }
+
+    nonisolated static func preparedPrompt(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    func inject(_ raw: String, into session: SessionData?, fallbackAppPID: pid_t? = nil) async -> InjectionResult {
+        guard let session else { logger.info("inject: no target session"); return .noSession }
+        guard Self.canInject(into: session) else {
+            logger.info("inject: session not injectable (codex desktop)")
+            return .notInjectable
+        }
+        guard let text = Self.preparedPrompt(raw) else { return .failed }
+
+        // Preferred path: write straight into the session's own tab in the
+        // BACKGROUND (Terminal.app / iTerm2) — no focus change, no clipboard, no
+        // Accessibility. The user can stay in another app while it runs.
+        if let delivered = await scriptInject(text, session) {
+            if delivered {
+                logger.info("inject: delivered to \(session.provider.rawValue, privacy: .public) session tab via script")
+                return .sent
+            }
+            logger.error("inject: script delivery failed for \(session.provider.rawValue, privacy: .public) session (tab gone or Automation denied)")
+            return .failed
+        }
+
+        // Fallback (non-scriptable terminals, e.g. VSCode/Warp): synthesize
+        // ⌘V+Return to the terminal's focused tab. Needs Accessibility and is NOT
+        // background — it lands wherever that terminal is focused.
+        guard accessibilityTrusted() else {
+            logger.error("inject: accessibility not trusted; cannot post paste events")
+            return .needsAccessibility
+        }
+        // Prefer the session's own terminal; only fall back to the frontmost app
+        // if it's actually a terminal — otherwise ⌘V+Return would land in an
+        // unrelated app (e.g. the browser the user dictated from).
+        let targetPID: pid_t?
+        if let resolved = resolveTerminalPID(session) {
+            targetPID = resolved
+        } else if let fallbackAppPID, isTerminalPID(fallbackAppPID) {
+            targetPID = fallbackAppPID
+        } else {
+            targetPID = nil
+        }
+        guard let targetPID else {
+            logger.error("inject: no terminal target for \(session.provider.rawValue, privacy: .public) session (claudePid=\(session.claudeProcessId ?? -1, privacy: .public), fallbackPID=\(fallbackAppPID ?? -1, privacy: .public))")
+            return .failed
+        }
+
+        let saved = pasteboard.string()
+        pasteboard.setString(text)
+        poster.postPasteAndReturn(toPID: targetPID)
+        restorePasteboard(saved: saved, injected: text)
+        logger.info("inject: posted paste to pid \(targetPID, privacy: .public) for \(session.provider.rawValue, privacy: .public) session (fallback)")
+        return .sent
+    }
+
+    private func restorePasteboard(saved: String?, injected: String) {
+        // Restore to whatever was there before — including empty, so the dictated
+        // text isn't left lingering on the clipboard when it started out empty.
+        let restored = saved ?? ""
+        // Only restore if OUR injected text is still on the clipboard; the user
+        // may have copied something new during the delay — don't clobber it.
+        let restoreIfUnchanged: @MainActor (Pasteboarding) -> Void = { board in
+            if board.string() == injected { board.setString(restored) }
+        }
+        if restoreDelay <= 0 {
+            restoreIfUnchanged(pasteboard)
+        } else {
+            // WHY: restore only after the target has surely consumed the paste;
+            // reverting too soon would clobber the pasteboard before ⌘V is read.
+            let delay = restoreDelay, board = pasteboard
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(delay))
+                restoreIfUnchanged(board)
+            }
+        }
+    }
+}
+
+struct NSPasteboardAdapter: Pasteboarding {
+    nonisolated init() {}
+    nonisolated func string() -> String? { NSPasteboard.general.string(forType: .string) }
+    nonisolated func setString(_ value: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
+    }
+}
+
+// Not unit-tested: posts real system key events (needs Accessibility).
+struct CGEventKeyPoster: KeyEventPosting {
+    nonisolated init() {}
+
+    nonisolated func postPasteAndReturn(toPID pid: pid_t) {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        postKey(CGKeyCode(kVK_ANSI_V), flags: .maskCommand, source: source, pid: pid)
+        postKey(CGKeyCode(kVK_Return), flags: [], source: source, pid: pid)
+    }
+
+    nonisolated private func postKey(_ key: CGKeyCode, flags: CGEventFlags, source: CGEventSource?, pid: pid_t) {
+        let down = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: true)
+        down?.flags = flags
+        down?.postToPid(pid)
+        let up = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: false)
+        up?.flags = flags
+        up?.postToPid(pid)
+    }
+}

--- a/notchi/notchi/Services/PromptInjectionService.swift
+++ b/notchi/notchi/Services/PromptInjectionService.swift
@@ -7,9 +7,9 @@ import os.log
 nonisolated private let logger = Logger(subsystem: "com.ruban.notchi", category: "PromptInjection")
 
 nonisolated protocol KeyEventPosting {
-    /// Types `text` then Return into the app owning `pid` — via synthesized
-    /// Unicode key events, so the clipboard is never touched.
-    func postTextAndReturn(_ text: String, toPID pid: pid_t)
+    /// Types `text` into the app owning `pid` via synthesized Unicode key events.
+    /// If `withReturn` is true, posts a Return key event immediately after typing.
+    func postText(_ text: String, toPID pid: pid_t, withReturn: Bool)
 }
 
 @MainActor
@@ -26,6 +26,7 @@ struct PromptInjectionService {
     // fallback so keystrokes are never posted into an unrelated app.
     private let isTerminalPID: @MainActor (pid_t) -> Bool
     private let accessibilityTrusted: @Sendable () -> Bool
+    private let activateProcess: @MainActor (pid_t) -> Bool
 
     init(
         poster: KeyEventPosting = CGEventKeyPoster(),
@@ -35,13 +36,15 @@ struct PromptInjectionService {
             guard let bundleId = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier else { return false }
             return TerminalFocusDetector.terminalBundleIds.contains(bundleId)
         },
-        accessibilityTrusted: @escaping @Sendable () -> Bool = { AXIsProcessTrusted() }
+        accessibilityTrusted: @escaping @Sendable () -> Bool = { AXIsProcessTrusted() },
+        activateProcess: @escaping @MainActor (pid_t) -> Bool = { NSRunningApplication(processIdentifier: $0)?.activate() ?? false }
     ) {
         self.poster = poster
         self.scriptInject = scriptInject
         self.resolveTerminalPID = resolveTerminalPID
         self.isTerminalPID = isTerminalPID
         self.accessibilityTrusted = accessibilityTrusted
+        self.activateProcess = activateProcess
     }
 
     // Not `nonisolated`: `codexOrigin` is a mutable, MainActor-isolated property
@@ -77,9 +80,10 @@ struct PromptInjectionService {
             return .failed
         }
 
-        // Fallback (non-scriptable terminals, e.g. VSCode/Warp): type the text +
-        // Return into the terminal's focused tab. Needs Accessibility and is NOT
-        // background — it lands wherever that terminal is focused.
+        // Fallback (non-scriptable terminals, e.g. VSCode/Warp): type the text into
+        // the terminal. Needs Accessibility and is NOT background — it requires
+        // the target terminal to be activated so keystrokes are not sent to an
+        // arbitrary background window.
         guard accessibilityTrusted() else {
             logger.error("inject: accessibility not trusted; cannot post key events")
             return .needsAccessibility
@@ -101,8 +105,18 @@ struct PromptInjectionService {
             return .failed
         }
 
-        poster.postTextAndReturn(text, toPID: targetPID)
-        logger.info("inject: typed text to pid \(targetPID, privacy: .public) for \(session.provider.rawValue, privacy: .public) session (fallback)")
+        // Activate the target terminal so the user sees the receiving window
+        // and keystrokes are received by the active focus rather than lost or
+        // misdirected to a background process.
+        _ = activateProcess(targetPID)
+
+        // If dictation started from this exact terminal app (i.e. frontmost when
+        // hotkey held), the user was already in this context: send Return to submit.
+        // Otherwise, the terminal was in the background: type the text WITHOUT
+        // Return so the user can verify the target tab/pane before executing.
+        let isInitiatedFromTarget = (fallbackAppPID == targetPID)
+        poster.postText(text, toPID: targetPID, withReturn: isInitiatedFromTarget)
+        logger.info("inject: typed text to pid \(targetPID, privacy: .public) for \(session.provider.rawValue, privacy: .public) session (fallback, withReturn=\(isInitiatedFromTarget, privacy: .public))")
         return .sent
     }
 }
@@ -111,12 +125,14 @@ struct PromptInjectionService {
 struct CGEventKeyPoster: KeyEventPosting {
     nonisolated init() {}
 
-    nonisolated func postTextAndReturn(_ text: String, toPID pid: pid_t) {
+    nonisolated func postText(_ text: String, toPID pid: pid_t, withReturn: Bool) {
         let source = CGEventSource(stateID: .combinedSessionState)
         // WHY: type the prompt as Unicode key events instead of a ⌘V paste, so we
         // never overwrite the user's clipboard (string OR rich data).
         typeUnicode(text, source: source, pid: pid)
-        postKey(CGKeyCode(kVK_Return), source: source, pid: pid)
+        if withReturn {
+            postKey(CGKeyCode(kVK_Return), source: source, pid: pid)
+        }
     }
 
     nonisolated private func typeUnicode(_ text: String, source: CGEventSource?, pid: pid_t) {

--- a/notchi/notchi/Services/Speech/AudioCaptureEngine.swift
+++ b/notchi/notchi/Services/Speech/AudioCaptureEngine.swift
@@ -28,6 +28,9 @@ final class AudioCaptureEngine: AudioCapturing, @unchecked Sendable {
 
         let input = engine.inputNode
         let inputFormat = input.outputFormat(forBus: 0)
+        guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
+            throw AudioCaptureError.converterUnavailable
+        }
         guard let targetFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
             sampleRate: Self.targetSampleRate,
@@ -37,8 +40,10 @@ final class AudioCaptureEngine: AudioCapturing, @unchecked Sendable {
             throw AudioCaptureError.converterUnavailable
         }
 
+        // Defensively remove any dangling tap before installing a new one.
+        input.removeTap(onBus: 0)
         input.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-            guard let self else { return }
+            guard let self, inputFormat.sampleRate > 0 else { return }
             let ratio = Self.targetSampleRate / inputFormat.sampleRate
             let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1
             guard let out = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: capacity) else { return }

--- a/notchi/notchi/Services/Speech/AudioCaptureEngine.swift
+++ b/notchi/notchi/Services/Speech/AudioCaptureEngine.swift
@@ -1,0 +1,81 @@
+import AVFoundation
+import os.log
+
+nonisolated private let logger = Logger(subsystem: "com.ruban.notchi", category: "AudioCaptureEngine")
+
+nonisolated protocol AudioCapturing: Sendable {
+    func start() throws
+    func stop() -> [Float]
+}
+
+nonisolated enum AudioCaptureError: Error { case engineStartFailed, converterUnavailable }
+
+// WHY: whisper.cpp expects 16 kHz mono Float32 PCM. The hardware input format
+// varies (often 44.1/48 kHz), so tap the input node and convert each buffer.
+final class AudioCaptureEngine: AudioCapturing, @unchecked Sendable {
+    private let engine = AVAudioEngine()
+    private let lock = NSLock()
+    private var samples: [Float] = []
+    // Set under `lock` in stop(); a tap callback still executing on the audio
+    // thread after removeTap checks this and skips appending, so it never writes
+    // into a buffer that a subsequent start() has reset. (The final in-flight
+    // buffer at key-release is inherently bounded — push-to-talk tail.)
+    private var stopped = false
+    private static let targetSampleRate = 16_000.0
+
+    func start() throws {
+        lock.lock(); samples.removeAll(); stopped = false; lock.unlock()
+
+        let input = engine.inputNode
+        let inputFormat = input.outputFormat(forBus: 0)
+        guard let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Self.targetSampleRate,
+            channels: 1,
+            interleaved: false
+        ), let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
+            throw AudioCaptureError.converterUnavailable
+        }
+
+        input.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
+            guard let self else { return }
+            let ratio = Self.targetSampleRate / inputFormat.sampleRate
+            let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1
+            guard let out = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: capacity) else { return }
+            var error: NSError?
+            var consumed = false
+            converter.convert(to: out, error: &error) { _, status in
+                if consumed { status.pointee = .noDataNow; return nil }
+                consumed = true
+                status.pointee = .haveData
+                return buffer
+            }
+            guard error == nil, let channel = out.floatChannelData?[0] else { return }
+            let frames = Int(out.frameLength)
+            self.lock.lock()
+            if !self.stopped {
+                self.samples.append(contentsOf: UnsafeBufferPointer(start: channel, count: frames))
+            }
+            self.lock.unlock()
+        }
+
+        engine.prepare()
+        do {
+            try engine.start()
+        } catch {
+            input.removeTap(onBus: 0)
+            logger.error("Audio engine start failed: \(error.localizedDescription, privacy: .public)")
+            throw AudioCaptureError.engineStartFailed
+        }
+    }
+
+    func stop() -> [Float] {
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        lock.lock(); defer { lock.unlock() }
+        stopped = true
+        let captured = samples
+        samples = []
+        return captured
+    }
+}

--- a/notchi/notchi/Services/Speech/PushToTalkService.swift
+++ b/notchi/notchi/Services/Speech/PushToTalkService.swift
@@ -1,0 +1,97 @@
+import AppKit
+import Carbon.HIToolbox
+
+@MainActor
+final class PushToTalkService {
+    struct HoldKeyEvent: Equatable {
+        enum Kind { case down, up }
+        let kind: Kind
+        let keyCode: UInt32
+        let modifiers: UInt32
+    }
+
+    private let shortcut: @MainActor () -> GlobalShortcut
+    private let onStart: @MainActor () -> Void
+    private let onStop: @MainActor () -> Void
+    private let eventSource: HoldKeyMonitoring
+    private var isHolding = false
+
+    init(
+        shortcut: @escaping @MainActor () -> GlobalShortcut = { AppSettings.dictationPushToTalkShortcut },
+        onStart: @escaping @MainActor () -> Void,
+        onStop: @escaping @MainActor () -> Void,
+        eventSource: HoldKeyMonitoring = NSEventHoldKeyMonitor()
+    ) {
+        self.shortcut = shortcut
+        self.onStart = onStart
+        self.onStop = onStop
+        self.eventSource = eventSource
+    }
+
+    func start() {
+        eventSource.begin { [weak self] event in
+            MainActor.assumeIsolated { self?.handle(event) }
+        }
+    }
+
+    func stop() {
+        eventSource.end()
+        isHolding = false
+    }
+
+    func handle(_ event: HoldKeyEvent) {
+        switch event.kind {
+        case .down:
+            guard Self.matches(event, shortcut: shortcut()), !isHolding else { return }
+            isHolding = true
+            onStart()
+        case .up:
+            guard isHolding, event.keyCode == shortcut().keyCode else { return }
+            isHolding = false
+            onStop()
+        }
+    }
+
+    nonisolated static func matches(_ event: HoldKeyEvent, shortcut: GlobalShortcut) -> Bool {
+        event.keyCode == shortcut.keyCode && event.modifiers == shortcut.modifiers
+    }
+}
+
+@MainActor
+protocol HoldKeyMonitoring: AnyObject {
+    func begin(_ handler: @escaping (PushToTalkService.HoldKeyEvent) -> Void)
+    func end()
+}
+
+// Not unit-tested: requires Accessibility and a live event stream.
+@MainActor
+final class NSEventHoldKeyMonitor: HoldKeyMonitoring {
+    private var globalMonitor: Any?
+    private var localMonitor: Any?
+
+    // Explicit nonisolated init so this type can be constructed as a default
+    // argument value (default-argument expressions evaluate in a nonisolated
+    // context even for a @MainActor initializer's parameter list).
+    nonisolated init() {}
+
+    func begin(_ handler: @escaping (PushToTalkService.HoldKeyEvent) -> Void) {
+        let convert: (NSEvent) -> PushToTalkService.HoldKeyEvent = { event in
+            PushToTalkService.HoldKeyEvent(
+                kind: event.type == .keyDown ? .down : .up,
+                keyCode: UInt32(event.keyCode),
+                modifiers: GlobalShortcut.carbonModifiers(from: event.modifierFlags)
+            )
+        }
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.keyDown, .keyUp]) { handler(convert($0)) }
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .keyUp]) { event in
+            handler(convert(event)); return event
+        }
+    }
+
+    func end() {
+        [globalMonitor, localMonitor].forEach { monitor in
+            if let monitor { NSEvent.removeMonitor(monitor) }
+        }
+        globalMonitor = nil; localMonitor = nil
+    }
+}

--- a/notchi/notchi/Services/Speech/SpeechToTextService.swift
+++ b/notchi/notchi/Services/Speech/SpeechToTextService.swift
@@ -1,0 +1,155 @@
+import AppKit
+import AVFoundation
+import Foundation
+import Observation
+
+struct SpeechToTextServiceDependencies {
+    var makeCapture: @Sendable () -> AudioCapturing
+    var makeTranscriber: @Sendable (URL) -> Transcribing
+    var isModelDownloaded: @MainActor () -> Bool
+    var modelURL: @MainActor () -> URL
+    var language: @MainActor () -> String
+    var microphoneAuthorized: @Sendable () -> Bool
+    var frontmostAppPID: @MainActor () -> pid_t? = { nil }
+
+    static let live = SpeechToTextServiceDependencies(
+        makeCapture: { AudioCaptureEngine() },
+        makeTranscriber: { WhisperTranscriber(modelURL: $0) },
+        isModelDownloaded: {
+            guard let model = WhisperCatalog.model(id: AppSettings.dictationModelId) else { return false }
+            return WhisperModelStore.shared.isDownloaded(model)
+        },
+        modelURL: {
+            let model = WhisperCatalog.model(id: AppSettings.dictationModelId) ?? WhisperCatalog.models[1]
+            return WhisperModelStore.fileURL(for: model)
+        },
+        language: { AppSettings.dictationLanguage },
+        microphoneAuthorized: {
+            AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+        },
+        // The app the user was in when they held the push-to-talk key — the
+        // terminal to paste back into if session-based resolution can't find it.
+        frontmostAppPID: { NSWorkspace.shared.frontmostApplication?.processIdentifier }
+    )
+}
+
+@MainActor
+@Observable
+final class SpeechToTextService {
+    static let shared = SpeechToTextService(dependencies: .live)
+
+    private(set) var phase: DictationPhase = .idle
+    var transcript: String = ""
+    /// PID of the app frontmost when recording started (paste-back fallback).
+    private(set) var originAppPID: pid_t?
+
+    private let dependencies: SpeechToTextServiceDependencies
+    private var capture: AudioCapturing?
+    // Text already in the box when a new recording starts, so re-dictation
+    // appends to the existing transcript instead of replacing it.
+    private var carriedTranscript: String = ""
+    // Reused across dictations so the (multi-hundred-MB) model file is loaded
+    // once, not reloaded from disk on every finishRecording(). Rebuilt only when
+    // the selected model URL changes.
+    private var transcriber: Transcribing?
+    private var transcriberURL: URL?
+
+    init(dependencies: SpeechToTextServiceDependencies) {
+        self.dependencies = dependencies
+    }
+
+    func startRecording() {
+        // WHY: AVAudioEngine crashes if start() is called again without an
+        // intervening stop(); guard against re-entrant taps on the notch shortcut.
+        guard phase != .recording, phase != .transcribing else { return }
+        guard dependencies.microphoneAuthorized() else { phase = .error(.microphoneDenied); return }
+        guard dependencies.isModelDownloaded() else { phase = .error(.modelMissing); return }
+
+        // Carry any text already under review so this recording appends to it.
+        let carried: String
+        if case .review = phase { carried = transcript } else { carried = "" }
+
+        let capture = dependencies.makeCapture()
+        do {
+            try capture.start()
+        } catch {
+            phase = .error(.transcriptionFailed)
+            return
+        }
+        self.capture = capture
+        carriedTranscript = carried
+        originAppPID = dependencies.frontmostAppPID()
+        transcript = carried
+        phase = .recording
+    }
+
+    func finishRecording() async {
+        guard case .recording = phase, let capture else { return }
+        let samples = capture.stop()
+        self.capture = nil
+        phase = .transcribing
+
+        let url = dependencies.modelURL()
+        let transcriber: Transcribing
+        if let cached = self.transcriber, transcriberURL == url {
+            transcriber = cached
+        } else {
+            transcriber = dependencies.makeTranscriber(url)
+            self.transcriber = transcriber
+            transcriberURL = url
+        }
+        let language = dependencies.language()
+        do {
+            let newText = try await transcriber.transcribe(samples: samples, language: language)
+            // WHY: re-check phase — the user may have cancelled (reset → .idle) or
+            // started a new recording while transcription was in flight. Committing
+            // the result unconditionally would resurrect a dismissed dictation box.
+            guard case .transcribing = phase else { return }
+            let combined = Self.appended(carriedTranscript, newText)
+            guard !combined.isEmpty else { phase = .error(.transcriptionFailed); return }
+            transcript = combined
+            phase = .review(combined)
+        } catch {
+            guard case .transcribing = phase else { return }
+            phase = .error(.transcriptionFailed)
+        }
+    }
+
+    static func appended(_ existing: String, _ addition: String) -> String {
+        guard !existing.isEmpty else { return addition }
+        guard !addition.isEmpty else { return existing }
+        return existing + " " + addition
+    }
+
+    func reset() {
+        _ = capture?.stop()
+        capture = nil
+        carriedTranscript = ""
+        originAppPID = nil
+        transcript = ""
+        phase = .idle
+    }
+
+    @discardableResult
+    func send(
+        using injector: (String, SessionData?) async -> InjectionResult,
+        targetSession: SessionData?
+    ) async -> InjectionResult {
+        guard case .review = phase else { return .failed }
+        phase = .sending
+        let result = await injector(transcript, targetSession)
+        switch result {
+        case .sent:
+            reset()
+        case .noSession:
+            phase = .error(.noActiveSession)
+        case .notInjectable:
+            phase = .error(.sessionNotInjectable)
+        case .needsAccessibility:
+            phase = .error(.accessibilityDenied)
+        case .failed:
+            phase = .review(transcript)
+        }
+        return result
+    }
+}

--- a/notchi/notchi/Services/Speech/WhisperModelStore.swift
+++ b/notchi/notchi/Services/Speech/WhisperModelStore.swift
@@ -15,11 +15,18 @@ final class WhisperModelStore {
     private let downloader: @Sendable (URL, URL, @Sendable @escaping (Double) -> Void) async throws -> Void
 
     init(
-        fileExists: @escaping @Sendable (URL) -> Bool = { FileManager.default.fileExists(atPath: $0.path) },
+        fileExists: @escaping @Sendable (URL) -> Bool = WhisperModelStore.defaultFileExists,
         downloader: @escaping @Sendable (URL, URL, @Sendable @escaping (Double) -> Void) async throws -> Void = WhisperModelStore.liveDownloader
     ) {
         self.fileExists = fileExists
         self.downloader = downloader
+    }
+
+    nonisolated static func defaultFileExists(at url: URL) -> Bool {
+        let path = url.path
+        guard FileManager.default.fileExists(atPath: path) else { return false }
+        let size = (try? FileManager.default.attributesOfItem(atPath: path)[.size] as? Int64) ?? 0
+        return size > 0
     }
 
     nonisolated static func modelsDirectory() -> URL {
@@ -65,12 +72,55 @@ final class WhisperModelStore {
     }
 
     nonisolated static let liveDownloader: @Sendable (URL, URL, @Sendable @escaping (Double) -> Void) async throws -> Void = { remote, destination, progress in
-        let (tempURL, response) = try await URLSession.shared.download(from: remote)
-        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
-            throw URLError(.badServerResponse)
+        let delegate = DownloadProgressDelegate(progress: progress)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        defer { session.invalidateAndCancel() }
+        let tempURL: URL = try await withCheckedThrowingContinuation { continuation in
+            delegate.continuation = continuation
+            let task = session.downloadTask(with: remote)
+            task.resume()
         }
         progress(1.0)
         try? FileManager.default.removeItem(at: destination)
         try FileManager.default.moveItem(at: tempURL, to: destination)
+    }
+}
+
+private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+    let progress: @Sendable (Double) -> Void
+    var continuation: CheckedContinuation<URL, Error>?
+
+    init(progress: @escaping @Sendable (Double) -> Void) {
+        self.progress = progress
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        guard totalBytesExpectedToWrite > 0 else { return }
+        progress(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        if let http = downloadTask.response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            continuation?.resume(throwing: URLError(.badServerResponse))
+            return
+        }
+        let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        do {
+            try FileManager.default.moveItem(at: location, to: temp)
+            continuation?.resume(returning: temp)
+        } catch {
+            continuation?.resume(throwing: error)
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let error else { return }
+        continuation?.resume(throwing: error)
     }
 }

--- a/notchi/notchi/Services/Speech/WhisperModelStore.swift
+++ b/notchi/notchi/Services/Speech/WhisperModelStore.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Observation
+import os.log
+
+nonisolated private let logger = Logger(subsystem: "com.ruban.notchi", category: "WhisperModelStore")
+
+@MainActor
+@Observable
+final class WhisperModelStore {
+    static let shared = WhisperModelStore()
+
+    private(set) var downloadProgress: [String: Double] = [:]
+
+    private let fileExists: @Sendable (URL) -> Bool
+    private let downloader: @Sendable (URL, URL, @Sendable @escaping (Double) -> Void) async throws -> Void
+
+    init(
+        fileExists: @escaping @Sendable (URL) -> Bool = { FileManager.default.fileExists(atPath: $0.path) },
+        downloader: @escaping @Sendable (URL, URL, @Sendable @escaping (Double) -> Void) async throws -> Void = WhisperModelStore.liveDownloader
+    ) {
+        self.fileExists = fileExists
+        self.downloader = downloader
+    }
+
+    nonisolated static func modelsDirectory() -> URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Notchi", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+    }
+
+    nonisolated static func fileURL(for model: WhisperModel) -> URL {
+        modelsDirectory().appendingPathComponent(model.fileName)
+    }
+
+    nonisolated static func remoteURL(for model: WhisperModel) -> URL {
+        // The ggml Whisper weights are hosted on the ggerganov/whisper.cpp HF
+        // repo; ggml-org/whisper.cpp is the source-code mirror and 401s on
+        // resolve/, so downloads must target ggerganov.
+        URL(string: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/\(model.fileName)")!
+    }
+
+    func isDownloaded(_ model: WhisperModel) -> Bool {
+        fileExists(Self.fileURL(for: model))
+    }
+
+    func download(_ model: WhisperModel) async throws {
+        let destination = Self.fileURL(for: model)
+        let modelId = model.id
+        do {
+            try FileManager.default.createDirectory(at: Self.modelsDirectory(), withIntermediateDirectories: true)
+            downloadProgress[modelId] = 0
+            try await downloader(Self.remoteURL(for: model), destination) { fraction in
+                Task { @MainActor [weak self] in self?.downloadProgress[modelId] = fraction }
+            }
+            downloadProgress[modelId] = 1.0
+            logger.info("Downloaded model \(modelId, privacy: .public)")
+        } catch {
+            // WHY: clear progress so the settings row falls back to the Download
+            // affordance instead of showing a stuck spinner, and log so a failed
+            // fetch is never silently invisible.
+            downloadProgress[modelId] = nil
+            logger.error("Model download failed for \(modelId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+    }
+
+    nonisolated static let liveDownloader: @Sendable (URL, URL, @Sendable @escaping (Double) -> Void) async throws -> Void = { remote, destination, progress in
+        let (tempURL, response) = try await URLSession.shared.download(from: remote)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+        progress(1.0)
+        try? FileManager.default.removeItem(at: destination)
+        try FileManager.default.moveItem(at: tempURL, to: destination)
+    }
+}

--- a/notchi/notchi/Services/Speech/WhisperTranscriber.swift
+++ b/notchi/notchi/Services/Speech/WhisperTranscriber.swift
@@ -1,0 +1,79 @@
+import Foundation
+import os.log
+import whisper
+
+nonisolated private let logger = Logger(subsystem: "com.ruban.notchi", category: "WhisperTranscriber")
+
+nonisolated protocol Transcribing: Sendable {
+    func transcribe(samples: [Float], language: String) async throws -> String
+}
+
+nonisolated enum WhisperTranscriberError: Error { case modelLoadFailed, inferenceFailed }
+
+actor WhisperTranscriber: Transcribing {
+    private var context: OpaquePointer?
+    private let modelURL: URL
+
+    // whisper.cpp needs a minimum amount of audio; feeding a near-empty buffer
+    // segfaults inside whisper_encode_internal. Require ~0.25s at 16 kHz.
+    private static let minimumSampleCount = 4000
+
+    init(modelURL: URL) {
+        self.modelURL = modelURL
+    }
+
+    deinit {
+        if let context { whisper_free(context) }
+    }
+
+    private func loadedContext() throws -> OpaquePointer {
+        if let context { return context }
+        var params = whisper_context_default_params()
+        // WHY: the Metal/GPU encode path null-derefs (EXC_BAD_ACCESS in
+        // whisper_encode_internal) in this embedded static-xcframework build.
+        // CPU inference is reliable and near-real-time for base.en on Apple
+        // Silicon; revisit GPU once the Metal-context crash is understood.
+        params.use_gpu = false
+        let loaded = modelURL.path.withCString { whisper_init_from_file_with_params($0, params) }
+        guard let loaded else {
+            logger.error("whisper model load failed at \(self.modelURL.lastPathComponent, privacy: .public)")
+            throw WhisperTranscriberError.modelLoadFailed
+        }
+        context = loaded
+        return loaded
+    }
+
+    func transcribe(samples: [Float], language: String) async throws -> String {
+        guard samples.count >= Self.minimumSampleCount else {
+            logger.info("Skipping transcription: \(samples.count, privacy: .public) samples below minimum \(Self.minimumSampleCount, privacy: .public)")
+            return ""
+        }
+
+        let ctx = try loadedContext()
+        var params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY)
+        params.print_realtime = false
+        params.print_progress = false
+        params.print_timestamps = false
+        params.no_context = true
+        params.single_segment = false
+
+        let result: Int32 = language.withCString { langPtr in
+            params.language = (language == "auto") ? nil : langPtr
+            return samples.withUnsafeBufferPointer { buffer in
+                whisper_full(ctx, params, buffer.baseAddress, Int32(buffer.count))
+            }
+        }
+        guard result == 0 else {
+            logger.error("whisper_full failed with code \(result, privacy: .public)")
+            throw WhisperTranscriberError.inferenceFailed
+        }
+
+        var text = ""
+        for i in 0..<whisper_full_n_segments(ctx) {
+            if let segment = whisper_full_get_segment_text(ctx, i) {
+                text += String(cString: segment)
+            }
+        }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/notchi/notchi/Services/TerminalJumpService.swift
+++ b/notchi/notchi/Services/TerminalJumpService.swift
@@ -1,5 +1,8 @@
 import AppKit
 import Darwin
+import os.log
+
+nonisolated private let logger = Logger(subsystem: "com.ruban.notchi", category: "TerminalJump")
 
 @MainActor
 struct TerminalJumpService {
@@ -49,6 +52,121 @@ struct TerminalJumpService {
 
     func hostBundleIdentifier(hosting processId: pid_t) -> String? {
         terminalProcessID(hosting: processId).flatMap(bundleIdentifierForProcess)
+    }
+
+    // The pid of the terminal app hosting the session's CLI process — the
+    // target for direct key-event injection (CGEvent.postToPid).
+    func terminalProcessId(for session: SessionData) -> pid_t? {
+        guard let processId = Self.terminalBackedProcessId(for: session),
+              let terminalProcessId = terminalProcessID(hosting: processId) else {
+            return nil
+        }
+        return terminalProcessId
+    }
+
+    /// Injects `text` (as a submitted line) straight into the terminal tab hosting
+    /// `session`, in the BACKGROUND — no focus/activation — via AppleScript keyed
+    /// by the CLI process's controlling tty. Returns:
+    ///   • true  → delivered
+    ///   • false → scriptable terminal but delivery failed (tab gone / Automation denied)
+    ///   • nil   → terminal not scriptable or tty unknown; caller should fall back
+    func injectViaScript(_ text: String, into session: SessionData) async -> Bool? {
+        guard let cliPID = Self.terminalBackedProcessId(for: session),
+              let terminalPID = terminalProcessID(hosting: cliPID),
+              let bundleId = bundleIdentifierForProcess(terminalPID),
+              let tty = Self.controllingTTY(of: cliPID),
+              let script = Self.writeTextScript(bundleId: bundleId, tty: tty, text: text) else {
+            return nil
+        }
+        return await Self.runAppleScript(script)
+    }
+
+    private nonisolated static func controllingTTY(of pid: pid_t) -> String? {
+        var info = proc_bsdinfo()
+        let size = MemoryLayout<proc_bsdinfo>.size
+        let result = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, Int32(size))
+        guard result == Int32(size) else { return nil }
+        let dev = dev_t(bitPattern: info.e_tdev)
+        guard dev != -1, let name = devname(dev, S_IFCHR) else { return nil }
+        return "/dev/" + String(cString: name)
+    }
+
+    // ponytail: newlines flattened to spaces — dictated speech is single-line and
+    // an embedded newline in a terminal write submits early; preserve multiline
+    // only if a real need shows up.
+    private nonisolated static func escapeForAppleScript(_ text: String) -> String {
+        text.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+    }
+
+    // Only Terminal.app and iTerm2 can write into a specific tab by tty without
+    // focusing it. Every other "terminal" in the supported list (Warp, kitty,
+    // VSCode/JetBrains integrated terminals, …) has no such API → nil, caller falls back.
+    private nonisolated static func writeTextScript(bundleId: String, tty: String, text: String) -> String? {
+        let escaped = escapeForAppleScript(text)
+        switch bundleId {
+        case "com.apple.Terminal":
+            return """
+            tell application "Terminal"
+                repeat with w in windows
+                    repeat with t in tabs of w
+                        if tty of t is "\(tty)" then
+                            do script "\(escaped)" in t
+                            return "ok"
+                        end if
+                    end repeat
+                end repeat
+            end tell
+            return "notfound"
+            """
+        case "com.googlecode.iterm2":
+            return """
+            tell application "iTerm2"
+                repeat with w in windows
+                    repeat with t in tabs of w
+                        repeat with s in sessions of t
+                            if tty of s is "\(tty)" then
+                                tell s to write text "\(escaped)"
+                                return "ok"
+                            end if
+                        end repeat
+                    end repeat
+                end repeat
+            end tell
+            return "notfound"
+            """
+        default:
+            return nil
+        }
+    }
+
+    // Runs off the main thread via `osascript` so a slow/busy Terminal (or an
+    // Automation prompt) never freezes the notch UI. Returns true only when the
+    // script printed "ok" (tab found + written).
+    private nonisolated static func runAppleScript(_ source: String) async -> Bool {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+                process.arguments = ["-e", source]
+                let stdout = Pipe()
+                process.standardOutput = stdout
+                process.standardError = Pipe()
+                do {
+                    try process.run()
+                } catch {
+                    logger.error("tab-write osascript failed to launch: \(error.localizedDescription, privacy: .public)")
+                    continuation.resume(returning: false)
+                    return
+                }
+                process.waitUntilExit()
+                let data = stdout.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+                continuation.resume(returning: process.terminationStatus == 0 && output == "ok")
+            }
+        }
     }
 
     static func codexDesktopThreadURL(for session: SessionData) -> URL? {

--- a/notchi/notchi/Views/Dictation/DictationBoxView.swift
+++ b/notchi/notchi/Views/Dictation/DictationBoxView.swift
@@ -8,6 +8,9 @@ struct DictationBoxView: View {
     let onCTA: (DictationCTA) -> Void
     var onCancel: () -> Void = {}
 
+    @Environment(\.panelScale) private var panelScale
+    private var fontScale: CGFloat { PanelTypography.fontScale(panelScale: panelScale) }
+
     private var isEmpty: Bool {
         service.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
@@ -16,19 +19,19 @@ struct DictationBoxView: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
                 Text(DictationPresentation.statusText(for: service.phase))
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: 11 * fontScale, weight: .medium))
                     .foregroundColor(TerminalColors.secondaryText)
                 Spacer()
                 if let targetLabel {
                     Text(targetLabel)
-                        .font(.system(size: 10))
+                        .font(.system(size: 10 * fontScale))
                         .foregroundColor(TerminalColors.dimmedText)
                 }
             }
 
             if DictationPresentation.showsEditor(service.phase, hasText: !isEmpty) {
-                DictationTextField(text: $service.transcript, onSubmit: submit, onCancel: onCancel)
-                    .frame(minHeight: 44, maxHeight: 88)
+                DictationTextField(text: $service.transcript, fontScale: fontScale, onSubmit: submit, onCancel: onCancel)
+                    .frame(minHeight: 44 * fontScale, maxHeight: 88 * fontScale)
                     .padding(6)
                     .background(TerminalColors.subtleBackground)
                     .cornerRadius(8)
@@ -43,19 +46,19 @@ struct DictationBoxView: View {
                         HStack(spacing: 6) {
                             ProgressView().controlSize(.mini)
                             Text(DictationPresentation.statusText(for: service.phase))
-                                .font(.system(size: 10))
+                                .font(.system(size: 10 * fontScale))
                                 .foregroundColor(TerminalColors.dimmedText)
                             Spacer()
                         }
                     } else {
                         HStack(spacing: 8) {
                             Text("Return to send · ⌥Return newline · Esc to discard")
-                                .font(.system(size: 10))
+                                .font(.system(size: 10 * fontScale))
                                 .foregroundColor(TerminalColors.dimmedText)
                             Spacer()
                             Button(action: submit) {
                                 Text("Send")
-                                    .font(.system(size: 12, weight: .semibold))
+                                    .font(.system(size: 12 * fontScale, weight: .semibold))
                                     .foregroundColor(.white)
                                     .padding(.horizontal, 12).padding(.vertical, 5)
                                     .background(TerminalColors.iMessageBlue)
@@ -66,14 +69,14 @@ struct DictationBoxView: View {
                         }
                     }
                 }
-                .frame(height: 26)
+                .frame(height: 26 * fontScale)
             }
 
             let cta = DictationPresentation.cta(for: service.phase)
             if cta != .none, !ctaLabel(cta).isEmpty {
                 Button(action: { onCTA(cta) }) {
                     Text(ctaLabel(cta))
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.system(size: 11 * fontScale, weight: .medium))
                         .foregroundColor(TerminalColors.amber)
                 }
                 .buttonStyle(.plain)
@@ -103,6 +106,7 @@ struct DictationBoxView: View {
 /// Multiline editor where Return submits and ⌥Return / ⇧Return inserts a newline.
 private struct DictationTextField: NSViewRepresentable {
     @Binding var text: String
+    var fontScale: CGFloat = 1.0
     let onSubmit: () -> Void
     var onCancel: () -> Void = {}
 
@@ -113,7 +117,7 @@ private struct DictationTextField: NSViewRepresentable {
         textView.delegate = context.coordinator
         textView.onSubmit = { context.coordinator.parent.onSubmit() }
         textView.onCancel = { context.coordinator.parent.onCancel() }
-        textView.font = .systemFont(ofSize: 13)
+        textView.font = .systemFont(ofSize: 13 * fontScale)
         textView.textColor = .white
         textView.insertionPointColor = .white
         textView.drawsBackground = false
@@ -135,11 +139,6 @@ private struct DictationTextField: NSViewRepresentable {
         scroll.hasVerticalScroller = true
         scroll.borderType = .noBorder
         scroll.documentView = textView
-
-        Task { @MainActor in
-            textView.window?.makeFirstResponder(textView)
-            textView.setSelectedRange(NSRange(location: (textView.string as NSString).length, length: 0))
-        }
         return scroll
     }
 
@@ -148,6 +147,7 @@ private struct DictationTextField: NSViewRepresentable {
         guard let textView = nsView.documentView as? SubmittingTextView else { return }
         textView.onSubmit = { context.coordinator.parent.onSubmit() }
         textView.onCancel = { context.coordinator.parent.onCancel() }
+        textView.font = .systemFont(ofSize: 13 * fontScale)
         if textView.string != text {
             textView.string = text
             // Setting .string resets the caret to 0; for an external update
@@ -171,12 +171,27 @@ private struct DictationTextField: NSViewRepresentable {
         var onSubmit: (() -> Void)?
         var onCancel: (() -> Void)?
 
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if let window {
+                window.makeFirstResponder(self)
+                setSelectedRange(NSRange(location: (string as NSString).length, length: 0))
+            }
+        }
+
         // Esc discards the dictation box.
         override func cancelOperation(_ sender: Any?) {
             onCancel?()
         }
 
         override func keyDown(with event: NSEvent) {
+            // If the user is composing text in an IME (e.g. CJK/Vietnamese), Return
+            // confirms the marked composition candidate — don't submit early.
+            if hasMarkedText() {
+                super.keyDown(with: event)
+                return
+            }
+
             // 36 = Return, 76 = keypad Enter
             guard event.keyCode == 36 || event.keyCode == 76 else {
                 super.keyDown(with: event)

--- a/notchi/notchi/Views/Dictation/DictationBoxView.swift
+++ b/notchi/notchi/Views/Dictation/DictationBoxView.swift
@@ -1,0 +1,193 @@
+import AppKit
+import SwiftUI
+
+struct DictationBoxView: View {
+    @Bindable var service: SpeechToTextService
+    let targetLabel: String?
+    let onSend: (String) -> Void
+    let onCTA: (DictationCTA) -> Void
+    var onCancel: () -> Void = {}
+
+    private var isEmpty: Bool {
+        service.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(DictationPresentation.statusText(for: service.phase))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(TerminalColors.secondaryText)
+                Spacer()
+                if let targetLabel {
+                    Text(targetLabel)
+                        .font(.system(size: 10))
+                        .foregroundColor(TerminalColors.dimmedText)
+                }
+            }
+
+            if DictationPresentation.showsEditor(service.phase, hasText: !isEmpty) {
+                DictationTextField(text: $service.transcript, onSubmit: submit, onCancel: onCancel)
+                    .frame(minHeight: 44, maxHeight: 88)
+                    .padding(6)
+                    .background(TerminalColors.subtleBackground)
+                    .cornerRadius(8)
+
+                // WHY: fixed-height bottom bar so swapping the Send button (review)
+                // for the activity indicator (busy) doesn't change the box height
+                // and jump the text field up/down during re-dictation.
+                Group {
+                    if DictationPresentation.isBusy(service.phase) {
+                        // Activity indicator below the still-visible text; new speech
+                        // appends into the field above on return to review.
+                        HStack(spacing: 6) {
+                            ProgressView().controlSize(.mini)
+                            Text(DictationPresentation.statusText(for: service.phase))
+                                .font(.system(size: 10))
+                                .foregroundColor(TerminalColors.dimmedText)
+                            Spacer()
+                        }
+                    } else {
+                        HStack(spacing: 8) {
+                            Text("Return to send · ⌥Return newline · Esc to discard")
+                                .font(.system(size: 10))
+                                .foregroundColor(TerminalColors.dimmedText)
+                            Spacer()
+                            Button(action: submit) {
+                                Text("Send")
+                                    .font(.system(size: 12, weight: .semibold))
+                                    .foregroundColor(.white)
+                                    .padding(.horizontal, 12).padding(.vertical, 5)
+                                    .background(TerminalColors.iMessageBlue)
+                                    .cornerRadius(6)
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(isEmpty)
+                        }
+                    }
+                }
+                .frame(height: 26)
+            }
+
+            let cta = DictationPresentation.cta(for: service.phase)
+            if cta != .none, !ctaLabel(cta).isEmpty {
+                Button(action: { onCTA(cta) }) {
+                    Text(ctaLabel(cta))
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(TerminalColors.amber)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(10)
+        .background(TerminalColors.subtleBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func submit() {
+        guard !isEmpty else { return }
+        onSend(service.transcript)
+    }
+
+    private func ctaLabel(_ cta: DictationCTA) -> String {
+        switch cta {
+        case .grantMicrophone: return String(localized: "Grant Microphone")
+        case .grantAccessibility: return String(localized: "Grant Accessibility")
+        case .downloadModel: return String(localized: "Download Model")
+        case .retry: return String(localized: "Try Again")
+        case .noSession, .sessionNotInjectable, .none: return ""
+        }
+    }
+}
+
+/// Multiline editor where Return submits and ⌥Return / ⇧Return inserts a newline.
+private struct DictationTextField: NSViewRepresentable {
+    @Binding var text: String
+    let onSubmit: () -> Void
+    var onCancel: () -> Void = {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let textView = SubmittingTextView()
+        textView.delegate = context.coordinator
+        textView.onSubmit = { context.coordinator.parent.onSubmit() }
+        textView.onCancel = { context.coordinator.parent.onCancel() }
+        textView.font = .systemFont(ofSize: 13)
+        textView.textColor = .white
+        textView.insertionPointColor = .white
+        textView.drawsBackground = false
+        textView.isRichText = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.allowsUndo = true
+        textView.textContainerInset = NSSize(width: 2, height: 4)
+        textView.string = text
+
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.widthTracksTextView = true
+
+        let scroll = NSScrollView()
+        scroll.drawsBackground = false
+        scroll.hasVerticalScroller = true
+        scroll.borderType = .noBorder
+        scroll.documentView = textView
+
+        Task { @MainActor in
+            textView.window?.makeFirstResponder(textView)
+            textView.setSelectedRange(NSRange(location: (textView.string as NSString).length, length: 0))
+        }
+        return scroll
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        context.coordinator.parent = self
+        guard let textView = nsView.documentView as? SubmittingTextView else { return }
+        textView.onSubmit = { context.coordinator.parent.onSubmit() }
+        textView.onCancel = { context.coordinator.parent.onCancel() }
+        if textView.string != text {
+            textView.string = text
+            // Setting .string resets the caret to 0; for an external update
+            // (re-dictation appending new text) place it at the end so the user
+            // can keep going / edit the tail instead of jumping to the start.
+            textView.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: DictationTextField
+        init(_ parent: DictationTextField) { self.parent = parent }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            parent.text = textView.string
+        }
+    }
+
+    final class SubmittingTextView: NSTextView {
+        var onSubmit: (() -> Void)?
+        var onCancel: (() -> Void)?
+
+        // Esc discards the dictation box.
+        override func cancelOperation(_ sender: Any?) {
+            onCancel?()
+        }
+
+        override func keyDown(with event: NSEvent) {
+            // 36 = Return, 76 = keypad Enter
+            guard event.keyCode == 36 || event.keyCode == 76 else {
+                super.keyDown(with: event)
+                return
+            }
+            let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            if modifiers.contains(.option) || modifiers.contains(.shift) {
+                super.keyDown(with: event) // insert a newline
+            } else {
+                onSubmit?()
+            }
+        }
+    }
+}

--- a/notchi/notchi/Views/Dictation/DictationPresentation.swift
+++ b/notchi/notchi/Views/Dictation/DictationPresentation.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+nonisolated enum DictationCTA: Equatable {
+    case none, grantMicrophone, grantAccessibility, downloadModel, noSession, sessionNotInjectable, retry
+}
+
+nonisolated enum DictationPresentation {
+    static func cta(for phase: DictationPhase) -> DictationCTA {
+        guard case let .error(error) = phase else { return .none }
+        switch error {
+        case .microphoneDenied: return .grantMicrophone
+        case .accessibilityDenied: return .grantAccessibility
+        case .modelMissing: return .downloadModel
+        case .noActiveSession: return .noSession
+        case .sessionNotInjectable: return .sessionNotInjectable
+        case .transcriptionFailed: return .retry
+        }
+    }
+
+    static func isEditable(_ phase: DictationPhase) -> Bool {
+        if case .review = phase { return true }
+        return false
+    }
+
+    static func isBusy(_ phase: DictationPhase) -> Bool {
+        switch phase {
+        case .recording, .transcribing: return true
+        default: return false
+        }
+    }
+
+    /// Keep the editor mounted across a re-dictation (review → recording →
+    /// transcribing → review) whenever there's already text, so the box doesn't
+    /// flit out and back — the new speech appends into the same visible field.
+    static func showsEditor(_ phase: DictationPhase, hasText: Bool) -> Bool {
+        isEditable(phase) || (isBusy(phase) && hasText)
+    }
+
+    static func statusText(for phase: DictationPhase) -> String {
+        switch phase {
+        case .idle: return String(localized: "Hold to dictate")
+        case .recording: return String(localized: "Listening…")
+        case .transcribing: return String(localized: "Transcribing…")
+        case .review: return String(localized: "Review and send")
+        case .sending: return String(localized: "Sending…")
+        case .error(.microphoneDenied): return String(localized: "Microphone access needed")
+        case .error(.accessibilityDenied): return String(localized: "Accessibility access needed")
+        case .error(.modelMissing): return String(localized: "Download a model to dictate")
+        case .error(.noActiveSession): return String(localized: "No active session")
+        case .error(.sessionNotInjectable): return String(localized: "This session can't receive dictation")
+        case .error(.transcriptionFailed): return String(localized: "Didn't catch that")
+        }
+    }
+}

--- a/notchi/notchi/Views/Dictation/DictationSettingsView.swift
+++ b/notchi/notchi/Views/Dictation/DictationSettingsView.swift
@@ -1,0 +1,118 @@
+import AppKit
+import AVFoundation
+import SwiftUI
+
+enum DictationPermission {
+    static func accessibilityGranted() -> Bool { AXIsProcessTrusted() }
+
+    /// Triggers the system Accessibility prompt, which registers this binary in
+    /// the Accessibility list (opening System Settings alone never adds it).
+    static func requestAccessibility() {
+        // Raw value of kAXTrustedCheckOptionPrompt — avoids CFString import churn.
+        let options = ["AXTrustedCheckOptionPrompt": true] as CFDictionary
+        _ = AXIsProcessTrustedWithOptions(options)
+        openAccessibilitySettings()
+    }
+
+    static func openAccessibilitySettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") else { return }
+        NSWorkspace.shared.open(url)
+    }
+}
+
+struct DictationSettingsView: View {
+    @AppStorage(AppSettings.dictationEnabledRawKey) private var enabled = false
+    @State private var pushToTalk = AppSettings.dictationPushToTalkShortcut
+    @State private var modelId = AppSettings.dictationModelId
+    private let modelStore = WhisperModelStore.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
+            Button(action: { enabled.toggle() }) {
+                SettingsRowView(icon: "mic", title: "Voice Dictation") { ToggleSwitch(isOn: enabled) }
+            }
+            .buttonStyle(.plain)
+
+            if enabled {
+                SettingsRowView(icon: "keyboard", title: "Push-to-Talk") {
+                    ShortcutRecorderView(
+                        shortcut: pushToTalk,
+                        onReset: { update(.defaultDictationPushToTalk) },
+                        onShortcutChange: { update($0) }
+                    )
+                }
+                modelRow
+
+                Button(action: { DictationPermission.requestAccessibility() }) {
+                    SettingsRowView(icon: "hand.raised", title: "Accessibility") {
+                        Text(DictationPermission.accessibilityGranted() ? String(localized: "Granted") : String(localized: "Enable"))
+                            .font(.system(size: 11))
+                            .foregroundColor(DictationPermission.accessibilityGranted() ? TerminalColors.green : TerminalColors.amber)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var modelRow: some View {
+        let model = WhisperCatalog.model(id: modelId) ?? WhisperCatalog.models[1]
+        // Reading downloadProgress (observable) drives the row to re-render as the
+        // download starts and finishes, at which point isDownloaded flips to true.
+        let progress = modelStore.downloadProgress[model.id]
+        SettingsRowView(icon: "cpu", title: "Model") {
+            HStack(spacing: 6) {
+                if let progress, progress < 1 {
+                    ProgressView().controlSize(.mini)
+                } else if !modelStore.isDownloaded(model) {
+                    Text(String(localized: "\(model.approxMB) MB"))
+                        .font(.system(size: 10))
+                        .foregroundColor(TerminalColors.amber)
+                }
+                Menu {
+                    ForEach(WhisperCatalog.models) { candidate in
+                        Button {
+                            select(candidate)
+                        } label: {
+                            Text((candidate.id == model.id ? "✓ " : "") + menuLabel(candidate))
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(model.displayName)
+                            .font(.system(size: 11))
+                            .foregroundColor(TerminalColors.secondaryText)
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.system(size: 9))
+                            .foregroundColor(TerminalColors.dimmedText)
+                    }
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+            }
+        }
+    }
+
+    private func menuLabel(_ model: WhisperModel) -> String {
+        modelStore.isDownloaded(model) ? model.displayName : "\(model.displayName) • \(model.approxMB) MB"
+    }
+
+    private func update(_ shortcut: GlobalShortcut) {
+        pushToTalk = shortcut
+        AppSettings.dictationPushToTalkShortcut = shortcut
+    }
+
+    // Switch the active dictation model; download it first if it isn't cached yet.
+    private func select(_ model: WhisperModel) {
+        modelId = model.id
+        AppSettings.dictationModelId = model.id
+        if !modelStore.isDownloaded(model) {
+            download(model)
+        }
+    }
+
+    private func download(_ model: WhisperModel) {
+        Task { try? await modelStore.download(model) }
+    }
+}

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -419,7 +419,7 @@ struct ExpandedPanelView: View {
                                 targetLabel: effectiveSession.map { sessionStore.displaySessionLabel(for: $0) },
                                 onSend: { _ in
                                     Task { @MainActor in
-                                        _ = await SpeechToTextService.shared.send(
+                                        let result = await SpeechToTextService.shared.send(
                                             using: { text, session in
                                                 await PromptInjectionService.shared.inject(
                                                     text,
@@ -429,6 +429,9 @@ struct ExpandedPanelView: View {
                                             },
                                             targetSession: effectiveSession
                                         )
+                                        if result == .sent {
+                                            NotchPanelManager.shared.collapseAfterDictation()
+                                        }
                                     }
                                 },
                                 onCTA: { cta in
@@ -443,7 +446,10 @@ struct ExpandedPanelView: View {
                                     case .noSession, .sessionNotInjectable, .none: break
                                     }
                                 },
-                                onCancel: { SpeechToTextService.shared.reset() }
+                                onCancel: {
+                                    SpeechToTextService.shared.reset()
+                                    NotchPanelManager.shared.collapseAfterDictation()
+                                }
                             )
                             .padding(.horizontal, 12)
                         }

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import SwiftUI
 
 private struct PanelSwapTransitionModifier: ViewModifier {
@@ -411,6 +412,41 @@ struct ExpandedPanelView: View {
                             }
                         }
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+                        if SpeechToTextService.shared.phase != .idle {
+                            DictationBoxView(
+                                service: SpeechToTextService.shared,
+                                targetLabel: effectiveSession.map { sessionStore.displaySessionLabel(for: $0) },
+                                onSend: { _ in
+                                    Task { @MainActor in
+                                        _ = await SpeechToTextService.shared.send(
+                                            using: { text, session in
+                                                await PromptInjectionService.shared.inject(
+                                                    text,
+                                                    into: session,
+                                                    fallbackAppPID: SpeechToTextService.shared.originAppPID
+                                                )
+                                            },
+                                            targetSession: effectiveSession
+                                        )
+                                    }
+                                },
+                                onCTA: { cta in
+                                    switch cta {
+                                    case .grantAccessibility: DictationPermission.requestAccessibility()
+                                    case .downloadModel:
+                                        if let model = WhisperCatalog.model(id: AppSettings.dictationModelId) {
+                                            Task { try? await WhisperModelStore.shared.download(model) }
+                                        }
+                                    case .grantMicrophone: AVCaptureDevice.requestAccess(for: .audio) { _ in }
+                                    case .retry: SpeechToTextService.shared.startRecording()
+                                    case .noSession, .sessionNotInjectable, .none: break
+                                    }
+                                },
+                                onCancel: { SpeechToTextService.shared.reset() }
+                            )
+                            .padding(.horizontal, 12)
+                        }
 
                         if !isShowingUsageDetail {
                             sharedUsageBar

--- a/notchi/notchi/Views/SettingsGeneralView.swift
+++ b/notchi/notchi/Views/SettingsGeneralView.swift
@@ -38,6 +38,8 @@ struct SettingsGeneralView: View {
                 }
             }
             .buttonStyle(.plain)
+
+            DictationSettingsView()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onAppear {

--- a/notchi/notchi/Views/SettingsGeneralView.swift
+++ b/notchi/notchi/Views/SettingsGeneralView.swift
@@ -39,6 +39,8 @@ struct SettingsGeneralView: View {
             }
             .buttonStyle(.plain)
 
+            Divider().background(Color.white.opacity(0.08))
+
             DictationSettingsView()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/scripts/build-whisper-xcframework.sh
+++ b/scripts/build-whisper-xcframework.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Builds a static, macOS-only whisper.xcframework (Metal embedded) from a
+# pinned whisper.cpp tag. Output is git-ignored; regenerate with this script.
+set -euo pipefail
+
+WHISPER_TAG="v1.9.1"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="${ROOT}/build/whisper-src"
+DEST="${ROOT}/third_party/whisper.xcframework"
+
+command -v cmake >/dev/null 2>&1 || { echo "cmake required: brew install cmake"; exit 1; }
+
+if [[ -d "${DEST}" ]]; then
+    echo "whisper.xcframework already present at ${DEST} (delete to rebuild)"; exit 0
+fi
+
+rm -rf "${BUILD_DIR}"
+git clone --depth 1 --branch "${WHISPER_TAG}" https://github.com/ggml-org/whisper.cpp "${BUILD_DIR}"
+
+# Static xcframework so the app links (no embed/sign). Metal is embedded by the script.
+( cd "${BUILD_DIR}" && BUILD_STATIC_XCFRAMEWORK=ON ./build-xcframework.sh )
+
+mkdir -p "${ROOT}/third_party"
+# The script emits build-apple/whisper.xcframework with all Apple slices; we
+# keep the whole xcframework (macOS slice is what links for platform=macOS).
+rm -rf "${DEST}"
+cp -R "${BUILD_DIR}/build-apple/whisper.xcframework" "${DEST}"
+echo "Built ${DEST}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,17 +14,18 @@ ATTEMPT2_LOG_PATH="${BUILD_ROOT}/test-attempt-2.log"
 
 usage() {
     cat <<'EOF'
-Usage: ./scripts/test.sh [focused|all]
+Usage: ./scripts/test.sh [focused|all|dictation]
 
 Presets:
-  focused   Run the most frequently touched suites (default)
-  all       Run the full test suite
+  focused    Run the most frequently touched suites (default)
+  dictation  Run the speech dictation test suites
+  all        Run the full test suite
 EOF
 }
 
 preset="${1:-focused}"
 case "$preset" in
-    focused|all)
+    focused|all|dictation)
         ;;
     -h|--help)
         usage
@@ -38,6 +39,11 @@ esac
 
 mkdir -p "$BUILD_ROOT"
 
+if [[ ! -d "third_party/whisper.xcframework" ]]; then
+    echo "===> whisper.xcframework missing; building via scripts/build-whisper-xcframework.sh..."
+    ./scripts/build-whisper-xcframework.sh
+fi
+
 TEST_ARGS=()
 if [[ "$preset" == "focused" ]]; then
     TEST_ARGS=(
@@ -50,6 +56,15 @@ if [[ "$preset" == "focused" ]]; then
         "-only-testing:Tests/CostHistoryStoreTests"
         "-only-testing:Tests/ClaudeModelPricingTests"
         "-only-testing:Tests/HookScriptImportIsolationTests"
+    )
+elif [[ "$preset" == "dictation" ]]; then
+    TEST_ARGS=(
+        "-only-testing:Tests/AppSettingsDictationTests"
+        "-only-testing:Tests/DictationPresentationTests"
+        "-only-testing:Tests/PromptInjectionServiceTests"
+        "-only-testing:Tests/PushToTalkServiceTests"
+        "-only-testing:Tests/SpeechToTextServiceTests"
+        "-only-testing:Tests/WhisperModelStoreTests"
     )
 fi
 


### PR DESCRIPTION
## Summary

Adds push-to-talk **speech-to-text dictation** to Notchi. Hold a global hotkey, speak, review the transcription in the notch, and send it directly into your active Claude Code or Codex session. Powered completely on-device via `whisper.cpp`.

Refs sk-ruban/notchi#90.

## Key Features

- **Push-to-Talk Workflow**: Hold the configurable global shortcut (default `⌘⌥⇧D`) to record, release to transcribe. Holding again appends additional speech.
- **On-Device Whisper Engine**: 100% offline transcription using `whisper.cpp` (`whisper.xcframework`), keeping audio and transcripts private on-device.
- **Review Box in the Notch**: Transcriptions appear in an editable input box in the notch panel. Press `Return` to send, `⌥Return` for newline, or `Esc` to cancel.
- **Targeted Prompt Injection**:
  - **Terminal.app & iTerm2**: Delivers prompts straight into the session's exact tab in the background via AppleScript (matched by TTY).
  - **Other Terminals**: Activates the target terminal and types the prompt via accessibility key events.
- **Model Management**: Download and switch Whisper models (Tiny, Base, Small, Turbo) in Settings with real-time download progress.

## Permissions

- **Microphone**: Audio recording during push-to-talk.
- **Accessibility**: Fallback keystroke injection for non-scriptable terminals.
- **Automation**: Background tab delivery for Terminal.app / iTerm2.

## Verification

- Verified complete push-to-talk lifecycle, model switching, and prompt delivery across Terminal.app, iTerm2, and fallback terminals.
- Added unit test suites covering the dictation state machine, prompt injection, and model store.
- All tests pass via `CI=1 ./scripts/test.sh`.
