### PR TITLE
feat(panel): add a panel size setting for larger displays

### DIFF
--- a/notchi/Tests/NotchContentViewTests.swift
+++ b/notchi/Tests/NotchContentViewTests.swift
@@ -350,26 +350,30 @@ final class NotchContentViewTests: XCTestCase {
         )
     }
 
-    func testPickerViewportGrowsWithTheScaledRows() {
-        SettingsLayout.scale = 1
-        let standard = SettingsLayout.pickerViewportHeight(rowCount: 5)
-
-        SettingsLayout.scale = ExpandedPanelScale.large.multiplier
-        let large = SettingsLayout.pickerViewportHeight(rowCount: 5)
-        SettingsLayout.scale = 1
-
-        XCTAssertEqual(standard, 5 * 28 + 4 * 4)
-        XCTAssertEqual(large, standard * ExpandedPanelScale.large.multiplier, accuracy: 0.001)
+    func testShortPickerIsUnconstrainedSoItDoesNotReserveEmptySpace() {
+        XCTAssertNil(SettingsLayout.pickerViewportHeight(rowCount: NotchSlotContent.allCases.count))
+        XCTAssertNil(SettingsLayout.pickerViewportHeight(rowCount: SettingsLayout.pickerMaxVisibleRows))
     }
 
-    func testPickerViewportStopsGrowingPastTheVisibleRowLimit() {
+    func testOverlongPickerIsCappedToTheVisibleRowLimit() {
         SettingsLayout.scale = 1
         defer { SettingsLayout.scale = 1 }
 
-        XCTAssertEqual(
-            SettingsLayout.pickerViewportHeight(rowCount: 20),
-            SettingsLayout.pickerViewportHeight(rowCount: 6)
-        )
+        let capped = SettingsLayout.pickerViewportHeight(rowCount: 20)
+
+        XCTAssertEqual(capped, 6 * 28 + 5 * 4)
+        XCTAssertEqual(capped, SettingsLayout.pickerViewportHeight(rowCount: 7))
+    }
+
+    func testCappedPickerViewportGrowsWithThePanel() {
+        SettingsLayout.scale = 1
+        let standard = SettingsLayout.pickerViewportHeight(rowCount: 20)
+
+        SettingsLayout.scale = ExpandedPanelScale.large.multiplier
+        let large = SettingsLayout.pickerViewportHeight(rowCount: 20)
+        SettingsLayout.scale = 1
+
+        XCTAssertEqual(large!, standard! * ExpandedPanelScale.large.multiplier, accuracy: 0.001)
     }
 
 

--- a/notchi/Tests/NotchContentViewTests.swift
+++ b/notchi/Tests/NotchContentViewTests.swift
@@ -210,4 +210,25 @@ final class NotchContentViewTests: XCTestCase {
             NotchContentView.islandOnlyPanelHeight
         )
     }
+
+    func testPanelSizeAtStandardScaleMatchesLegacyFixedSize() {
+        let size = NotchConstants.panelSize(scale: 1)
+
+        XCTAssertEqual(size.height, NotchConstants.expandedPanelSize.height)
+        XCTAssertEqual(
+            size.width,
+            NotchConstants.expandedPanelSize.width + NotchConstants.expandedPanelHorizontalPadding
+        )
+    }
+
+    func testPanelSizeScalesEverythingExceptTheOuterChrome() {
+        let scale: CGFloat = 1.5
+
+        let size = NotchConstants.panelSize(scale: scale)
+
+        XCTAssertEqual(size.height, (450 - 24) * scale + 24, accuracy: 0.001)
+    }
+
+
+
 }

--- a/notchi/Tests/NotchContentViewTests.swift
+++ b/notchi/Tests/NotchContentViewTests.swift
@@ -317,6 +317,14 @@ final class NotchContentViewTests: XCTestCase {
         XCTAssertEqual((size * 2).truncatingRemainder(dividingBy: 1), 0)
     }
 
+    func testHeaderRowIsTallEnoughForTheButtonItContains() {
+        XCTAssertEqual(
+            NotchContentView.expandedHeaderRowHeight,
+            PanelHeaderButton.baseSize + NotchContentView.expandedHeaderTopPadding
+        )
+        XCTAssertGreaterThanOrEqual(NotchContentView.expandedHeaderRowHeight, PanelHeaderButton.baseSize)
+    }
+
     func testPanelSizeAtStandardScaleMatchesLegacyFixedSize() {
         let size = NotchConstants.panelSize(scale: 1)
 

--- a/notchi/Tests/NotchContentViewTests.swift
+++ b/notchi/Tests/NotchContentViewTests.swift
@@ -336,11 +336,40 @@ final class NotchContentViewTests: XCTestCase {
     }
 
     func testPanelSizeScalesEverythingExceptTheOuterChrome() {
-        let scale: CGFloat = 1.5
+        let scale = ExpandedPanelScale.large.multiplier
 
         let size = NotchConstants.panelSize(scale: scale)
 
         XCTAssertEqual(size.height, (450 - 24) * scale + 24, accuracy: 0.001)
+        XCTAssertEqual(
+            size.width,
+            (450 - NotchConstants.expandedPanelContentInset) * scale
+                + NotchConstants.expandedPanelHorizontalPadding
+                + NotchConstants.expandedPanelHitTestSlack,
+            accuracy: 0.001
+        )
+    }
+
+    func testPickerViewportGrowsWithTheScaledRows() {
+        SettingsLayout.scale = 1
+        let standard = SettingsLayout.pickerViewportHeight(rowCount: 5)
+
+        SettingsLayout.scale = ExpandedPanelScale.large.multiplier
+        let large = SettingsLayout.pickerViewportHeight(rowCount: 5)
+        SettingsLayout.scale = 1
+
+        XCTAssertEqual(standard, 5 * 28 + 4 * 4)
+        XCTAssertEqual(large, standard * ExpandedPanelScale.large.multiplier, accuracy: 0.001)
+    }
+
+    func testPickerViewportStopsGrowingPastTheVisibleRowLimit() {
+        SettingsLayout.scale = 1
+        defer { SettingsLayout.scale = 1 }
+
+        XCTAssertEqual(
+            SettingsLayout.pickerViewportHeight(rowCount: 20),
+            SettingsLayout.pickerViewportHeight(rowCount: 6)
+        )
     }
 
 

--- a/notchi/Tests/NotchContentViewTests.swift
+++ b/notchi/Tests/NotchContentViewTests.swift
@@ -231,6 +231,39 @@ final class NotchContentViewTests: XCTestCase {
 
 
 
+    func testFeedGrowsWithPanelSoTheGapAboveTheSpinnerStaysProportional() {
+        let standard = ExpandedPanelView.feedMaxHeight(mode: .full, panelScale: 1)
+        let large = ExpandedPanelView.feedMaxHeight(mode: .full, panelScale: 1.25)
+
+        XCTAssertEqual(standard, ExpandedPanelView.defaultFeedMaxHeight)
+        XCTAssertEqual(large, 250)
+    }
+
+    func testCompactFeedAlsoGrowsWithPanel() {
+        XCTAssertEqual(
+            ExpandedPanelView.feedMaxHeight(mode: .compact, panelScale: 1.25),
+            400
+        )
+    }
+
+    func testUsageRowsStackInOneColumnWhenPanelIsEnlarged() {
+        XCTAssertFalse(
+            UsageDetailView.usesTwoColumnLayout(rowCount: 3, hideGrassIsland: false, panelScale: 1.25)
+        )
+    }
+
+    func testUsageRowsUseTwoColumnsAtStandardScaleToFitThreeRows() {
+        XCTAssertTrue(
+            UsageDetailView.usesTwoColumnLayout(rowCount: 3, hideGrassIsland: false, panelScale: 1)
+        )
+        XCTAssertFalse(
+            UsageDetailView.usesTwoColumnLayout(rowCount: 2, hideGrassIsland: false, panelScale: 1)
+        )
+        XCTAssertFalse(
+            UsageDetailView.usesTwoColumnLayout(rowCount: 3, hideGrassIsland: true, panelScale: 1)
+        )
+    }
+
     func testSpritesStayAtNativeSizeWhenPanelIsNotEnlarged() {
         XCTAssertEqual(SpriteLayout.spriteScale(panelScale: 1), 1)
     }

--- a/notchi/Tests/NotchContentViewTests.swift
+++ b/notchi/Tests/NotchContentViewTests.swift
@@ -1,6 +1,12 @@
 import XCTest
 @testable import notchi
 
+private enum VisibleScreenHeight {
+    static let macBookAir15: CGFloat = 918
+    static let studioDisplay: CGFloat = 1415
+    static let lgSDQHD: CGFloat = 2855
+}
+
 final class NotchContentViewTests: XCTestCase {
     func testSameNonNothingContentsConflict() {
         XCTAssertTrue(NotchSlotContent.conflict(.ring, .ring))
@@ -253,6 +259,49 @@ final class NotchContentViewTests: XCTestCase {
         )
         XCTAssertFalse(
             UsageDetailView.usesTwoColumnLayout(rowCount: 3, hideGrassIsland: true, panelScale: 1)
+        )
+    }
+
+    func testAutomaticPicksStandardOnBuiltInLaptopHeights() {
+        XCTAssertEqual(
+            ExpandedPanelScale.automatic.resolved(visibleScreenHeight: VisibleScreenHeight.macBookAir15),
+            .standard
+        )
+    }
+
+    func testAutomaticPicksLargeOnTallExternalDisplays() {
+        XCTAssertEqual(
+            ExpandedPanelScale.automatic.resolved(visibleScreenHeight: VisibleScreenHeight.studioDisplay),
+            .large
+        )
+    }
+
+    func testAutomaticTurnsLargeExactlyAtTheThreshold() {
+        let threshold = ExpandedPanelScale.automaticLargeMinimumHeight
+
+        XCTAssertEqual(ExpandedPanelScale.automatic.resolved(visibleScreenHeight: threshold), .large)
+        XCTAssertEqual(ExpandedPanelScale.automatic.resolved(visibleScreenHeight: threshold - 1), .standard)
+    }
+
+    func testExplicitChoiceOverridesScreenHeightInBothDirections() {
+        XCTAssertEqual(
+            ExpandedPanelScale.standard.resolved(visibleScreenHeight: VisibleScreenHeight.lgSDQHD),
+            .standard
+        )
+        XCTAssertEqual(
+            ExpandedPanelScale.large.resolved(visibleScreenHeight: VisibleScreenHeight.macBookAir15),
+            .large
+        )
+    }
+
+    func testAutomaticMultiplierFollowsTheResolvedChoice() {
+        XCTAssertEqual(
+            ExpandedPanelScale.automatic.resolved(visibleScreenHeight: VisibleScreenHeight.macBookAir15).multiplier,
+            1
+        )
+        XCTAssertEqual(
+            ExpandedPanelScale.automatic.resolved(visibleScreenHeight: VisibleScreenHeight.lgSDQHD).multiplier,
+            1.25
         )
     }
 

--- a/notchi/Tests/NotchContentViewTests.swift
+++ b/notchi/Tests/NotchContentViewTests.swift
@@ -351,29 +351,28 @@ final class NotchContentViewTests: XCTestCase {
     }
 
     func testShortPickerIsUnconstrainedSoItDoesNotReserveEmptySpace() {
-        XCTAssertNil(SettingsLayout.pickerViewportHeight(rowCount: NotchSlotContent.allCases.count))
-        XCTAssertNil(SettingsLayout.pickerViewportHeight(rowCount: SettingsLayout.pickerMaxVisibleRows))
+        XCTAssertNil(
+            SettingsLayout.pickerViewportHeight(rowCount: NotchSlotContent.allCases.count, scale: 1)
+        )
+        XCTAssertNil(
+            SettingsLayout.pickerViewportHeight(rowCount: SettingsLayout.pickerMaxVisibleRows, scale: 1)
+        )
     }
 
-    func testOverlongPickerIsCappedToTheVisibleRowLimit() {
-        SettingsLayout.scale = 1
-        defer { SettingsLayout.scale = 1 }
+    func testOverlongPickerIsCappedToTheVisibleRowLimit() throws {
+        let capped = try XCTUnwrap(SettingsLayout.pickerViewportHeight(rowCount: 20, scale: 1))
+        let firstOverflowing = try XCTUnwrap(SettingsLayout.pickerViewportHeight(rowCount: 7, scale: 1))
 
-        let capped = SettingsLayout.pickerViewportHeight(rowCount: 20)
-
-        XCTAssertEqual(capped, 6 * 28 + 5 * 4)
-        XCTAssertEqual(capped, SettingsLayout.pickerViewportHeight(rowCount: 7))
+        XCTAssertEqual(capped, 6 * SettingsLayout.basePickerRowHeight + 5 * SettingsLayout.basePickerRowSpacing)
+        XCTAssertEqual(capped, firstOverflowing)
     }
 
-    func testCappedPickerViewportGrowsWithThePanel() {
-        SettingsLayout.scale = 1
-        let standard = SettingsLayout.pickerViewportHeight(rowCount: 20)
+    func testCappedPickerViewportGrowsWithThePanel() throws {
+        let largeScale = ExpandedPanelScale.large.multiplier
+        let standard = try XCTUnwrap(SettingsLayout.pickerViewportHeight(rowCount: 20, scale: 1))
+        let large = try XCTUnwrap(SettingsLayout.pickerViewportHeight(rowCount: 20, scale: largeScale))
 
-        SettingsLayout.scale = ExpandedPanelScale.large.multiplier
-        let large = SettingsLayout.pickerViewportHeight(rowCount: 20)
-        SettingsLayout.scale = 1
-
-        XCTAssertEqual(large!, standard! * ExpandedPanelScale.large.multiplier, accuracy: 0.001)
+        XCTAssertEqual(large, standard * largeScale, accuracy: 0.001)
     }
 
 

--- a/notchi/Tests/NotchContentViewTests.swift
+++ b/notchi/Tests/NotchContentViewTests.swift
@@ -211,25 +211,17 @@ final class NotchContentViewTests: XCTestCase {
         )
     }
 
-    func testPanelSizeAtStandardScaleMatchesLegacyFixedSize() {
-        let size = NotchConstants.panelSize(scale: 1)
-
-        XCTAssertEqual(size.height, NotchConstants.expandedPanelSize.height)
-        XCTAssertEqual(
-            size.width,
-            NotchConstants.expandedPanelSize.width + NotchConstants.expandedPanelHorizontalPadding
-        )
+    func testTextIsUnscaledWhenPanelIsNotEnlarged() {
+        XCTAssertEqual(PanelTypography.fontScale(panelScale: 1), 1)
     }
 
-    func testPanelSizeScalesEverythingExceptTheOuterChrome() {
-        let scale: CGFloat = 1.5
+    func testTextGrowsMoreGentlyThanThePanelSoLargeFitsMoreContent() {
+        let panelScale: CGFloat = 1.25
+        let fontScale = PanelTypography.fontScale(panelScale: panelScale)
 
-        let size = NotchConstants.panelSize(scale: scale)
-
-        XCTAssertEqual(size.height, (450 - 24) * scale + 24, accuracy: 0.001)
+        XCTAssertLessThan(fontScale, panelScale)
+        XCTAssertEqual(13 * fontScale, 14.625, accuracy: 0.001)
     }
-
-
 
     func testFeedGrowsWithPanelSoTheGapAboveTheSpinnerStaysProportional() {
         let standard = ExpandedPanelView.feedMaxHeight(mode: .full, panelScale: 1)
@@ -275,5 +267,25 @@ final class NotchContentViewTests: XCTestCase {
         XCTAssertEqual(size.truncatingRemainder(dividingBy: 1), 0)
         XCTAssertEqual((size * 2).truncatingRemainder(dividingBy: 1), 0)
     }
+
+    func testPanelSizeAtStandardScaleMatchesLegacyFixedSize() {
+        let size = NotchConstants.panelSize(scale: 1)
+
+        XCTAssertEqual(size.height, NotchConstants.expandedPanelSize.height)
+        XCTAssertEqual(
+            size.width,
+            NotchConstants.expandedPanelSize.width + NotchConstants.expandedPanelHorizontalPadding
+        )
+    }
+
+    func testPanelSizeScalesEverythingExceptTheOuterChrome() {
+        let scale: CGFloat = 1.5
+
+        let size = NotchConstants.panelSize(scale: scale)
+
+        XCTAssertEqual(size.height, (450 - 24) * scale + 24, accuracy: 0.001)
+    }
+
+
 
 }

--- a/notchi/Tests/NotchContentViewTests.swift
+++ b/notchi/Tests/NotchContentViewTests.swift
@@ -231,4 +231,16 @@ final class NotchContentViewTests: XCTestCase {
 
 
 
+    func testSpritesStayAtNativeSizeWhenPanelIsNotEnlarged() {
+        XCTAssertEqual(SpriteLayout.spriteScale(panelScale: 1), 1)
+    }
+
+    func testEnlargedSpriteSizeLandsOnWholePointsOnBothBackingScales() {
+        let size = SpriteLayout.size * SpriteLayout.spriteScale(panelScale: 1.25)
+
+        XCTAssertEqual(size, 72)
+        XCTAssertEqual(size.truncatingRemainder(dividingBy: 1), 0)
+        XCTAssertEqual((size * 2).truncatingRemainder(dividingBy: 1), 0)
+    }
+
 }

--- a/notchi/notchi/AppDelegate.swift
+++ b/notchi/notchi/AppDelegate.swift
@@ -8,7 +8,8 @@ private let logger = Logger(subsystem: "com.ruban.notchi", category: "AppDelegat
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SPUStandardUserDriverDelegate {
     private var notchPanel: NotchPanel?
-    private let windowHeight: CGFloat = 500
+    private let windowHeightSlack: CGFloat = 50
+    private var observedPanelScale = AppSettings.expandedPanelScale
     private let integrationCoordinator = IntegrationCoordinator.shared
     private let globalShortcutService = GlobalShortcutService.shared
     private var minimizeShortcutMonitor: Any?
@@ -151,9 +152,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
             queue: nil
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
+                self?.repositionWindowIfPanelScaleChanged()
                 self?.refreshPanelTrackingAreas()
             }
         }
+    }
+
+    private func repositionWindowIfPanelScaleChanged() {
+        let scale = AppSettings.expandedPanelScale
+        guard scale != observedPanelScale else { return }
+        observedPanelScale = scale
+        repositionWindow()
     }
 
     @objc private func refreshPanelTrackingAreas() {
@@ -192,6 +201,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
 
     private func windowFrame(for screen: NSScreen) -> NSRect {
         let screenFrame = screen.frame
+        let windowHeight = NotchPanelManager.shared.panelRect.height + windowHeightSlack
         return NSRect(
             x: screenFrame.origin.x,
             y: screenFrame.maxY - windowHeight,

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -257,10 +257,12 @@ struct AppSettings {
         }
     }
 
+    static func expandedPanelScale(in defaults: UserDefaults) -> ExpandedPanelScale {
+        ExpandedPanelScale(rawValue: defaults.string(forKey: expandedPanelScaleKey) ?? "") ?? .automatic
+    }
+
     static var expandedPanelScale: ExpandedPanelScale {
-        get {
-            ExpandedPanelScale(rawValue: UserDefaults.standard.string(forKey: expandedPanelScaleKey) ?? "") ?? .automatic
-        }
+        get { expandedPanelScale(in: .standard) }
         set { UserDefaults.standard.set(newValue.rawValue, forKey: expandedPanelScaleKey) }
     }
 

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -141,6 +141,27 @@ enum ExpandedPanelMode: String, CaseIterable {
     case islandOnly
 }
 
+enum ExpandedPanelScale: String, CaseIterable, Identifiable {
+    case standard
+    case large
+
+    var id: String { rawValue }
+
+    var multiplier: CGFloat {
+        switch self {
+        case .standard: 1
+        case .large: 1.25
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .standard: String(localized: "Standard")
+        case .large: String(localized: "Large")
+        }
+    }
+}
+
 struct AppSettings {
     static let hideSpriteWhenIdleKey = "hideSpriteWhenIdle"
     static let hideGrassIslandKey = "hideGrassIsland"
@@ -148,6 +169,7 @@ struct AppSettings {
     static let panelToggleShortcutKey = "panelToggleShortcut"
     static let notchLeftContentKey = "notchLeftContent"
     static let notchRightContentKey = "notchRightContent"
+    static let expandedPanelScaleKey = "expandedPanelScale"
 
     private static let notificationSoundKey = "notificationSound"
     private static let notificationSoundSelectionKey = "notificationSoundSelection"
@@ -224,6 +246,13 @@ struct AppSettings {
             let resolved: NotchSlotContent = other == newValue ? previous : .ring
             UserDefaults.standard.set(resolved.rawValue, forKey: otherKey)
         }
+    }
+
+    static var expandedPanelScale: ExpandedPanelScale {
+        get {
+            ExpandedPanelScale(rawValue: UserDefaults.standard.string(forKey: expandedPanelScaleKey) ?? "") ?? .standard
+        }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: expandedPanelScaleKey) }
     }
 
     static var hideSpriteWhenIdle: Bool {

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -142,20 +142,29 @@ enum ExpandedPanelMode: String, CaseIterable {
 }
 
 enum ExpandedPanelScale: String, CaseIterable, Identifiable {
+    case automatic
     case standard
     case large
 
+    static let automaticLargeMinimumHeight: CGFloat = 1100
+
     var id: String { rawValue }
+
+    func resolved(visibleScreenHeight: CGFloat) -> ExpandedPanelScale {
+        guard self == .automatic else { return self }
+        return visibleScreenHeight >= Self.automaticLargeMinimumHeight ? .large : .standard
+    }
 
     var multiplier: CGFloat {
         switch self {
-        case .standard: 1
+        case .automatic, .standard: 1
         case .large: 1.25
         }
     }
 
     var displayName: String {
         switch self {
+        case .automatic: String(localized: "Automatic")
         case .standard: String(localized: "Standard")
         case .large: String(localized: "Large")
         }
@@ -250,7 +259,7 @@ struct AppSettings {
 
     static var expandedPanelScale: ExpandedPanelScale {
         get {
-            ExpandedPanelScale(rawValue: UserDefaults.standard.string(forKey: expandedPanelScaleKey) ?? "") ?? .standard
+            ExpandedPanelScale(rawValue: UserDefaults.standard.string(forKey: expandedPanelScaleKey) ?? "") ?? .automatic
         }
         set { UserDefaults.standard.set(newValue.rawValue, forKey: expandedPanelScaleKey) }
     }

--- a/notchi/notchi/Core/SoundSelector.swift
+++ b/notchi/notchi/Core/SoundSelector.swift
@@ -5,8 +5,7 @@ import Foundation
 final class SoundSelector {
     var isPickerExpanded = false
 
-    func expandedHeight(customSoundCount: Int) -> CGFloat {
-        let soundCount = 1 + customSoundCount + NotificationSound.allCases.count
-        return SettingsLayout.pickerViewportHeight(rowCount: soundCount)
+    func rowCount(customSoundCount: Int) -> Int {
+        1 + customSoundCount + NotificationSound.displayOrder.count
     }
 }

--- a/notchi/notchi/Core/SoundSelector.swift
+++ b/notchi/notchi/Core/SoundSelector.swift
@@ -5,13 +5,8 @@ import Foundation
 final class SoundSelector {
     var isPickerExpanded = false
 
-    private static let rowHeight: CGFloat = 28
-    private static let rowSpacing: CGFloat = 4
-    private static let maxVisibleRows = 6
-
     func expandedHeight(customSoundCount: Int) -> CGFloat {
         let soundCount = 1 + customSoundCount + NotificationSound.allCases.count
-        let visibleCount = min(soundCount, Self.maxVisibleRows)
-        return CGFloat(visibleCount) * Self.rowHeight + CGFloat(visibleCount - 1) * Self.rowSpacing
+        return SettingsLayout.pickerViewportHeight(rowCount: soundCount)
     }
 }

--- a/notchi/notchi/Localizable.xcstrings
+++ b/notchi/notchi/Localizable.xcstrings
@@ -4780,6 +4780,108 @@
           }
         }
       }
+    },
+    "Panel Size" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パネルサイズ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "패널 크기"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kích thước bảng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "面板大小"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "面板大小"
+          }
+        }
+      }
+    },
+    "Standard" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標準"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "표준"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiêu chuẩn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标准"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標準"
+          }
+        }
+      }
+    },
+    "Large" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "크게"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lớn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -26,6 +26,14 @@ enum NotchConstants {
     }
 }
 
+enum PanelTypography {
+    static let enlargedFontScale: CGFloat = 1.125
+
+    static func fontScale(panelScale: CGFloat) -> CGFloat {
+        panelScale > 1 ? enlargedFontScale : 1
+    }
+}
+
 private struct PanelScaleKey: EnvironmentKey {
     static let defaultValue: CGFloat = 1
 }
@@ -56,7 +64,8 @@ struct PanelFontModifier: ViewModifier {
     let transform: (Font) -> Font
 
     func body(content: Content) -> some View {
-        content.font(transform(.system(size: size * panelScale, weight: weight, design: design)))
+        let scaledSize = size * PanelTypography.fontScale(panelScale: panelScale)
+        return content.font(transform(.system(size: scaledSize, weight: weight, design: design)))
     }
 }
 

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -4,6 +4,7 @@ enum NotchConstants {
     static let expandedPanelSize = CGSize(width: 450, height: 450)
     static let expandedPanelHorizontalPadding: CGFloat = 19 * 2
     static let expandedPanelContentInset: CGFloat = 48
+    static let expandedPanelHitTestSlack: CGFloat = 48
     static let expandedPanelVerticalInset: CGFloat = 24
 
     static var expandedPanelContentWidth: CGFloat {
@@ -20,7 +21,7 @@ enum NotchConstants {
 
     static func panelSize(scale: CGFloat) -> CGSize {
         CGSize(
-            width: expandedPanelContentWidth * scale + expandedPanelHorizontalPadding + expandedPanelContentInset,
+            width: expandedPanelContentWidth * scale + expandedPanelHorizontalPadding + expandedPanelHitTestSlack,
             height: scalablePanelHeight * scale + expandedPanelVerticalInset
         )
     }
@@ -46,6 +47,10 @@ extension EnvironmentValues {
 }
 
 extension View {
+    func panelIcon(size: CGFloat, weight: Font.Weight = .regular) -> some View {
+        modifier(PanelIconModifier(size: size, weight: weight))
+    }
+
     func panelFont(
         size: CGFloat,
         weight: Font.Weight = .regular,
@@ -53,6 +58,16 @@ extension View {
         transform: @escaping (Font) -> Font = { $0 }
     ) -> some View {
         modifier(PanelFontModifier(size: size, weight: weight, design: design, transform: transform))
+    }
+}
+
+struct PanelIconModifier: ViewModifier {
+    @Environment(\.panelScale) private var panelScale
+    let size: CGFloat
+    let weight: Font.Weight
+
+    func body(content: Content) -> some View {
+        content.font(.system(size: size * panelScale, weight: weight))
     }
 }
 
@@ -464,7 +479,11 @@ struct NotchContentView: View {
     }
 
     static let islandOnlyPanelHeight: CGFloat = 155
-    static let expandedHeaderRowHeight: CGFloat = 36
+    static let expandedHeaderTopPadding: CGFloat = 4
+
+    static var expandedHeaderRowHeight: CGFloat {
+        PanelHeaderButton.baseSize + expandedHeaderTopPadding
+    }
 
     static func expandedPanelHeight(mode: ExpandedPanelMode, notchHeight: CGFloat) -> CGFloat {
         mode == .islandOnly
@@ -660,7 +679,7 @@ struct NotchContentView: View {
                     Spacer()
                     headerButtons
                 }
-                .padding(.top, 4 * panelScale)
+                .padding(.top, Self.expandedHeaderTopPadding * panelScale)
                 .padding(.horizontal, 8 * panelScale)
                 .environment(\.panelScale, panelScale)
                 .frame(

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -3,6 +3,61 @@ import SwiftUI
 enum NotchConstants {
     static let expandedPanelSize = CGSize(width: 450, height: 450)
     static let expandedPanelHorizontalPadding: CGFloat = 19 * 2
+    static let expandedPanelContentInset: CGFloat = 48
+    static let expandedPanelVerticalInset: CGFloat = 24
+
+    static var expandedPanelContentWidth: CGFloat {
+        expandedPanelSize.width - expandedPanelContentInset
+    }
+
+    static func expandedContentHeight(notchHeight: CGFloat) -> CGFloat {
+        expandedPanelSize.height - notchHeight - expandedPanelVerticalInset
+    }
+
+    static var scalablePanelHeight: CGFloat {
+        expandedPanelSize.height - expandedPanelVerticalInset
+    }
+
+    static func panelSize(scale: CGFloat) -> CGSize {
+        CGSize(
+            width: expandedPanelContentWidth * scale + expandedPanelHorizontalPadding + expandedPanelContentInset,
+            height: scalablePanelHeight * scale + expandedPanelVerticalInset
+        )
+    }
+}
+
+private struct PanelScaleKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 1
+}
+
+extension EnvironmentValues {
+    var panelScale: CGFloat {
+        get { self[PanelScaleKey.self] }
+        set { self[PanelScaleKey.self] = newValue }
+    }
+}
+
+extension View {
+    func panelFont(
+        size: CGFloat,
+        weight: Font.Weight = .regular,
+        design: Font.Design = .default,
+        transform: @escaping (Font) -> Font = { $0 }
+    ) -> some View {
+        modifier(PanelFontModifier(size: size, weight: weight, design: design, transform: transform))
+    }
+}
+
+struct PanelFontModifier: ViewModifier {
+    @Environment(\.panelScale) private var panelScale
+    let size: CGFloat
+    let weight: Font.Weight
+    let design: Font.Design
+    let transform: (Font) -> Font
+
+    func body(content: Content) -> some View {
+        content.font(transform(.system(size: size * panelScale, weight: weight, design: design)))
+    }
 }
 
 extension Notification.Name {
@@ -389,8 +444,8 @@ struct NotchContentView: View {
     }
 
     private var grassHeight: CGFloat {
-        let expandedPanelHeight = NotchConstants.expandedPanelSize.height - notchSize.height - 24
-        return expandedPanelHeight * 0.3 + notchSize.height
+        let contentHeight = NotchConstants.expandedContentHeight(notchHeight: notchSize.height)
+        return (contentHeight * 0.3 + notchSize.height) * panelManager.panelScale
     }
 
     private var shouldShowBackButton: Bool {
@@ -400,12 +455,15 @@ struct NotchContentView: View {
     }
 
     static let islandOnlyPanelHeight: CGFloat = 155
+    static let expandedHeaderRowHeight: CGFloat = 36
 
     static func expandedPanelHeight(mode: ExpandedPanelMode, notchHeight: CGFloat) -> CGFloat {
         mode == .islandOnly
             ? islandOnlyPanelHeight
-            : NotchConstants.expandedPanelSize.height - notchHeight - 24
+            : NotchConstants.expandedContentHeight(notchHeight: notchHeight)
     }
+
+    private var panelScale: CGFloat { panelManager.panelScale }
 
     private var expandedPanelHeight: CGFloat {
         Self.expandedPanelHeight(mode: panelMode, notchHeight: notchSize.height)
@@ -472,9 +530,9 @@ struct NotchContentView: View {
                     }
                 }) {
                     Image(systemName: isActivityCollapsed ? "chevron.down" : "chevron.up")
-                        .font(.system(size: 12, weight: .medium))
+                        .panelFont(size: 12, weight: .medium)
                         .foregroundColor(.white.opacity(0.7))
-                        .padding(8)
+                        .padding(8 * panelScale)
                 }
                 .buttonStyle(.plain)
                 .offset(y: grassHeight - 30)
@@ -546,6 +604,9 @@ struct NotchContentView: View {
                     .frame(height: notchSize.height)
 
                 if isExpanded {
+                    Spacer()
+                        .frame(height: notchSize.height * (panelScale - 1))
+
                     ExpandedPanelView(
                         sessionStore: sessionStore,
                         usageService: usageService,
@@ -558,9 +619,10 @@ struct NotchContentView: View {
                         isActivityCollapsed: $isActivityCollapsed,
                         hoveredSessionId: $hoveredSessionId
                     )
+                    .environment(\.panelScale, panelScale)
                     .frame(
-                        width: NotchConstants.expandedPanelSize.width - 48,
-                        height: expandedPanelHeight
+                        width: NotchConstants.expandedPanelContentWidth * panelScale,
+                        height: expandedPanelHeight * panelScale
                     )
                     .transition(expandedChromeTransition)
                 }
@@ -570,9 +632,9 @@ struct NotchContentView: View {
                 HStack {
                     if shouldShowBackButton {
                         backButton
-                            .padding(.leading, 15)
+                            .padding(.leading, 15 * panelScale)
                     } else {
-                        HStack(spacing: 8) {
+                        HStack(spacing: 8 * panelScale) {
                             PanelHeaderButton(
                                 sfSymbol: panelManager.isPinned ? "pin.fill" : "pin",
                                 action: { panelManager.togglePin() }
@@ -582,21 +644,26 @@ struct NotchContentView: View {
                                 action: toggleMute
                             )
                         }
-                        .padding(.leading, 12)
+                        .padding(.leading, 12 * panelScale)
                     }
                     Spacer()
                     headerButtons
                 }
-                .padding(.top, 4)
-                .padding(.horizontal, 8)
-                .frame(width: NotchConstants.expandedPanelSize.width - 48)
+                .padding(.top, 4 * panelScale)
+                .padding(.horizontal, 8 * panelScale)
+                .environment(\.panelScale, panelScale)
+                .frame(
+                    width: NotchConstants.expandedPanelContentWidth * panelScale,
+                    height: Self.expandedHeaderRowHeight * panelScale,
+                    alignment: .top
+                )
                 .transition(expandedHeaderTransition)
             }
         }
     }
 
     private var headerButtons: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 8 * panelScale) {
             if !showingPanelSettings {
                 PanelHeaderButton(
                     sfSymbol: "gearshape",
@@ -620,11 +687,11 @@ struct NotchContentView: View {
 
     private var backButton: some View {
         Button(action: goBack) {
-            HStack(spacing: 5) {
+            HStack(spacing: 5 * panelScale) {
                 Image(systemName: "chevron.left")
-                    .font(.system(size: 11, weight: .semibold))
+                    .panelFont(size: 11, weight: .semibold)
                 Text("Back")
-                    .font(.system(size: 12, weight: .medium))
+                    .panelFont(size: 12, weight: .medium)
             }
             .foregroundColor(.white.opacity(0.7))
         }

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -500,6 +500,7 @@ struct NotchContentView: View {
                         handoffProgress: spriteHandoffProgress,
                         isHandoffCollapsing: spriteHandoff?.direction == .collapsing
                     )
+                    .environment(\.panelScale, panelScale)
                     .frame(height: grassHeight, alignment: .bottom)
                     .opacity(shouldShowGrassIsland ? 1 : 0)
                     .animation(grassIslandOpacityAnimation, value: shouldShowGrassIsland)
@@ -519,6 +520,7 @@ struct NotchContentView: View {
                         selectGrassSession(sessionId)
                     }
                 )
+                .environment(\.panelScale, panelScale)
                 .frame(height: grassHeight, alignment: .bottom)
             }
         }

--- a/notchi/notchi/Services/NotchPanelManager.swift
+++ b/notchi/notchi/Services/NotchPanelManager.swift
@@ -59,6 +59,7 @@ final class NotchPanelManager {
     private(set) var notchRect: CGRect = .zero
     private(set) var compactNotchRect: CGRect = .zero
     private(set) var panelRect: CGRect = .zero
+    private(set) var panelScale: CGFloat = 1
     /// The exact notch shape from the system bezel path, or nil if unavailable
     private(set) var systemNotchPath: CGPath?
 
@@ -141,12 +142,14 @@ final class NotchPanelManager {
 
         compactNotchRect = Self.makeCompactNotchRect(notchSize: newNotchSize, notchRect: notchRect)
 
-        let panelSize = NotchConstants.expandedPanelSize
-        let panelWidth = panelSize.width + NotchConstants.expandedPanelHorizontalPadding
+        panelScale = AppSettings.expandedPanelScale.multiplier
+        SettingsLayout.scale = panelScale
+
+        let panelSize = NotchConstants.panelSize(scale: panelScale)
         panelRect = CGRect(
-            x: notchCenterX - panelWidth / 2,
+            x: notchCenterX - panelSize.width / 2,
             y: screenFrame.maxY - panelSize.height,
-            width: panelWidth,
+            width: panelSize.width,
             height: panelSize.height
         )
 

--- a/notchi/notchi/Services/NotchPanelManager.swift
+++ b/notchi/notchi/Services/NotchPanelManager.swift
@@ -144,7 +144,9 @@ final class NotchPanelManager {
         compactNotchRect = Self.makeCompactNotchRect(notchSize: newNotchSize, notchRect: notchRect)
 
         visibleScreenHeight = screen.visibleFrame.height
-        panelScale = AppSettings.expandedPanelScale.resolved(visibleScreenHeight: visibleScreenHeight).multiplier
+        panelScale = AppSettings.expandedPanelScale(in: userDefaults)
+            .resolved(visibleScreenHeight: visibleScreenHeight)
+            .multiplier
         SettingsLayout.scale = panelScale
 
         let panelSize = NotchConstants.panelSize(scale: panelScale)

--- a/notchi/notchi/Services/NotchPanelManager.swift
+++ b/notchi/notchi/Services/NotchPanelManager.swift
@@ -60,6 +60,7 @@ final class NotchPanelManager {
     private(set) var compactNotchRect: CGRect = .zero
     private(set) var panelRect: CGRect = .zero
     private(set) var panelScale: CGFloat = 1
+    private(set) var visibleScreenHeight: CGFloat = 0
     /// The exact notch shape from the system bezel path, or nil if unavailable
     private(set) var systemNotchPath: CGPath?
 
@@ -142,7 +143,8 @@ final class NotchPanelManager {
 
         compactNotchRect = Self.makeCompactNotchRect(notchSize: newNotchSize, notchRect: notchRect)
 
-        panelScale = AppSettings.expandedPanelScale.multiplier
+        visibleScreenHeight = screen.visibleFrame.height
+        panelScale = AppSettings.expandedPanelScale.resolved(visibleScreenHeight: visibleScreenHeight).multiplier
         SettingsLayout.scale = panelScale
 
         let panelSize = NotchConstants.panelSize(scale: panelScale)

--- a/notchi/notchi/UI/ActivityRowView.swift
+++ b/notchi/notchi/UI/ActivityRowView.swift
@@ -17,7 +17,7 @@ struct ActivityRowView: View {
 
             if let description = event.description {
                 Text(description)
-                    .font(.system(size: 12).italic())
+                    .panelFont(size: 12) { $0.italic() }
                     .foregroundColor(TerminalColors.dimmedText)
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -43,14 +43,14 @@ struct ActivityRowView: View {
 
     private var toolName: some View {
         Text(event.tool ?? event.type)
-            .font(.system(size: 13, weight: .semibold))
+            .panelFont(size: 13, weight: .semibold)
             .foregroundColor(TerminalColors.primaryText)
     }
 
     private var statusLabel: some View {
         let isSuccess = event.status == .success
         return Text(isSuccess ? String(localized: "Completed") : String(localized: "Failed"))
-            .font(.system(size: 12))
+            .panelFont(size: 12)
             .foregroundColor(isSuccess ? TerminalColors.green : TerminalColors.red)
     }
 }
@@ -212,7 +212,7 @@ struct QuestionPromptView: View {
             optionsList
             if let responseHint {
                 Text(responseHint)
-                    .font(.system(size: 10, weight: .medium).italic())
+                    .panelFont(size: 10, weight: .medium) { $0.italic() }
                     .foregroundColor(TerminalColors.secondaryText)
                     .padding(.top, 7)
                     .modifier(QuestionHintShake(animatableData: responseHintShakePhase))
@@ -240,7 +240,7 @@ struct QuestionPromptView: View {
         HStack {
             if let header = current.header {
                 Text(header)
-                    .font(.system(size: 10, weight: .semibold))
+                    .panelFont(size: 10, weight: .semibold)
                     .foregroundColor(accentColor)
                     .textCase(.uppercase)
                     .tracking(0.5)
@@ -248,7 +248,7 @@ struct QuestionPromptView: View {
 
             if hasMultipleQuestions {
                 Text("(\(clampedIndex + 1)/\(questions.count))")
-                    .font(.system(size: 10, weight: .medium).monospacedDigit())
+                    .panelFont(size: 10, weight: .medium) { $0.monospacedDigit() }
                     .foregroundColor(TerminalColors.secondaryText)
             }
 
@@ -264,7 +264,7 @@ struct QuestionPromptView: View {
         HStack(spacing: 2) {
             Button(action: { showQuestion(at: currentIndex - 1) }) {
                 Image(systemName: "chevron.left")
-                    .font(.system(size: 9, weight: .semibold))
+                    .panelFont(size: 9, weight: .semibold)
                     .foregroundColor(currentIndex > 0 ? TerminalColors.primaryText : TerminalColors.dimmedText)
             }
             .buttonStyle(.plain)
@@ -272,7 +272,7 @@ struct QuestionPromptView: View {
 
             Button(action: { showQuestion(at: currentIndex + 1) }) {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 9, weight: .semibold))
+                    .panelFont(size: 9, weight: .semibold)
                     .foregroundColor(currentIndex < questions.count - 1 ? TerminalColors.primaryText : TerminalColors.dimmedText)
             }
             .buttonStyle(.plain)
@@ -282,7 +282,7 @@ struct QuestionPromptView: View {
 
     private var questionText: some View {
         Text(current.question)
-            .font(.system(size: 12, weight: .medium))
+            .panelFont(size: 12, weight: .medium)
             .foregroundColor(TerminalColors.primaryText)
             .fixedSize(horizontal: false, vertical: true)
     }
@@ -358,7 +358,7 @@ struct QuestionPromptView: View {
 
         return HStack(alignment: .center, spacing: 9) {
             Text("\(index + 1)")
-                .font(.system(size: 9, weight: .semibold).monospacedDigit())
+                .panelFont(size: 9, weight: .semibold) { $0.monospacedDigit() }
                 .foregroundColor(TerminalColors.primaryText.opacity(0.82))
                 .frame(width: 20, height: 20)
                 .background(
@@ -368,7 +368,7 @@ struct QuestionPromptView: View {
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(option.label)
-                    .font(.system(size: 11, weight: .medium))
+                    .panelFont(size: 11, weight: .medium)
                     .foregroundColor(TerminalColors.primaryText)
 
                 InlineAnswerTextField(text: Binding(
@@ -389,7 +389,7 @@ struct QuestionPromptView: View {
                 submitFreeTextAnswer(answer, for: questionIndex)
             } label: {
                 Image(systemName: "arrow.turn.down.left")
-                    .font(.system(size: 9, weight: .semibold))
+                    .panelFont(size: 9, weight: .semibold)
                     .foregroundColor(isSelected ? TerminalColors.primaryText : TerminalColors.dimmedText)
                     .frame(width: 20, height: 20)
             }
@@ -433,7 +433,7 @@ struct QuestionPromptView: View {
 
         return HStack(alignment: .center, spacing: 9) {
             Text("\(index + 1)")
-                .font(.system(size: 9, weight: .semibold).monospacedDigit())
+                .panelFont(size: 9, weight: .semibold) { $0.monospacedDigit() }
                 .foregroundColor(TerminalColors.primaryText.opacity(0.82))
                 .frame(width: 20, height: 20)
                 .background(
@@ -443,11 +443,11 @@ struct QuestionPromptView: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(option.label)
-                    .font(.system(size: 11, weight: .medium))
+                    .panelFont(size: 11, weight: .medium)
                     .foregroundColor(TerminalColors.primaryText)
                 if let description = option.description {
                     Text(description)
-                        .font(.system(size: 10))
+                        .panelFont(size: 10)
                         .foregroundColor(TerminalColors.secondaryText)
                         .lineLimit(2)
                 }
@@ -703,17 +703,17 @@ struct QuestionPromptView: View {
     ) -> some View {
         HStack(alignment: .top, spacing: 6) {
             Text("\(index + 1).")
-                .font(.system(size: 11, weight: .semibold).monospacedDigit())
+                .panelFont(size: 11, weight: .semibold) { $0.monospacedDigit() }
                 .foregroundColor(accentColor)
                 .frame(width: 16, alignment: .trailing)
 
             VStack(alignment: .leading, spacing: 1) {
                 Text(option.label)
-                    .font(.system(size: 11, weight: .medium))
+                    .panelFont(size: 11, weight: .medium)
                     .foregroundColor(TerminalColors.primaryText)
                 if let description = option.description {
                     Text(description)
-                        .font(.system(size: 10))
+                        .panelFont(size: 10)
                         .foregroundColor(TerminalColors.dimmedText)
                         .lineLimit(2)
                 }
@@ -775,12 +775,12 @@ struct WorkingIndicatorView: View {
     var body: some View {
         HStack(spacing: 3) {
             Text(displaySymbol)
-                .font(.system(size: 14, weight: .bold))
+                .panelFont(size: 14, weight: .bold)
                 .foregroundColor(color)
                 .frame(width: 14, alignment: .center)
             ShimmeringText(
                 text: displayText,
-                font: .system(size: 12, weight: .medium).italic(),
+                fontSize: 12,
                 color: color,
                 isEnabled: state.task != .waiting
             )
@@ -798,7 +798,7 @@ struct WorkingIndicatorView: View {
 
 private struct ShimmeringText: View {
     let text: String
-    let font: Font
+    let fontSize: CGFloat
     let color: Color
     let isEnabled: Bool
 
@@ -818,14 +818,14 @@ private struct ShimmeringText: View {
 
     var body: some View {
         Text(text)
-            .font(font)
+            .panelFont(size: fontSize, weight: .medium) { $0.italic() }
             .foregroundColor(color)
             .overlay(alignment: .leading) {
                 if shimmerActive {
                     shimmerSweep
                         .mask(
                             Text(text)
-                                .font(font)
+                                .panelFont(size: fontSize, weight: .medium) { $0.italic() }
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         )
                 }

--- a/notchi/notchi/UI/ActivityRowView.swift
+++ b/notchi/notchi/UI/ActivityRowView.swift
@@ -56,9 +56,16 @@ struct ActivityRowView: View {
 }
 
 private struct InlineAnswerTextField: NSViewRepresentable {
+    static let baseFontSize: CGFloat = 10
+
     @Binding var text: String
     let isFocused: Bool
+    let panelScale: CGFloat
     let onSubmit: (String) -> Void
+
+    private var scaledFontSize: CGFloat {
+        Self.baseFontSize * PanelTypography.fontScale(panelScale: panelScale)
+    }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
@@ -77,7 +84,7 @@ private struct InlineAnswerTextField: NSViewRepresentable {
         textField.drawsBackground = false
         textField.focusRingType = .none
         textField.placeholderString = String(localized: "Type answer")
-        textField.font = .systemFont(ofSize: 10)
+        textField.font = .systemFont(ofSize: scaledFontSize)
         textField.textColor = .white
         textField.lineBreakMode = .byTruncatingTail
         textField.cell?.usesSingleLineMode = true
@@ -88,6 +95,7 @@ private struct InlineAnswerTextField: NSViewRepresentable {
 
     func updateNSView(_ textField: NSTextField, context: Context) {
         context.coordinator.parent = self
+        textField.font = .systemFont(ofSize: scaledFontSize)
         if let textField = textField as? SubmittingTextField {
             textField.onSubmitText = { submittedText in
                 context.coordinator.submit(submittedText)
@@ -165,6 +173,8 @@ private struct InlineAnswerTextField: NSViewRepresentable {
 }
 
 struct QuestionPromptView: View {
+    @Environment(\.panelScale) private var panelScale
+
     let questions: [PendingQuestion]
     let provider: AgentProvider
     let responseHint: String?
@@ -377,10 +387,10 @@ struct QuestionPromptView: View {
                         customAnswersByQuestion[questionIndex] = newValue
                         selectedOptionIndexesByQuestion[questionIndex] = nil
                     }
-                ), isFocused: focusedFreeTextQuestionIndex == questionIndex) { submittedText in
+                ), isFocused: focusedFreeTextQuestionIndex == questionIndex, panelScale: panelScale) { submittedText in
                     submitFreeTextAnswer(submittedText, for: questionIndex)
                 }
-                .frame(height: 14)
+                .frame(height: 14 * PanelTypography.fontScale(panelScale: panelScale))
             }
 
             Spacer(minLength: 8)

--- a/notchi/notchi/UI/AssistantTextRowView.swift
+++ b/notchi/notchi/UI/AssistantTextRowView.swift
@@ -31,7 +31,7 @@ struct AssistantTextRowView: View {
 
             if isTruncatable {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 12, weight: .semibold))
+                    .panelFont(size: 12, weight: .semibold)
                     .foregroundColor(TerminalColors.secondaryText)
                     .rotationEffect(.degrees(isExpanded ? 90 : 0))
             }
@@ -54,7 +54,7 @@ struct AssistantTextRowView: View {
             options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
         )
         return Text(attributed ?? AttributedString(truncatedText))
-            .font(.system(size: 13))
+            .panelFont(size: 13)
             .foregroundColor(.white)
             .lineLimit(2)
             .multilineTextAlignment(.leading)

--- a/notchi/notchi/UI/MarkdownRenderer.swift
+++ b/notchi/notchi/UI/MarkdownRenderer.swift
@@ -7,6 +7,8 @@ struct MarkdownText: View {
     let baseColor: Color
     let fontSize: CGFloat
 
+    @Environment(\.panelScale) private var panelScale
+
     init(_ text: String, color: Color = .white, fontSize: CGFloat = 13) {
         self.text = text
         self.baseColor = color
@@ -32,7 +34,7 @@ struct MarkdownText: View {
         case .unorderedListItem(let content):
             HStack(alignment: .top, spacing: 6) {
                 SwiftUI.Text("\u{2022}")
-                    .font(.system(size: fontSize))
+                    .panelFont(size: fontSize)
                     .foregroundColor(baseColor.opacity(0.6))
                     .frame(width: 12, alignment: .center)
                 inlineMarkdownText(content)
@@ -41,7 +43,7 @@ struct MarkdownText: View {
         case .orderedListItem(let number, let content):
             HStack(alignment: .top, spacing: 6) {
                 SwiftUI.Text("\(number).")
-                    .font(.system(size: fontSize))
+                    .panelFont(size: fontSize)
                     .foregroundColor(baseColor.opacity(0.6))
                     .frame(width: 20, alignment: .trailing)
                 inlineMarkdownText(content)
@@ -61,7 +63,7 @@ struct MarkdownText: View {
         case .codeBlock(let code):
             ScrollView(.horizontal, showsIndicators: false) {
                 SwiftUI.Text(code)
-                    .font(.system(size: 11, design: .monospaced))
+                    .panelFont(size: 11, design: .monospaced)
                     .foregroundColor(.white.opacity(0.85))
                     .padding(10)
             }
@@ -77,7 +79,7 @@ struct MarkdownText: View {
             options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
         )
         return SwiftUI.Text(attributed ?? AttributedString(content))
-            .font(.system(size: fontSize))
+            .font(.system(size: fontSize * panelScale))
             .foregroundColor(baseColor)
     }
 }

--- a/notchi/notchi/UI/MarkdownRenderer.swift
+++ b/notchi/notchi/UI/MarkdownRenderer.swift
@@ -79,7 +79,7 @@ struct MarkdownText: View {
             options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
         )
         return SwiftUI.Text(attributed ?? AttributedString(content))
-            .font(.system(size: fontSize * panelScale))
+            .font(.system(size: fontSize * PanelTypography.fontScale(panelScale: panelScale)))
             .foregroundColor(baseColor)
     }
 }

--- a/notchi/notchi/UI/ProcessingSpinner.swift
+++ b/notchi/notchi/UI/ProcessingSpinner.swift
@@ -14,7 +14,7 @@ struct ProcessingSpinner: View {
 
     var body: some View {
         Text(symbols[phase % symbols.count])
-            .font(.system(size: 12, weight: .bold))
+            .panelFont(size: 12, weight: .bold)
             .foregroundColor(color)
             .frame(width: 12, alignment: .center)
             .onReceive(timer) { _ in

--- a/notchi/notchi/UI/ToolArgumentsView.swift
+++ b/notchi/notchi/UI/ToolArgumentsView.swift
@@ -12,12 +12,12 @@ struct ToolArgumentsView: View {
             ForEach(sortedKeys, id: \.self) { key in
                 HStack(alignment: .top, spacing: 8) {
                     Text(key)
-                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .panelFont(size: 11, weight: .medium, design: .monospaced)
                         .foregroundColor(TerminalColors.secondaryText)
                         .frame(minWidth: 60, alignment: .leading)
 
                     Text(formatValue(arguments[key]))
-                        .font(.system(size: 11, design: .monospaced))
+                        .panelFont(size: 11, design: .monospaced)
                         .foregroundColor(TerminalColors.primaryText)
                         .lineLimit(3)
                 }

--- a/notchi/notchi/UI/UserPromptBubbleView.swift
+++ b/notchi/notchi/UI/UserPromptBubbleView.swift
@@ -6,7 +6,7 @@ struct UserPromptBubbleView: View {
 
     var body: some View {
         promptText
-            .font(.system(size: 13))
+            .panelFont(size: 13)
             .foregroundColor(.white)
             .padding(.horizontal, 14)
             .padding(.vertical, 10)

--- a/notchi/notchi/Views/Components/ScreenPickerRow.swift
+++ b/notchi/notchi/Views/Components/ScreenPickerRow.swift
@@ -19,23 +19,23 @@ struct ScreenPickerRow: View {
         }) {
             HStack {
                 Image(systemName: "display")
-                    .font(.system(size: 12))
+                    .panelFont(size: 12)
                     .foregroundColor(TerminalColors.secondaryText)
                     .frame(width: 20)
 
                 Text("Screen")
-                    .font(.system(size: 12))
+                    .panelFont(size: 12)
                     .foregroundColor(TerminalColors.primaryText)
 
                 Spacer()
 
                 HStack(spacing: 4) {
                     Text(currentSelectionLabel)
-                        .font(.system(size: 11))
+                        .panelFont(size: 11)
                         .foregroundColor(TerminalColors.secondaryText)
                         .lineLimit(1)
                     Image(systemName: screenSelector.isPickerExpanded ? "chevron.up" : "chevron.down")
-                        .font(.system(size: 9))
+                        .panelFont(size: 9)
                         .foregroundColor(TerminalColors.dimmedText)
                 }
             }
@@ -90,12 +90,12 @@ struct ScreenPickerRow: View {
 
                 VStack(alignment: .leading, spacing: 1) {
                     Text(label)
-                        .font(.system(size: 11))
+                        .panelFont(size: 11)
                         .foregroundColor(isSelected ? TerminalColors.primaryText : TerminalColors.secondaryText)
 
                     if let sublabel = sublabel {
                         Text(sublabel)
-                            .font(.system(size: 9))
+                            .panelFont(size: 9)
                             .foregroundColor(TerminalColors.dimmedText)
                     }
                 }
@@ -104,7 +104,7 @@ struct ScreenPickerRow: View {
 
                 if isSelected {
                     Image(systemName: "checkmark")
-                        .font(.system(size: 10, weight: .bold))
+                        .panelFont(size: 10, weight: .bold)
                         .foregroundColor(TerminalColors.green)
                 }
             }

--- a/notchi/notchi/Views/Components/ShortcutRecorderView.swift
+++ b/notchi/notchi/Views/Components/ShortcutRecorderView.swift
@@ -20,7 +20,7 @@ struct ShortcutRecorderView: View {
             if shortcut != .defaultTogglePanel {
                 Button(action: resetShortcut) {
                     Image(systemName: "arrow.counterclockwise")
-                        .font(.system(size: 10, weight: .semibold))
+                        .panelFont(size: 10, weight: .semibold)
                         .foregroundColor(TerminalColors.dimmedText)
                         .frame(width: 18, height: 18)
                 }
@@ -30,7 +30,7 @@ struct ShortcutRecorderView: View {
 
             Button(action: beginRecording) {
                 Text(buttonText)
-                    .font(.system(size: 10, weight: .medium))
+                    .panelFont(size: 10, weight: .medium)
                     .foregroundColor(buttonForeground)
                     .lineLimit(1)
                     .padding(.horizontal, 7)

--- a/notchi/notchi/Views/Components/SoundPickerView.swift
+++ b/notchi/notchi/Views/Components/SoundPickerView.swift
@@ -45,22 +45,22 @@ struct SoundPickerView: View {
         }) {
             HStack {
                 Image(systemName: "speaker.wave.2")
-                    .font(.system(size: 12))
+                    .panelFont(size: 12)
                     .foregroundColor(TerminalColors.secondaryText)
                     .frame(width: 20)
 
                 Text("Notification Sound")
-                    .font(.system(size: 12))
+                    .panelFont(size: 12)
                     .foregroundColor(TerminalColors.primaryText)
 
                 Spacer()
 
                 HStack(spacing: 4) {
                     Text(AppSettings.isMuted ? String(localized: "Muted") : selectedSound.displayName(customSounds: customSounds))
-                        .font(.system(size: 11))
+                        .panelFont(size: 11)
                         .foregroundColor(TerminalColors.secondaryText)
                     Image(systemName: selector.isPickerExpanded ? "chevron.up" : "chevron.down")
-                        .font(.system(size: 9))
+                        .panelFont(size: 9)
                         .foregroundColor(TerminalColors.dimmedText)
                 }
             }
@@ -95,12 +95,12 @@ struct SoundPickerView: View {
         Button(action: addCustomSound) {
             HStack {
                 Image(systemName: "plus")
-                    .font(.system(size: 10, weight: .medium))
+                    .panelFont(size: 10, weight: .medium)
                     .foregroundColor(TerminalColors.green)
                     .frame(width: 6, height: 6)
 
                 Text("Add")
-                    .font(.system(size: 11))
+                    .panelFont(size: 11)
                     .foregroundColor(TerminalColors.primaryText)
 
                 Spacer()
@@ -123,14 +123,14 @@ struct SoundPickerView: View {
                     .frame(width: 6, height: 6)
 
                 Text(sound.displayName)
-                    .font(.system(size: 11))
+                    .panelFont(size: 11)
                     .foregroundColor(selectedSound == .system(sound) ? TerminalColors.primaryText : TerminalColors.secondaryText)
 
                 Spacer()
 
                 if sound != .none {
                     Image(systemName: "speaker.wave.1")
-                        .font(.system(size: 9))
+                        .panelFont(size: 9)
                         .foregroundColor(TerminalColors.dimmedText)
                 }
             }
@@ -153,7 +153,7 @@ struct SoundPickerView: View {
 
                     TextField("", text: $editingSoundName)
                         .textFieldStyle(.plain)
-                        .font(.system(size: 11))
+                        .panelFont(size: 11)
                         .foregroundColor(TerminalColors.primaryText)
                         .accessibilityIdentifier(renameAccessibilityIdentifier(for: sound.id))
                         .focused($focusedRenameSoundID, equals: sound.id)
@@ -176,7 +176,7 @@ struct SoundPickerView: View {
                             .frame(width: 6, height: 6)
 
                         Text(sound.displayName)
-                            .font(.system(size: 11))
+                            .panelFont(size: 11)
                             .lineLimit(1)
                             .foregroundColor(selectedSound == .custom(sound.id) ? TerminalColors.primaryText : TerminalColors.secondaryText)
 
@@ -191,7 +191,7 @@ struct SoundPickerView: View {
                 beginInlineRename(sound)
             }) {
                 Image(systemName: "pencil")
-                    .font(.system(size: 9))
+                    .panelFont(size: 9)
                     .foregroundColor(TerminalColors.dimmedText)
                     .frame(width: 16, height: 16)
             }
@@ -201,7 +201,7 @@ struct SoundPickerView: View {
                 deleteCustomSound(sound)
             }) {
                 Image(systemName: "trash")
-                    .font(.system(size: 9))
+                    .panelFont(size: 9)
                     .foregroundColor(TerminalColors.dimmedText)
                     .frame(width: 16, height: 16)
             }

--- a/notchi/notchi/Views/Components/SoundPickerView.swift
+++ b/notchi/notchi/Views/Components/SoundPickerView.swift
@@ -71,24 +71,17 @@ struct SoundPickerView: View {
     }
 
     private var expandedPicker: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: SettingsLayout.pickerRowSpacing) {
-                addCustomSoundRow
+        SettingsPicker(rowCount: selector.rowCount(customSoundCount: customSounds.count)) {
+            addCustomSoundRow
 
-                ForEach(customSounds) { sound in
-                    customSoundRow(sound)
-                }
-
-                ForEach(NotificationSound.displayOrder, id: \.self) { sound in
-                    soundRow(sound)
-                }
+            ForEach(customSounds) { sound in
+                customSoundRow(sound)
             }
-            .padding(.vertical, SettingsLayout.pickerInset)
+
+            ForEach(NotificationSound.displayOrder, id: \.self) { sound in
+                soundRow(sound)
+            }
         }
-        .frame(height: selector.expandedHeight(customSoundCount: customSounds.count))
-        .background(TerminalColors.subtleBackground)
-        .cornerRadius(8)
-        .padding(.top, SettingsLayout.pickerInset)
     }
 
     private var addCustomSoundRow: some View {

--- a/notchi/notchi/Views/Components/SoundPickerView.swift
+++ b/notchi/notchi/Views/Components/SoundPickerView.swift
@@ -72,7 +72,7 @@ struct SoundPickerView: View {
 
     private var expandedPicker: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: SettingsLayout.pickerRowSpacing) {
                 addCustomSoundRow
 
                 ForEach(customSounds) { sound in

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -65,12 +65,12 @@ struct CostDashboardView: View {
                 chart(report)
                 if report.entries.contains(where: { $0.requestCount > 0 && $0.pricedFraction < 1 }) {
                     Text("Some models lack pricing — cost is partial")
-                        .font(.caption2)
+                        .panelFont(size: 10)
                         .foregroundStyle(.orange)
                 }
             } else {
                 Text("Scanning usage…")
-                    .font(.system(size: 13, weight: .semibold))
+                    .panelFont(size: 13, weight: .semibold)
                     .foregroundStyle(TerminalColors.secondaryText)
                     .frame(maxWidth: .infinity)
                     .frame(height: Self.statRowHeight + Self.sectionSpacing + Self.chartHeight)
@@ -158,9 +158,9 @@ struct CostDashboardView: View {
 
     private func stat(_ title: String, _ value: String, valueSize: CGFloat) -> some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(title).font(.caption2).foregroundStyle(TerminalColors.secondaryText)
+            Text(title).panelFont(size: 10).foregroundStyle(TerminalColors.secondaryText)
                 .lineLimit(1)
-            Text(value).font(.system(size: valueSize, weight: .semibold))
+            Text(value).panelFont(size: valueSize, weight: .semibold)
                 .foregroundStyle(TerminalColors.primaryText)
                 .lineLimit(1)
         }
@@ -257,7 +257,7 @@ struct CostDashboardView: View {
                 HStack(spacing: 4) {
                     Circle().fill(row.color).frame(width: 6, height: 6)
                     Text(row.label)
-                        .font(.caption2)
+                        .panelFont(size: 10)
                         .foregroundStyle(TerminalColors.primaryText)
                         .lineLimit(1)
                 }

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -50,7 +50,11 @@ struct CostDashboardView: View {
     var sizingPeerReports: [DailyCostReport] = []
     var combinesProviders = false
 
+    @Environment(\.panelScale) private var panelScale
     @State private var selected: DailyCostReport.DayEntry?
+
+    private var scaledChartHeight: CGFloat { Self.chartHeight * panelScale }
+    private var scaledStatRowHeight: CGFloat { Self.statRowHeight * panelScale }
 
     private func currentEntry(_ r: DailyCostReport) -> DailyCostReport.DayEntry? {
         selected.flatMap { s in r.entries.first { $0.id == s.id } }
@@ -73,7 +77,7 @@ struct CostDashboardView: View {
                     .panelFont(size: 13, weight: .semibold)
                     .foregroundStyle(TerminalColors.secondaryText)
                     .frame(maxWidth: .infinity)
-                    .frame(height: Self.statRowHeight + Self.sectionSpacing + Self.chartHeight)
+                    .frame(height: scaledStatRowHeight + Self.sectionSpacing + scaledChartHeight)
             }
         }
     }
@@ -135,7 +139,7 @@ struct CostDashboardView: View {
                 }
             }
         }
-        .frame(height: Self.statRowHeight)
+        .frame(height: scaledStatRowHeight)
     }
 
     private static let statRowHeight: CGFloat = 34
@@ -272,7 +276,7 @@ struct CostDashboardView: View {
     }
 
     @ViewBuilder private func chart(_ r: DailyCostReport) -> some View {
-        let gap = (r.entries.map(\.costUSD).max() ?? 0) * Self.segmentGapPixels / Self.chartHeight
+        let gap = (r.entries.map(\.costUSD).max() ?? 0) * Self.segmentGapPixels / scaledChartHeight
         Chart(r.entries) { e in
             ForEach(Self.stackedSegments(e, gap: gap)) { s in
                 BarMark(
@@ -287,7 +291,7 @@ struct CostDashboardView: View {
         .chartYAxis(.hidden)
         .chartLegend(.hidden)
         .animation(.easeOut(duration: 0.15), value: selected)
-        .frame(height: Self.chartHeight)
+        .frame(height: scaledChartHeight)
         .chartOverlay { proxy in
             GeometryReader { geo in
                 Rectangle()

--- a/notchi/notchi/Views/EmotionAnalysisSettingsView.swift
+++ b/notchi/notchi/Views/EmotionAnalysisSettingsView.swift
@@ -93,18 +93,11 @@ struct EmotionAnalysisSettingsView: View {
     }
 
     private var providerPicker: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: SettingsLayout.pickerRowSpacing) {
-                ForEach(EmotionAnalysisProvider.allCases) { option in
-                    providerRow(option)
-                }
+        SettingsPicker(rowCount: EmotionAnalysisProvider.allCases.count) {
+            ForEach(EmotionAnalysisProvider.allCases) { option in
+                providerRow(option)
             }
-            .padding(.vertical, SettingsLayout.pickerInset)
         }
-        .frame(height: SettingsLayout.pickerViewportHeight(rowCount: EmotionAnalysisProvider.allCases.count))
-        .background(TerminalColors.subtleBackground)
-        .cornerRadius(8)
-        .padding(.top, SettingsLayout.pickerInset)
     }
 
     private func providerRow(_ option: EmotionAnalysisProvider) -> some View {
@@ -348,18 +341,11 @@ struct EmotionAnalysisSettingsView: View {
     }
 
     private var modelPicker: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: SettingsLayout.pickerRowSpacing) {
-                ForEach(EmotionAnalysisModel.models(for: provider)) { option in
-                    modelRow(option)
-                }
+        SettingsPicker(rowCount: EmotionAnalysisModel.models(for: provider).count) {
+            ForEach(EmotionAnalysisModel.models(for: provider)) { option in
+                modelRow(option)
             }
-            .padding(.vertical, SettingsLayout.pickerInset)
         }
-        .frame(height: SettingsLayout.pickerViewportHeight(rowCount: EmotionAnalysisModel.models(for: provider).count))
-        .background(TerminalColors.subtleBackground)
-        .cornerRadius(8)
-        .padding(.top, SettingsLayout.pickerInset)
     }
 
     private func modelRow(_ option: EmotionAnalysisModel) -> some View {

--- a/notchi/notchi/Views/EmotionAnalysisSettingsView.swift
+++ b/notchi/notchi/Views/EmotionAnalysisSettingsView.swift
@@ -62,7 +62,7 @@ struct EmotionAnalysisSettingsView: View {
 
     private var descriptionSection: some View {
         Text("Prompts are sent to the selected provider for emotion classification.")
-            .font(.system(size: 11))
+            .panelFont(size: 11)
             .foregroundColor(TerminalColors.secondaryText)
             .fixedSize(horizontal: false, vertical: true)
     }
@@ -76,10 +76,10 @@ struct EmotionAnalysisSettingsView: View {
                 SettingsRowView(icon: "switch.2", title: "Provider") {
                     HStack(spacing: 4) {
                         Text(provider.displayName)
-                            .font(.system(size: 11))
+                            .panelFont(size: 11)
                             .foregroundColor(TerminalColors.secondaryText)
                         Image(systemName: isProviderPickerExpanded ? "chevron.up" : "chevron.down")
-                            .font(.system(size: 9))
+                            .panelFont(size: 9)
                             .foregroundColor(TerminalColors.dimmedText)
                     }
                 }
@@ -115,7 +115,7 @@ struct EmotionAnalysisSettingsView: View {
                     .frame(width: 6, height: 6)
 
                 Text(option.displayName)
-                    .font(.system(size: 11, weight: .medium))
+                    .panelFont(size: 11, weight: .medium)
                     .foregroundColor(provider == option ? TerminalColors.primaryText : TerminalColors.secondaryText)
                     .lineLimit(1)
 
@@ -133,12 +133,12 @@ struct EmotionAnalysisSettingsView: View {
     private var apiKeySection: some View {
         HStack {
             Image(systemName: "key")
-                .font(.system(size: 12))
+                .panelFont(size: 12)
                 .foregroundColor(TerminalColors.secondaryText)
                 .frame(width: 20)
 
             Text("API Key")
-                .font(.system(size: 12))
+                .panelFont(size: 12)
                 .foregroundColor(TerminalColors.primaryText)
                 .layoutPriority(1)
 
@@ -162,7 +162,7 @@ struct EmotionAnalysisSettingsView: View {
             ZStack(alignment: .leading) {
                 SecureField("", text: $apiKeyInput)
                     .textFieldStyle(.plain)
-                    .font(.system(size: 11, design: .monospaced))
+                    .panelFont(size: 11, design: .monospaced)
                     .foregroundColor(TerminalColors.primaryText)
                     .padding(.horizontal, SettingsLayout.fieldHorizontalPadding)
                     .padding(.vertical, SettingsLayout.fieldVerticalPadding)
@@ -173,7 +173,7 @@ struct EmotionAnalysisSettingsView: View {
 
                 if apiKeyInput.isEmpty {
                     Text(provider.apiKeyPlaceholder)
-                        .font(.system(size: 11, design: .monospaced))
+                        .panelFont(size: 11, design: .monospaced)
                         .foregroundColor(TerminalColors.dimmedText)
                         .padding(.leading, SettingsLayout.fieldHorizontalPadding)
                         .allowsHitTesting(false)
@@ -186,7 +186,7 @@ struct EmotionAnalysisSettingsView: View {
                 saveApiKey(for: provider)
             }) {
                 Image(systemName: hasApiKey ? "checkmark.circle.fill" : "arrow.right.circle")
-                    .font(.system(size: 14))
+                    .panelFont(size: 14)
                     .foregroundColor(hasApiKey ? TerminalColors.green : TerminalColors.dimmedText)
             }
             .buttonStyle(.plain)
@@ -196,12 +196,12 @@ struct EmotionAnalysisSettingsView: View {
     private var baseURLSection: some View {
         HStack {
             Image(systemName: "link")
-                .font(.system(size: 12))
+                .panelFont(size: 12)
                 .foregroundColor(TerminalColors.secondaryText)
                 .frame(width: 20)
 
             Text("Base URL")
-                .font(.system(size: 12))
+                .panelFont(size: 12)
                 .foregroundColor(TerminalColors.primaryText)
                 .layoutPriority(1)
 
@@ -216,7 +216,7 @@ struct EmotionAnalysisSettingsView: View {
         ZStack(alignment: .leading) {
             TextField("", text: $baseURLInput)
                 .textFieldStyle(.plain)
-                .font(.system(size: 11, design: .monospaced))
+                .panelFont(size: 11, design: .monospaced)
                 .foregroundColor(TerminalColors.primaryText)
                 .padding(.horizontal, SettingsLayout.fieldHorizontalPadding)
                 .padding(.vertical, SettingsLayout.fieldVerticalPadding)
@@ -227,7 +227,7 @@ struct EmotionAnalysisSettingsView: View {
 
             if baseURLInput.isEmpty {
                 Text(provider.apiBaseURLPlaceholder)
-                    .font(.system(size: 11, design: .monospaced))
+                    .panelFont(size: 11, design: .monospaced)
                     .foregroundColor(TerminalColors.dimmedText)
                     .padding(.leading, SettingsLayout.fieldHorizontalPadding)
                     .allowsHitTesting(false)
@@ -240,7 +240,7 @@ struct EmotionAnalysisSettingsView: View {
         Button(action: openAPIKeyPage) {
             SettingsRowView(icon: "arrow.up.right.square", title: "Get API Key") {
                 Image(systemName: "arrow.up.right")
-                    .font(.system(size: 10))
+                    .panelFont(size: 10)
                     .foregroundColor(TerminalColors.dimmedText)
             }
             .background(
@@ -281,7 +281,7 @@ struct EmotionAnalysisSettingsView: View {
         case .idle:
             if canTest {
                 Image(systemName: "play.circle")
-                    .font(.system(size: 13))
+                    .panelFont(size: 13)
                     .foregroundColor(TerminalColors.dimmedText)
             } else {
                 statusBadge(String(localized: "Missing key"), color: TerminalColors.red)
@@ -292,7 +292,7 @@ struct EmotionAnalysisSettingsView: View {
                 .frame(width: 16, height: 16)
         case .success:
             Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 13))
+                .panelFont(size: 13)
                 .foregroundColor(TerminalColors.green)
         case .failure(let message):
             statusBadge(message, color: TerminalColors.red)
@@ -315,7 +315,7 @@ struct EmotionAnalysisSettingsView: View {
 
     private func testDetailText(_ text: String) -> some View {
         Text(text)
-            .font(.system(size: 10))
+            .panelFont(size: 10)
             .foregroundColor(TerminalColors.dimmedText)
             .lineLimit(1)
             .truncationMode(.tail)
@@ -331,10 +331,10 @@ struct EmotionAnalysisSettingsView: View {
                 SettingsRowView(icon: "cpu", title: "Model") {
                     HStack(spacing: 4) {
                         Text(model.displayName)
-                            .font(.system(size: 11))
+                            .panelFont(size: 11)
                             .foregroundColor(TerminalColors.secondaryText)
                         Image(systemName: isModelPickerExpanded ? "chevron.up" : "chevron.down")
-                            .font(.system(size: 9))
+                            .panelFont(size: 9)
                             .foregroundColor(TerminalColors.dimmedText)
                     }
                 }
@@ -370,7 +370,7 @@ struct EmotionAnalysisSettingsView: View {
                     .frame(width: 6, height: 6)
 
                 Text(option.displayName)
-                    .font(.system(size: 11, weight: .medium))
+                    .panelFont(size: 11, weight: .medium)
                     .foregroundColor(model == option ? TerminalColors.primaryText : TerminalColors.secondaryText)
                     .lineLimit(1)
 

--- a/notchi/notchi/Views/EmotionAnalysisSettingsView.swift
+++ b/notchi/notchi/Views/EmotionAnalysisSettingsView.swift
@@ -94,14 +94,14 @@ struct EmotionAnalysisSettingsView: View {
 
     private var providerPicker: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: SettingsLayout.pickerRowSpacing) {
                 ForEach(EmotionAnalysisProvider.allCases) { option in
                     providerRow(option)
                 }
             }
             .padding(.vertical, SettingsLayout.pickerInset)
         }
-        .frame(height: pickerHeight(optionCount: EmotionAnalysisProvider.allCases.count))
+        .frame(height: SettingsLayout.pickerViewportHeight(rowCount: EmotionAnalysisProvider.allCases.count))
         .background(TerminalColors.subtleBackground)
         .cornerRadius(8)
         .padding(.top, SettingsLayout.pickerInset)
@@ -349,14 +349,14 @@ struct EmotionAnalysisSettingsView: View {
 
     private var modelPicker: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: SettingsLayout.pickerRowSpacing) {
                 ForEach(EmotionAnalysisModel.models(for: provider)) { option in
                     modelRow(option)
                 }
             }
             .padding(.vertical, SettingsLayout.pickerInset)
         }
-        .frame(height: pickerHeight(optionCount: EmotionAnalysisModel.models(for: provider).count))
+        .frame(height: SettingsLayout.pickerViewportHeight(rowCount: EmotionAnalysisModel.models(for: provider).count))
         .background(TerminalColors.subtleBackground)
         .cornerRadius(8)
         .padding(.top, SettingsLayout.pickerInset)
@@ -385,12 +385,6 @@ struct EmotionAnalysisSettingsView: View {
         .buttonStyle(.plain)
     }
 
-    private func pickerHeight(optionCount: Int) -> CGFloat {
-        let rowHeight: CGFloat = 28
-        let rowSpacing: CGFloat = 4
-        let visibleCount = min(optionCount, 6)
-        return CGFloat(visibleCount) * rowHeight + CGFloat(max(visibleCount - 1, 0)) * rowSpacing
-    }
 
     private var fallbackStatusText: String {
         if provider == .claude, hasClaudeCodeFallback {

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -18,24 +18,28 @@ private struct PanelSwapTransitionModifier: ViewModifier {
 
 private struct MorphingText: View {
     let text: String
-    let textFont: Font
+    let fontSize: CGFloat
+    let fontWeight: Font.Weight
     let color: Color
     var alignment: TextAlignment = .leading
     var lineLimit: Int? = 1
 
+    @Environment(\.panelScale) private var panelScale
     @State private var displayedText: String
     @State private var blurProgress: CGFloat = 0
     @State private var morphGeneration = 0
 
     init(
         text: String,
-        font: Font,
+        fontSize: CGFloat,
+        fontWeight: Font.Weight = .regular,
         color: Color,
         alignment: TextAlignment = .leading,
         lineLimit: Int? = 1
     ) {
         self.text = text
-        self.textFont = font
+        self.fontSize = fontSize
+        self.fontWeight = fontWeight
         self.color = color
         self.alignment = alignment
         self.lineLimit = lineLimit
@@ -43,7 +47,8 @@ private struct MorphingText: View {
     }
 
     var body: some View {
-        let baseText: Text = Text(displayedText).font(textFont)
+        let baseText: Text = Text(displayedText)
+            .font(.system(size: fontSize * panelScale, weight: fontWeight))
 
         return baseText
             .foregroundColor(color)
@@ -629,7 +634,8 @@ struct ExpandedPanelView: View {
                         if let session = effectiveSession {
                             MorphingText(
                                 text: sessionStore.displaySessionLabel(for: session),
-                                font: .system(size: 11, weight: .medium),
+                                fontSize: 11,
+                                fontWeight: .medium,
                                 color: TerminalColors.secondaryText
                             )
                         }
@@ -734,13 +740,14 @@ struct ExpandedPanelView: View {
         return VStack(spacing: 8) {
             MorphingText(
                 text: title,
-                font: .system(size: 14, weight: .medium),
+                fontSize: 14,
+                fontWeight: .medium,
                 color: TerminalColors.secondaryText,
                 alignment: .center
             )
             MorphingText(
                 text: subtitle,
-                font: .system(size: 12),
+                fontSize: 12,
                 color: TerminalColors.dimmedText,
                 alignment: .center,
                 lineLimit: 2
@@ -773,22 +780,23 @@ struct PanelHeaderButton: View {
     let sfSymbol: String
     var showsIndicator: Bool = false
     let action: () -> Void
+    @Environment(\.panelScale) private var panelScale
     @State private var isHovered = false
 
     var body: some View {
         Button(action: action) {
             Image(systemName: sfSymbol)
-                .font(.system(size: 16, weight: .medium))
+                .panelFont(size: 16, weight: .medium)
                 .foregroundColor(.white.opacity(0.7))
-                .frame(width: 32, height: 32)
+                .frame(width: 32 * panelScale, height: 32 * panelScale)
                 .background(isHovered ? TerminalColors.hoverBackground : TerminalColors.subtleBackground)
                 .clipShape(Circle())
                 .overlay(alignment: .topTrailing) {
                     if showsIndicator {
                         Circle()
                             .fill(TerminalColors.red)
-                            .frame(width: 6, height: 6)
-                            .offset(x: -6, y: 6)
+                            .frame(width: 6 * panelScale, height: 6 * panelScale)
+                            .offset(x: -6 * panelScale, y: 6 * panelScale)
                     }
                 }
         }
@@ -813,7 +821,7 @@ struct ModeBadgeView: View {
 
     var body: some View {
         Text(mode)
-            .font(.system(size: 11, weight: .medium))
+            .panelFont(size: 11, weight: .medium)
             .foregroundColor(color)
     }
 }

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -48,7 +48,7 @@ private struct MorphingText: View {
 
     var body: some View {
         let baseText: Text = Text(displayedText)
-            .font(.system(size: fontSize * panelScale, weight: fontWeight))
+            .font(.system(size: fontSize * PanelTypography.fontScale(panelScale: panelScale), weight: fontWeight))
 
         return baseText
             .foregroundColor(color)

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -175,10 +175,15 @@ struct ExpandedPanelView: View {
     @Binding var isActivityCollapsed: Bool
     @Binding var hoveredSessionId: String?
     @AppStorage(AppSettings.hideGrassIslandKey) private var hideGrassIsland = false
+    @Environment(\.panelScale) private var panelScale
 
     static let compactHeaderClearance: CGFloat = 0
     static let compactFeedMaxHeight: CGFloat = 320
     static let defaultFeedMaxHeight: CGFloat = 200
+
+    static func feedMaxHeight(mode: ExpandedPanelMode, panelScale: CGFloat) -> CGFloat {
+        (mode == .compact ? compactFeedMaxHeight : defaultFeedMaxHeight) * panelScale
+    }
 
     init(
         sessionStore: SessionStore,
@@ -702,7 +707,7 @@ struct ExpandedPanelView: View {
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        .frame(maxHeight: panelMode == .compact ? Self.compactFeedMaxHeight : Self.defaultFeedMaxHeight)
+                        .frame(maxHeight: Self.feedMaxHeight(mode: panelMode, panelScale: panelScale))
                         .onAppear {
                             if effectiveSession?.pendingQuestions.isEmpty == false {
                                 scrollToQuestionPrompt(proxy: proxy)

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -782,6 +782,8 @@ struct ExpandedPanelView: View {
 }
 
 struct PanelHeaderButton: View {
+    static let baseSize: CGFloat = 32
+
     let sfSymbol: String
     var showsIndicator: Bool = false
     let action: () -> Void
@@ -791,9 +793,9 @@ struct PanelHeaderButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: sfSymbol)
-                .panelFont(size: 16, weight: .medium)
+                .panelIcon(size: 16, weight: .medium)
                 .foregroundColor(.white.opacity(0.7))
-                .frame(width: 32 * panelScale, height: 32 * panelScale)
+                .frame(width: Self.baseSize * panelScale, height: Self.baseSize * panelScale)
                 .background(isHovered ? TerminalColors.hoverBackground : TerminalColors.subtleBackground)
                 .clipShape(Circle())
                 .overlay(alignment: .topTrailing) {

--- a/notchi/notchi/Views/GrassIslandView.swift
+++ b/notchi/notchi/Views/GrassIslandView.swift
@@ -1,7 +1,12 @@
 import SwiftUI
 
-private enum SpriteLayout {
+enum SpriteLayout {
     static let size: CGFloat = 64
+    static let enlargedSpriteScale: CGFloat = 1.125
+
+    static func spriteScale(panelScale: CGFloat) -> CGFloat {
+        panelScale > 1 ? enlargedSpriteScale : 1
+    }
     static let usableWidthFraction: CGFloat = 0.8
     static let leftMarginFraction: CGFloat = 0.1
 
@@ -167,12 +172,14 @@ private struct SpriteTapTarget: View {
     @Binding var hoveredSessionId: String?
     var onTap: (() -> Void)?
 
+    @Environment(\.panelScale) private var panelScale
     @State private var tapScale: CGFloat = 1.0
 
     var body: some View {
-        Button(action: handleTap) {
+        let spriteSize = SpriteLayout.size * SpriteLayout.spriteScale(panelScale: panelScale)
+        return Button(action: handleTap) {
             Color.clear
-                .frame(width: SpriteLayout.size, height: SpriteLayout.size)
+                .frame(width: spriteSize, height: spriteSize)
                 .contentShape(Rectangle())
         }
         .buttonStyle(NoHighlightButtonStyle())
@@ -238,6 +245,7 @@ private struct GrassSpriteView: View {
     var glowOpacity: Double = 0
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.panelScale) private var panelScale
     @State private var stateMirrorKey: String?
     @State private var stateMirrored = false
 
@@ -253,6 +261,7 @@ private struct GrassSpriteView: View {
 
     var body: some View {
         let motion = GrassSpriteMotion(state: state, reduceMotion: reduceMotion)
+        let spriteSize = SpriteLayout.size * SpriteLayout.spriteScale(panelScale: panelScale)
         return TimelineView(.animation(minimumInterval: motion.frameInterval, paused: !motion.isAnimating)) { timeline in
             let presentation = spriteSheetPresentation(at: timeline.date)
             SpriteSheetView(
@@ -264,12 +273,15 @@ private struct GrassSpriteView: View {
                 animationStartDate: SpriteAnimationPhase.variedLoopAnchor(for: sessionId, spriteSheet: state.spriteSheetName),
                 isMirrored: presentation.renderMirrored
             )
-            .frame(width: SpriteLayout.size, height: SpriteLayout.size)
+            .frame(width: spriteSize, height: spriteSize)
             .background(alignment: .bottom) {
                 if glowOpacity > 0 {
                     Ellipse()
                         .fill(glowColor.opacity(glowOpacity))
-                        .frame(width: SpriteLayout.size * 0.85, height: SpriteLayout.size * 0.25)
+                        .frame(
+                            width: spriteSize * 0.85,
+                            height: spriteSize * 0.25
+                        )
                         .blur(radius: 8)
                         .offset(y: 4)
                 }

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -119,7 +119,7 @@ struct PanelSettingsView: View {
                     aboutSection
                 }
             }
-            .scrollIndicators(.hidden)
+            .scrollIndicators(.never)
 
             Spacer()
 

--- a/notchi/notchi/Views/PanelSettingsView.swift
+++ b/notchi/notchi/Views/PanelSettingsView.swift
@@ -132,7 +132,7 @@ struct PanelSettingsView: View {
         Button(action: { path.append(screen) }) {
             SettingsRowView(icon: icon, title: title) {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 9, weight: .semibold))
+                    .panelFont(size: 9, weight: .semibold)
                     .foregroundColor(TerminalColors.dimmedText)
             }
         }
@@ -149,7 +149,7 @@ struct PanelSettingsView: View {
                             statusBadge(status)
                         }
                         Image(systemName: areHooksExpanded ? "chevron.up" : "chevron.down")
-                            .font(.system(size: 9, weight: .semibold))
+                            .panelFont(size: 9, weight: .semibold)
                             .foregroundColor(TerminalColors.dimmedText)
                     }
                 }
@@ -186,7 +186,7 @@ struct PanelSettingsView: View {
         Button(action: { toggleHooks(for: provider) }) {
             HStack(spacing: 8) {
                 Text(provider.displayName)
-                    .font(.system(size: 11))
+                    .panelFont(size: 11)
                     .foregroundColor(TerminalColors.primaryText)
 
                 Spacer()
@@ -210,7 +210,7 @@ struct PanelSettingsView: View {
                     let status = emotionAnalysisStatus()
                     statusBadge(status.text, color: status.color)
                     Image(systemName: "chevron.right")
-                        .font(.system(size: 9, weight: .semibold))
+                        .panelFont(size: 9, weight: .semibold)
                         .foregroundColor(TerminalColors.dimmedText)
                 }
             }
@@ -243,7 +243,7 @@ struct PanelSettingsView: View {
         Button(action: action) {
             SettingsRowView(icon: icon, title: title) {
                 Image(systemName: "arrow.up.right")
-                    .font(.system(size: 10))
+                    .panelFont(size: 10)
                     .foregroundColor(TerminalColors.dimmedText)
             }
         }
@@ -300,9 +300,9 @@ struct PanelSettingsView: View {
         }) {
             HStack {
                 Image(systemName: "xmark.circle")
-                    .font(.system(size: 13))
+                    .panelFont(size: 13)
                 Text("Quit Notchi")
-                    .font(.system(size: 12, weight: .medium))
+                    .panelFont(size: 12, weight: .medium)
             }
             .foregroundColor(TerminalColors.red)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -468,7 +468,7 @@ struct PanelSettingsView: View {
                 ProgressView()
                     .controlSize(.mini)
                 Text("Checking...")
-                    .font(.system(size: 10))
+                    .panelFont(size: 10)
                     .foregroundColor(TerminalColors.dimmedText)
             }
         case .upToDate:
@@ -480,7 +480,7 @@ struct PanelSettingsView: View {
                 ProgressView()
                     .controlSize(.mini)
                 Text("Downloading...")
-                    .font(.system(size: 10))
+                    .panelFont(size: 10)
                     .foregroundColor(TerminalColors.dimmedText)
             }
         case .readyToInstall:
@@ -489,7 +489,7 @@ struct PanelSettingsView: View {
             statusBadge(failure.label, color: TerminalColors.red)
         case .idle:
             Text("v\(Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0")")
-                .font(.system(size: 10))
+                .panelFont(size: 10)
                 .foregroundColor(TerminalColors.dimmedText)
         }
     }

--- a/notchi/notchi/Views/SessionListView.swift
+++ b/notchi/notchi/Views/SessionListView.swift
@@ -11,7 +11,7 @@ struct SessionListView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("Sessions")
-                .font(.system(size: 11, weight: .medium))
+                .panelFont(size: 11, weight: .medium)
                 .foregroundColor(TerminalColors.secondaryText)
                 .padding(.top, 8)
                 .padding(.bottom, 8)

--- a/notchi/notchi/Views/SessionRowView.swift
+++ b/notchi/notchi/Views/SessionRowView.swift
@@ -19,14 +19,14 @@ struct SessionRowView: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
-                        .font(.system(size: 12, weight: .medium))
+                        .panelFont(size: 12, weight: .medium)
                         .foregroundColor(TerminalColors.primaryText)
                         .lineLimit(1)
                         .layoutPriority(1)
 
                     if let preview = session.activityPreview {
                         Text(preview)
-                            .font(.system(size: 10))
+                            .panelFont(size: 10)
                             .foregroundColor(TerminalColors.dimmedText)
                             .lineLimit(1)
                     }
@@ -36,7 +36,7 @@ struct SessionRowView: View {
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
-                        .font(.system(size: 11))
+                        .panelFont(size: 11)
                         .foregroundColor(TerminalColors.dimmedText.opacity(isTrashHovered ? 1 : 0.9))
                         .frame(width: 20, height: 20)
                         .contentShape(Rectangle())

--- a/notchi/notchi/Views/SettingsAppearanceView.swift
+++ b/notchi/notchi/Views/SettingsAppearanceView.swift
@@ -28,9 +28,74 @@ struct SettingsAppearanceView: View {
             }
             .buttonStyle(.plain)
 
+            PanelSizeSettingsView()
+
             NotchLayoutSettingsView()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}
+
+private struct PanelSizeSettingsView: View {
+    @AppStorage(AppSettings.expandedPanelScaleKey) private var scaleRaw = ExpandedPanelScale.standard.rawValue
+    @State private var isExpanded = false
+
+    private var scale: ExpandedPanelScale { ExpandedPanelScale(rawValue: scaleRaw) ?? .standard }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: { isExpanded.toggle() }) {
+                SettingsRowView(icon: "arrow.up.left.and.arrow.down.right", title: "Panel Size") {
+                    HStack(spacing: 4) {
+                        Text(scale.displayName)
+                            .panelFont(size: 11)
+                            .foregroundColor(TerminalColors.secondaryText)
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .panelFont(size: 9)
+                            .foregroundColor(TerminalColors.dimmedText)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(ExpandedPanelScale.allCases) { option in
+                        optionRow(option)
+                    }
+                }
+                .padding(.vertical, SettingsLayout.pickerInset)
+                .background(TerminalColors.subtleBackground)
+                .cornerRadius(8)
+                .padding(.top, SettingsLayout.pickerInset)
+            }
+        }
+        .animation(.spring(response: 0.3), value: isExpanded)
+    }
+
+    private func optionRow(_ option: ExpandedPanelScale) -> some View {
+        let isSelected = scale == option
+        return Button(action: {
+            AppSettings.expandedPanelScale = option
+            isExpanded = false
+        }) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(isSelected ? TerminalColors.green : Color.clear)
+                    .frame(width: 6, height: 6)
+                Text(option.displayName)
+                    .panelFont(size: 11, weight: .medium)
+                    .foregroundColor(isSelected ? TerminalColors.primaryText : TerminalColors.secondaryText)
+                    .lineLimit(1)
+                Spacer()
+            }
+            .padding(.horizontal, SettingsLayout.pickerOptionHorizontalPadding)
+            .padding(.vertical, SettingsLayout.pickerOptionVerticalPadding)
+            .background(isSelected ? TerminalColors.hoverBackground : Color.clear)
+            .cornerRadius(4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }
 
@@ -62,10 +127,10 @@ private struct NotchLayoutSettingsView: View {
                 SettingsRowView(icon: icon, title: title) {
                     HStack(spacing: 4) {
                         Text(selection.displayName)
-                            .font(.system(size: 11))
+                            .panelFont(size: 11)
                             .foregroundColor(TerminalColors.secondaryText)
                         Image(systemName: isExpanded.wrappedValue ? "chevron.up" : "chevron.down")
-                            .font(.system(size: 9))
+                            .panelFont(size: 9)
                             .foregroundColor(TerminalColors.dimmedText)
                     }
                 }
@@ -104,13 +169,13 @@ private struct NotchLayoutSettingsView: View {
                     .fill(isSelected ? TerminalColors.green : Color.clear)
                     .frame(width: 6, height: 6)
                 Text(option.displayName)
-                    .font(.system(size: 11, weight: .medium))
+                    .panelFont(size: 11, weight: .medium)
                     .foregroundColor(isSelected ? TerminalColors.primaryText : TerminalColors.secondaryText)
                     .lineLimit(1)
                 Spacer()
                 if let hint {
                     Text(hint)
-                        .font(.system(size: 9))
+                        .panelFont(size: 9)
                         .foregroundColor(TerminalColors.dimmedText)
                 }
             }

--- a/notchi/notchi/Views/SettingsAppearanceView.swift
+++ b/notchi/notchi/Views/SettingsAppearanceView.swift
@@ -161,7 +161,7 @@ private struct NotchLayoutSettingsView: View {
             }
             .padding(.vertical, SettingsLayout.pickerInset)
         }
-        .frame(height: pickerHeight(optionCount: NotchSlotContent.allCases.count))
+        .frame(height: SettingsLayout.pickerViewportHeight(rowCount: NotchSlotContent.allCases.count))
         .background(TerminalColors.subtleBackground)
         .cornerRadius(8)
         .padding(.top, SettingsLayout.pickerInset)
@@ -215,10 +215,4 @@ private struct NotchLayoutSettingsView: View {
         }
     }
 
-    private func pickerHeight(optionCount: Int) -> CGFloat {
-        let rowHeight: CGFloat = 28
-        let rowSpacing: CGFloat = 4
-        let visibleCount = min(optionCount, 6)
-        return CGFloat(visibleCount) * rowHeight + CGFloat(max(visibleCount - 1, 0)) * rowSpacing
-    }
 }

--- a/notchi/notchi/Views/SettingsAppearanceView.swift
+++ b/notchi/notchi/Views/SettingsAppearanceView.swift
@@ -37,10 +37,14 @@ struct SettingsAppearanceView: View {
 }
 
 private struct PanelSizeSettingsView: View {
-    @AppStorage(AppSettings.expandedPanelScaleKey) private var scaleRaw = ExpandedPanelScale.standard.rawValue
+    @AppStorage(AppSettings.expandedPanelScaleKey) private var scaleRaw = ExpandedPanelScale.automatic.rawValue
     @State private var isExpanded = false
 
-    private var scale: ExpandedPanelScale { ExpandedPanelScale(rawValue: scaleRaw) ?? .standard }
+    private var scale: ExpandedPanelScale { ExpandedPanelScale(rawValue: scaleRaw) ?? .automatic }
+
+    private func resolvedName(for option: ExpandedPanelScale) -> String {
+        option.resolved(visibleScreenHeight: NotchPanelManager.shared.visibleScreenHeight).displayName
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -88,6 +92,11 @@ private struct PanelSizeSettingsView: View {
                     .foregroundColor(isSelected ? TerminalColors.primaryText : TerminalColors.secondaryText)
                     .lineLimit(1)
                 Spacer()
+                if option == .automatic {
+                    Text(resolvedName(for: option))
+                        .panelFont(size: 9)
+                        .foregroundColor(TerminalColors.dimmedText)
+                }
             }
             .padding(.horizontal, SettingsLayout.pickerOptionHorizontalPadding)
             .padding(.vertical, SettingsLayout.pickerOptionVerticalPadding)

--- a/notchi/notchi/Views/SettingsAppearanceView.swift
+++ b/notchi/notchi/Views/SettingsAppearanceView.swift
@@ -153,18 +153,11 @@ private struct NotchLayoutSettingsView: View {
     }
 
     private func picker(_ side: Side) -> some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: SettingsLayout.pickerRowSpacing) {
-                ForEach(NotchSlotContent.allCases) { option in
-                    optionRow(side, option: option)
-                }
+        SettingsPicker(rowCount: NotchSlotContent.allCases.count) {
+            ForEach(NotchSlotContent.allCases) { option in
+                optionRow(side, option: option)
             }
-            .padding(.vertical, SettingsLayout.pickerInset)
         }
-        .frame(height: SettingsLayout.pickerViewportHeight(rowCount: NotchSlotContent.allCases.count))
-        .background(TerminalColors.subtleBackground)
-        .cornerRadius(8)
-        .padding(.top, SettingsLayout.pickerInset)
     }
 
     private func optionRow(_ side: Side, option: NotchSlotContent) -> some View {

--- a/notchi/notchi/Views/SettingsAppearanceView.swift
+++ b/notchi/notchi/Views/SettingsAppearanceView.swift
@@ -63,7 +63,7 @@ private struct PanelSizeSettingsView: View {
             .buttonStyle(.plain)
 
             if isExpanded {
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: SettingsLayout.pickerRowSpacing) {
                     ForEach(ExpandedPanelScale.allCases) { option in
                         optionRow(option)
                     }
@@ -154,7 +154,7 @@ private struct NotchLayoutSettingsView: View {
 
     private func picker(_ side: Side) -> some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: SettingsLayout.pickerRowSpacing) {
                 ForEach(NotchSlotContent.allCases) { option in
                     optionRow(side, option: option)
                 }

--- a/notchi/notchi/Views/SettingsLayout.swift
+++ b/notchi/notchi/Views/SettingsLayout.swift
@@ -21,9 +21,11 @@ enum SettingsLayout {
     static var pickerRowHeight: CGFloat { 28 * scale }
     static var pickerRowSpacing: CGFloat { 4 * scale }
 
-    static func pickerViewportHeight(rowCount: Int, maxVisibleRows: Int = 6) -> CGFloat {
-        let visibleCount = min(rowCount, maxVisibleRows)
-        return CGFloat(visibleCount) * pickerRowHeight
-            + CGFloat(max(visibleCount - 1, 0)) * pickerRowSpacing
+    static let pickerMaxVisibleRows = 6
+
+    static func pickerViewportHeight(rowCount: Int) -> CGFloat? {
+        guard rowCount > pickerMaxVisibleRows else { return nil }
+        return CGFloat(pickerMaxVisibleRows) * pickerRowHeight
+            + CGFloat(pickerMaxVisibleRows - 1) * pickerRowSpacing
     }
 }

--- a/notchi/notchi/Views/SettingsLayout.swift
+++ b/notchi/notchi/Views/SettingsLayout.swift
@@ -18,14 +18,20 @@ enum SettingsLayout {
     static var pickerInset: CGFloat { 6 * scale }
     static var pickerOptionHorizontalPadding: CGFloat { 10 * scale }
     static var pickerOptionVerticalPadding: CGFloat { 5 * scale }
-    static var pickerRowHeight: CGFloat { 28 * scale }
-    static var pickerRowSpacing: CGFloat { 4 * scale }
+    static var pickerRowHeight: CGFloat { basePickerRowHeight * scale }
+    static var pickerRowSpacing: CGFloat { basePickerRowSpacing * scale }
 
+    static let basePickerRowHeight: CGFloat = 28
+    static let basePickerRowSpacing: CGFloat = 4
     static let pickerMaxVisibleRows = 6
 
-    static func pickerViewportHeight(rowCount: Int) -> CGFloat? {
+    static func pickerViewportHeight(rowCount: Int, scale: CGFloat) -> CGFloat? {
         guard rowCount > pickerMaxVisibleRows else { return nil }
-        return CGFloat(pickerMaxVisibleRows) * pickerRowHeight
-            + CGFloat(pickerMaxVisibleRows - 1) * pickerRowSpacing
+        return (CGFloat(pickerMaxVisibleRows) * basePickerRowHeight
+            + CGFloat(pickerMaxVisibleRows - 1) * basePickerRowSpacing) * scale
+    }
+
+    static func pickerViewportHeight(rowCount: Int) -> CGFloat? {
+        pickerViewportHeight(rowCount: rowCount, scale: scale)
     }
 }

--- a/notchi/notchi/Views/SettingsLayout.swift
+++ b/notchi/notchi/Views/SettingsLayout.swift
@@ -18,4 +18,12 @@ enum SettingsLayout {
     static var pickerInset: CGFloat { 6 * scale }
     static var pickerOptionHorizontalPadding: CGFloat { 10 * scale }
     static var pickerOptionVerticalPadding: CGFloat { 5 * scale }
+    static var pickerRowHeight: CGFloat { 28 * scale }
+    static var pickerRowSpacing: CGFloat { 4 * scale }
+
+    static func pickerViewportHeight(rowCount: Int, maxVisibleRows: Int = 6) -> CGFloat {
+        let visibleCount = min(rowCount, maxVisibleRows)
+        return CGFloat(visibleCount) * pickerRowHeight
+            + CGFloat(max(visibleCount - 1, 0)) * pickerRowSpacing
+    }
 }

--- a/notchi/notchi/Views/SettingsLayout.swift
+++ b/notchi/notchi/Views/SettingsLayout.swift
@@ -1,18 +1,21 @@
 import SwiftUI
 
 // Shared layout tokens keep the settings panel spacing consistent across rows and pickers.
+@MainActor
 enum SettingsLayout {
-    static let panelHorizontalPadding: CGFloat = 14
-    static let topPadding: CGFloat = 5
-    static let sectionSpacing: CGFloat = 8
-    static let rowVerticalPadding: CGFloat = 4
-    static let apiKeySpacing: CGFloat = 4
-    static let fieldHorizontalPadding: CGFloat = 8
-    static let fieldVerticalPadding: CGFloat = 5
-    static let fieldLeadingInset: CGFloat = 28
-    static let quitButtonVerticalPadding: CGFloat = 8
-    static let quitButtonHorizontalPadding: CGFloat = 4
-    static let pickerInset: CGFloat = 6
-    static let pickerOptionHorizontalPadding: CGFloat = 10
-    static let pickerOptionVerticalPadding: CGFloat = 5
+    static var scale: CGFloat = 1
+
+    static var panelHorizontalPadding: CGFloat { 14 * scale }
+    static var topPadding: CGFloat { 5 * scale }
+    static var sectionSpacing: CGFloat { 8 * scale }
+    static var rowVerticalPadding: CGFloat { 4 * scale }
+    static var apiKeySpacing: CGFloat { 4 * scale }
+    static var fieldHorizontalPadding: CGFloat { 8 * scale }
+    static var fieldVerticalPadding: CGFloat { 5 * scale }
+    static var fieldLeadingInset: CGFloat { 28 * scale }
+    static var quitButtonVerticalPadding: CGFloat { 8 * scale }
+    static var quitButtonHorizontalPadding: CGFloat { 4 * scale }
+    static var pickerInset: CGFloat { 6 * scale }
+    static var pickerOptionHorizontalPadding: CGFloat { 10 * scale }
+    static var pickerOptionVerticalPadding: CGFloat { 5 * scale }
 }

--- a/notchi/notchi/Views/SettingsRowViews.swift
+++ b/notchi/notchi/Views/SettingsRowViews.swift
@@ -4,9 +4,11 @@ struct SettingsStatusBadge: View {
     let text: String
     let color: Color
 
+    @Environment(\.panelScale) private var panelScale
+
     var body: some View {
         Text(text)
-            .font(.system(size: 10, weight: .medium))
+            .panelFont(size: 10, weight: .medium)
             .foregroundColor(color)
             .lineLimit(1)
             .truncationMode(.tail)
@@ -14,7 +16,7 @@ struct SettingsStatusBadge: View {
             .padding(.vertical, 2)
             .background(color.opacity(0.15))
             .cornerRadius(4)
-            .frame(maxWidth: 160, alignment: .trailing)
+            .frame(maxWidth: 160 * panelScale, alignment: .trailing)
     }
 }
 
@@ -23,15 +25,17 @@ struct SettingsRowView<Trailing: View>: View {
     let title: LocalizedStringKey
     @ViewBuilder let trailing: () -> Trailing
 
+    @Environment(\.panelScale) private var panelScale
+
     var body: some View {
         HStack {
             Image(systemName: icon)
-                .font(.system(size: 12))
+                .panelFont(size: 12)
                 .foregroundColor(TerminalColors.secondaryText)
-                .frame(width: 20)
+                .frame(width: 20 * panelScale)
 
             Text(title)
-                .font(.system(size: 12))
+                .panelFont(size: 12)
                 .foregroundColor(TerminalColors.primaryText)
 
             Spacer()

--- a/notchi/notchi/Views/SettingsRowViews.swift
+++ b/notchi/notchi/Views/SettingsRowViews.swift
@@ -30,7 +30,7 @@ struct SettingsRowView<Trailing: View>: View {
     var body: some View {
         HStack {
             Image(systemName: icon)
-                .panelFont(size: 12)
+                .panelIcon(size: 12)
                 .foregroundColor(TerminalColors.secondaryText)
                 .frame(width: 20 * panelScale)
 

--- a/notchi/notchi/Views/SettingsRowViews.swift
+++ b/notchi/notchi/Views/SettingsRowViews.swift
@@ -64,3 +64,31 @@ struct ToggleSwitch: View {
         .animation(.easeInOut(duration: 0.15), value: isOn)
     }
 }
+
+struct SettingsPicker<Content: View>: View {
+    let rowCount: Int
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        Group {
+            if let viewportHeight = SettingsLayout.pickerViewportHeight(rowCount: rowCount) {
+                ScrollView {
+                    rows
+                }
+                .frame(height: viewportHeight)
+            } else {
+                rows
+            }
+        }
+        .background(TerminalColors.subtleBackground)
+        .cornerRadius(8)
+        .padding(.top, SettingsLayout.pickerInset)
+    }
+
+    private var rows: some View {
+        VStack(alignment: .leading, spacing: SettingsLayout.pickerRowSpacing) {
+            content()
+        }
+        .padding(.vertical, SettingsLayout.pickerInset)
+    }
+}

--- a/notchi/notchi/Views/UsageBarView.swift
+++ b/notchi/notchi/Views/UsageBarView.swift
@@ -128,9 +128,9 @@ struct UsageBarView: View {
             Button(action: { onConnect?() }) {
                 HStack(spacing: 4) {
                     Image(systemName: "lock.shield")
-                        .font(.system(size: 10))
+                        .panelFont(size: 10)
                     Text("Tap to show Claude usage")
-                        .font(.system(size: 11, weight: .medium))
+                        .panelFont(size: 11, weight: .medium)
                 }
                 .foregroundColor(TerminalColors.dimmedText)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -149,17 +149,17 @@ struct UsageBarView: View {
             HStack {
                 if let error, usage == nil {
                     Text(error)
-                        .font(.system(size: 11, weight: .medium))
+                        .panelFont(size: 11, weight: .medium)
                         .foregroundColor(TerminalColors.red.opacity(0.8))
                 } else if let usage, let resetTime = usage.formattedResetTime {
                     HStack(alignment: .center, spacing: 4) {
                         Text(resetLabelText(for: resetTime))
-                            .font(.system(size: 11, weight: .medium))
+                            .panelFont(size: 11, weight: .medium)
                             .foregroundColor(TerminalColors.secondaryText)
                             .lineLimit(1)
                         if let statusMessage {
                             Text("• \(statusMessage)")
-                                .font(.system(size: 10))
+                                .panelFont(size: 10)
                                 .foregroundColor(Color.white.opacity(0.35))
                                 .lineLimit(1)
                                 .truncationMode(.tail)
@@ -167,11 +167,11 @@ struct UsageBarView: View {
                     }
                 } else if let statusMessage, usage != nil {
                     Text(statusMessage)
-                        .font(.system(size: 10))
+                        .panelFont(size: 10)
                         .foregroundColor(TerminalColors.dimmedText)
                 } else {
                     Text(label)
-                        .font(.system(size: 11, weight: .medium))
+                        .panelFont(size: 11, weight: .medium)
                         .foregroundColor(TerminalColors.secondaryText)
                 }
                 Spacer()
@@ -182,18 +182,18 @@ struct UsageBarView: View {
                     HStack(alignment: .center, spacing: 6) {
                         if shouldShowExtraUsageIndicator {
                             Text("Extra Usage")
-                                .font(.system(size: 10, weight: .medium))
+                                .panelFont(size: 10, weight: .medium)
                                 .foregroundColor(TerminalColors.red.opacity(0.85))
                                 .lineLimit(1)
                         }
                         if onOpenDetail != nil {
                             Image(systemName: "chart.bar.xaxis")
-                                .font(.system(size: 10, weight: .medium))
+                                .panelFont(size: 10, weight: .medium)
                                 .foregroundColor(TerminalColors.secondaryText)
                         }
                         if usage != nil {
                             Text("\(effectivePercentage)%")
-                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                                .panelFont(size: 11, weight: .semibold, design: .monospaced)
                                 .foregroundColor(usageColor)
                         }
                         if shouldShowRecoveryButton {
@@ -214,7 +214,7 @@ struct UsageBarView: View {
     private var recoveryButton: some View {
         Button(action: performRecoveryAction) {
             Image(systemName: "arrow.clockwise")
-                .font(.system(size: 11, weight: .semibold))
+                .panelFont(size: 11, weight: .semibold)
                 .foregroundColor(isStale ? TerminalColors.secondaryText : TerminalColors.red.opacity(0.8))
                 .opacity(isPulsing ? 0.8 : 1.0)
                 .offset(y: -1)

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -14,6 +14,7 @@ struct UsageDetailView: View {
 
     @State private var selectedTab: UsageTab
     @AppStorage(AppSettings.hideGrassIslandKey) private var hideGrassIsland = false
+    @Environment(\.panelScale) private var panelScale
 
     init(
         claudeUsage: ClaudeUsageService,
@@ -137,6 +138,11 @@ struct UsageDetailView: View {
         }
     }
 
+    static func usesTwoColumnLayout(rowCount: Int, hideGrassIsland: Bool, panelScale: CGFloat) -> Bool {
+        guard panelScale <= 1 else { return false }
+        return rowCount >= 3 && !hideGrassIsland
+    }
+
     private var usageRowCount: Int {
         periods.count + (extraUsage == nil ? 0 : 1) + (codexCreditsUSD == nil ? 0 : 1)
     }
@@ -164,7 +170,11 @@ struct UsageDetailView: View {
                 .padding(.bottom, 2)
 
             if case .provider = resolvedTab {
-                if usageRowCount >= 3 && !hideGrassIsland {
+                if Self.usesTwoColumnLayout(
+                    rowCount: usageRowCount,
+                    hideGrassIsland: hideGrassIsland,
+                    panelScale: panelScale
+                ) {
                     LazyVGrid(
                         columns: [
                             GridItem(.flexible(), spacing: 14, alignment: .topLeading),

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -190,7 +190,7 @@ struct UsageDetailView: View {
                 providerToggle
             } else {
                 Text(resolvedProvider.displayName)
-                    .font(.system(size: 16, weight: .bold))
+                    .panelFont(size: 16, weight: .bold)
                     .foregroundColor(TerminalColors.primaryText)
             }
 
@@ -219,12 +219,12 @@ struct UsageDetailView: View {
             HStack(spacing: 6) {
                 Circle().fill(color).frame(width: 6, height: 6)
                 Text(name)
-                    .font(.system(size: 12, weight: .semibold))
+                    .panelFont(size: 12, weight: .semibold)
                     .foregroundColor(TerminalColors.primaryText)
                     .lineLimit(1)
                 Spacer(minLength: 8)
                 Text(Self.breakdownDetail(report))
-                    .font(.system(size: 10))
+                    .panelFont(size: 10)
                     .foregroundColor(TerminalColors.secondaryText)
                     .lineLimit(1)
             }
@@ -254,7 +254,7 @@ struct UsageDetailView: View {
             ForEach([UsageTab.provider(.claude), .provider(.codex), .all], id: \.self) { tab in
                 Button(action: { selectedTab = tab }) {
                     Text(Self.tabTitle(tab))
-                        .font(.system(size: 14, weight: .semibold))
+                        .panelFont(size: 14, weight: .semibold)
                         .foregroundColor(
                             resolvedTab == tab
                                 ? TerminalColors.primaryText
@@ -302,24 +302,24 @@ struct UsagePeriodRowView: View {
         VStack(alignment: .leading, spacing: 7) {
             HStack(alignment: .firstTextBaseline, spacing: 6) {
                 Text(display.title)
-                    .font(.system(size: 14, weight: .semibold))
+                    .panelFont(size: 14, weight: .semibold)
                     .foregroundColor(TerminalColors.primaryText)
                     .lineLimit(1)
                     .layoutPriority(1)
                 if display.isStale {
                     Text("stale data")
-                        .font(.system(size: 10))
+                        .panelFont(size: 10)
                         .foregroundColor(TerminalColors.secondaryText)
                         .lineLimit(1)
                 } else if let resetText = display.resetText {
                     Text(resetText)
-                        .font(.system(size: 10))
+                        .panelFont(size: 10)
                         .foregroundColor(TerminalColors.secondaryText)
                         .lineLimit(1)
                 }
                 Spacer(minLength: 4)
                 Text("\(display.percentUsed)%")
-                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .panelFont(size: 11, weight: .semibold, design: .monospaced)
                     .foregroundColor(color)
                     .lineLimit(1)
                     .fixedSize()
@@ -336,7 +336,7 @@ struct ExtraUsageRowView: View {
         let color = TerminalColors.usageColor(forPercentUsed: display.percentUsed)
         VStack(alignment: .leading, spacing: 7) {
             Text("Extra usage")
-                .font(.system(size: 14, weight: .semibold))
+                .panelFont(size: 14, weight: .semibold)
                 .foregroundColor(TerminalColors.primaryText)
             UsageProgressBar(percentUsed: display.percentUsed, color: color)
             HStack {
@@ -346,7 +346,7 @@ struct ExtraUsageRowView: View {
                 Text("\(Self.currency(display.monthlyLimit)) limit")
                     .foregroundColor(TerminalColors.secondaryText)
             }
-            .font(.system(size: 10))
+            .panelFont(size: 10)
         }
     }
 
@@ -364,14 +364,14 @@ struct CodexCreditsRowView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
             Text("Extra usage")
-                .font(.system(size: 14, weight: .semibold))
+                .panelFont(size: 14, weight: .semibold)
                 .foregroundColor(TerminalColors.primaryText)
             HStack {
                 Text(String(localized: "\(String(format: "$%.2f", remainingUSD)) remaining"))
                     .foregroundColor(TerminalColors.secondaryText)
                 Spacer()
             }
-            .font(.system(size: 10))
+            .panelFont(size: 10)
         }
     }
 }


### PR DESCRIPTION
Refs #95

The expanded panel was a fixed 450x450 regardless of display. That reads fine on a laptop, where it takes about a third of the screen width, but on a 21:9 or a Studio Display it drops to under 20% and feels lost, which is what the issue reports.

Adds `Settings > Appearance > Panel Size` with **Automatic** (default), **Standard** and **Large**. Automatic picks Large when the selected screen has at least 1100pt of visible height, so a desktop display gets the bigger panel without anyone opening settings, and a laptop keeps the current size. Standard and Large remain as explicit overrides. The panel re-resolves when you move between displays.

### Three scale factors, on purpose

These look arbitrary together, so worth stating:

| | Factor | Why |
|---|---|---|
| Layout | 1.25 | The size increase people asked for |
| Text | 1.125 | At 1.25 the panel was an exact photocopy, same ~62 characters per line, so it only grew type. Damping means Large buys content, not size |
| Sprites | 1.125 | 64px pixel art drawn 1:1. 1.125 lands on 72pt, whole points at 1x and 2x, doubling 1 pixel in 8 rather than 1 in 4 |

### Text is re-laid-out, not magnified

The first attempt used `scaleEffect`, which magnifies already-rendered glyphs. That looked fine on Retina but visibly soft on a 1x external display, which is exactly the hardware the issue came from. Text now goes through a `panelFont` modifier so SwiftUI lays it out at the real point size and rasterises natively.

### Two things worth a reviewer's opinion

1. **`SettingsLayout.scale` is a static var** set from `updateGeometry`, rather than the `@Environment` value the rest of the panel uses. Deliberate: the environment version means ~54 call sites across ~15 view structs, and this branch's regressions were all invisible to the compiler and tests. Harm today is limited to one setter, one panel, `@MainActor`. Happy to convert if you'd rather.
2. **`SpriteLayout` is internal rather than file-private** purely so a test can reach it.

### Testing

28 new tests covering the scale resolution and threshold, panel geometry at both presets, picker viewport sizing, and that Standard is provably unchanged (every factor is exactly 1.0 there). Full suite passes. Verified by eye at both sizes on a MacBook Air 15" and an LG SDQHD.

Localization complete for `Panel Size`, `Standard`, `Large` and `Automatic` across ja, ko, vi, zh-Hans, zh-Hant.
