### PR TITLE
fix: hook stdlib shadowing and stuck update check

### DIFF
--- a/notchi/Tests/HookScriptImportIsolationTests.swift
+++ b/notchi/Tests/HookScriptImportIsolationTests.swift
@@ -1,0 +1,291 @@
+import Foundation
+import XCTest
+@testable import notchi
+
+final class HookScriptImportIsolationTests: XCTestCase {
+    private static let hookTimeout: TimeInterval = 5
+    private static let bundledHookNames = ["notchi-hook", "notchi-codex-hook"]
+
+    private var stagingDirectory: URL?
+    private var startedServers: [(server: SocketServer, path: String)] = []
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("notchi-hook-isolation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        stagingDirectory = directory
+    }
+
+    override func tearDown() async throws {
+        for entry in startedServers {
+            entry.server.stop()
+            _ = await waitUntil(timeout: 1) {
+                !FileManager.default.fileExists(atPath: entry.path)
+            }
+            unlink(entry.path)
+        }
+        startedServers.removeAll()
+
+        if let stagingDirectory {
+            try? FileManager.default.removeItem(at: stagingDirectory)
+        }
+
+        try await super.tearDown()
+    }
+
+    func testClaudeHookDeliversEventFromDirectoryShadowingStdlib() async throws {
+        try await assertHookDeliversEvent(scriptName: "notchi-hook", sessionId: "shadowed-claude")
+    }
+
+    func testCodexHookDeliversEventFromDirectoryShadowingStdlib() async throws {
+        try await assertHookDeliversEvent(scriptName: "notchi-codex-hook", sessionId: "shadowed-codex")
+    }
+
+    func testClaudePermissionResponseReachesStdoutFromDirectoryShadowingStdlib() async throws {
+        let decision = #"{"decision":"allow"}"#
+        let recorder = EventRecorder()
+        let socketPath = uniqueSocketPath()
+        try await startServer(at: socketPath, recorder: recorder, response: Data(decision.utf8))
+
+        let script = try stageScript(named: "notchi-hook", socketPath: socketPath)
+        let workspace = try makeShadowedWorkspace()
+
+        let result = try runHook(
+            script: script,
+            workingDirectory: workspace.directory,
+            payload: #"{"hook_event_name":"PermissionRequest","session_id":"shadowed-permission","tool_name":"Bash"}"#
+        )
+
+        XCTAssertEqual(result.standardOutput, decision)
+        XCTAssertEqual(result.standardError, "", "Hook leaked diagnostics into the agent transcript")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: workspace.marker.path),
+            "Hook executed a project-local stdlib shadow instead of the real stdlib"
+        )
+    }
+
+    func testBundledHooksRunPythonInIsolatedMode() throws {
+        for name in Self.bundledHookNames {
+            let script = try String(contentsOf: bundledScriptURL(named: name), encoding: .utf8)
+            XCTAssertTrue(
+                script.contains("/usr/bin/python3 -I -c"),
+                "\(name).sh must run python in isolated mode so the session cwd cannot shadow the stdlib"
+            )
+        }
+    }
+
+    func testBundledHooksEndWithExplicitExitZero() throws {
+        for name in Self.bundledHookNames {
+            let script = try String(contentsOf: bundledScriptURL(named: name), encoding: .utf8)
+            let lastLine = script
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .last
+                .map(String.init)
+
+            XCTAssertEqual(
+                lastLine,
+                "exit 0",
+                "\(name).sh must end with exit 0 so a python failure stays fail-open"
+            )
+        }
+    }
+
+    // MARK: - Assertions
+
+    private func assertHookDeliversEvent(
+        scriptName: String,
+        sessionId: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let recorder = EventRecorder()
+        let socketPath = uniqueSocketPath()
+        try await startServer(at: socketPath, recorder: recorder)
+
+        let script = try stageScript(named: scriptName, socketPath: socketPath)
+        let workspace = try makeShadowedWorkspace()
+
+        let result = try runHook(
+            script: script,
+            workingDirectory: workspace.directory,
+            payload: #"{"hook_event_name":"Stop","session_id":"\#(sessionId)"}"#
+        )
+
+        XCTAssertEqual(result.standardError, "", "Hook leaked diagnostics into the agent transcript", file: file, line: line)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: workspace.marker.path),
+            "Hook executed a project-local stdlib shadow instead of the real stdlib",
+            file: file,
+            line: line
+        )
+
+        let delivered = await waitUntil(timeout: 2) {
+            await recorder.snapshot().contains { $0.sessionId == sessionId }
+        }
+        XCTAssertTrue(delivered, "Hook never delivered an event for \(sessionId)", file: file, line: line)
+    }
+
+    // MARK: - Helpers
+
+    private func bundledScriptURL(named name: String) -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("notchi/Resources/\(name).sh")
+    }
+
+    private func uniqueSocketPath() -> String {
+        "/tmp/notchi-isolation-\(UUID().uuidString.prefix(8)).sock"
+    }
+
+    private func startServer(
+        at path: String,
+        recorder: EventRecorder,
+        response: Data? = nil
+    ) async throws {
+        let server = SocketServer(socketPath: path, clientReadTimeout: 1.0)
+        startedServers.append((server, path))
+
+        server.start { envelope in
+            Task { await recorder.record(envelope) }
+            return response
+        }
+
+        let didStart = await waitUntil(timeout: 2) {
+            FileManager.default.fileExists(atPath: path)
+        }
+        guard didStart else {
+            throw ServerDidNotBind(path: path)
+        }
+    }
+
+    private func stageScript(named name: String, socketPath: String) throws -> URL {
+        let original = try String(contentsOf: bundledScriptURL(named: name), encoding: .utf8)
+        let defaultAssignment = "SOCKET_PATH=\"/tmp/notchi.sock\""
+        XCTAssertTrue(original.contains(defaultAssignment), "\(name).sh no longer declares the default socket path")
+
+        let staged = original.replacingOccurrences(
+            of: defaultAssignment,
+            with: "SOCKET_PATH=\"\(socketPath)\""
+        )
+        let url = try XCTUnwrap(stagingDirectory).appendingPathComponent("\(name).sh")
+        try staged.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
+    }
+
+    private func makeShadowedWorkspace() throws -> (directory: URL, marker: URL) {
+        let directory = try XCTUnwrap(stagingDirectory)
+            .appendingPathComponent("workspace-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let marker = directory.appendingPathComponent("shadow-executed.marker")
+        let shadowSource = """
+        with open("\(marker.path)", "w") as handle:
+            handle.write("executed")
+        """
+
+        for module in ["json", "subprocess"] {
+            try shadowSource.write(
+                to: directory.appendingPathComponent("\(module).py"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        try Data("not a mach-o file".utf8).write(to: directory.appendingPathComponent("socket.so"))
+
+        return (directory, marker)
+    }
+
+    private func runHook(
+        script: URL,
+        workingDirectory: URL,
+        payload: String
+    ) throws -> (standardOutput: String, standardError: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [script.path]
+        process.currentDirectoryURL = workingDirectory
+
+        let input = Pipe()
+        let output = Pipe()
+        let error = Pipe()
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = error
+
+        try process.run()
+
+        input.fileHandleForWriting.write(Data(payload.utf8))
+        input.fileHandleForWriting.closeFile()
+
+        let pendingOutput = readConcurrently(output.fileHandleForReading)
+        let pendingError = readConcurrently(error.fileHandleForReading)
+
+        let deadline = Date().addingTimeInterval(Self.hookTimeout)
+        guard let outputData = pendingOutput.wait(until: deadline),
+              let errorData = pendingError.wait(until: deadline) else {
+            process.terminate()
+            throw HookDidNotFinish(timeout: Self.hookTimeout)
+        }
+
+        process.waitUntilExit()
+
+        return (
+            String(decoding: outputData, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines),
+            String(decoding: errorData, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    private func readConcurrently(_ handle: FileHandle) -> PendingRead {
+        let pending = PendingRead()
+        DispatchQueue.global().async {
+            pending.finish(handle.readDataToEndOfFile())
+        }
+        return pending
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval,
+        pollIntervalNanoseconds: UInt64 = 10_000_000,
+        condition: @escaping () async -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            if await condition() {
+                return true
+            }
+
+            try? await Task.sleep(nanoseconds: pollIntervalNanoseconds)
+        }
+
+        return await condition()
+    }
+}
+
+private struct HookDidNotFinish: Error {
+    let timeout: TimeInterval
+}
+
+private struct ServerDidNotBind: Error {
+    let path: String
+}
+
+private final class PendingRead: @unchecked Sendable {
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var data = Data()
+
+    func finish(_ value: Data) {
+        data = value
+        semaphore.signal()
+    }
+
+    func wait(until deadline: Date) -> Data? {
+        let remaining = max(0, deadline.timeIntervalSinceNow)
+        guard semaphore.wait(timeout: .now() + remaining) == .success else { return nil }
+        return data
+    }
+}

--- a/notchi/Tests/HookScriptImportIsolationTests.swift
+++ b/notchi/Tests/HookScriptImportIsolationTests.swift
@@ -6,6 +6,11 @@ final class HookScriptImportIsolationTests: XCTestCase {
     private static let hookTimeout: TimeInterval = 5
     private static let bundledHookNames = ["notchi-hook", "notchi-codex-hook"]
 
+    private static let agentLikeEnvironment = [
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        "HOME": NSHomeDirectory(),
+    ]
+
     private var stagingDirectory: URL?
     private var startedServers: [(server: SocketServer, path: String)] = []
 
@@ -43,6 +48,8 @@ final class HookScriptImportIsolationTests: XCTestCase {
     }
 
     func testClaudePermissionResponseReachesStdoutFromDirectoryShadowingStdlib() async throws {
+        try skipUnlessStdlibPythonRuns()
+
         let decision = #"{"decision":"allow"}"#
         let recorder = EventRecorder()
         let socketPath = uniqueSocketPath()
@@ -93,12 +100,36 @@ final class HookScriptImportIsolationTests: XCTestCase {
 
     // MARK: - Assertions
 
+    private func skipUnlessStdlibPythonRuns() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = ["-I", "-c", "import json, socket, subprocess"]
+        process.environment = Self.agentLikeEnvironment
+
+        let error = Pipe()
+        process.standardOutput = Pipe()
+        process.standardError = error
+
+        try process.run()
+        let errorData = error.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        guard process.terminationStatus != 0 else { return }
+
+        throw XCTSkip(
+            "/usr/bin/python3 cannot run here, so hook behaviour is untestable: "
+                + String(decoding: errorData, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
     private func assertHookDeliversEvent(
         scriptName: String,
         sessionId: String,
         file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
+        try skipUnlessStdlibPythonRuns()
+
         let recorder = EventRecorder()
         let socketPath = uniqueSocketPath()
         try await startServer(at: socketPath, recorder: recorder)
@@ -208,6 +239,7 @@ final class HookScriptImportIsolationTests: XCTestCase {
         process.executableURL = URL(fileURLWithPath: "/bin/bash")
         process.arguments = [script.path]
         process.currentDirectoryURL = workingDirectory
+        process.environment = Self.agentLikeEnvironment
 
         let input = Pipe()
         let output = Pipe()

--- a/notchi/Tests/UpdateManagerTests.swift
+++ b/notchi/Tests/UpdateManagerTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Sparkle
 import XCTest
 @testable import notchi
@@ -6,15 +7,21 @@ import XCTest
 final class UpdateManagerTests: XCTestCase {
     private let manager = UpdateManager.shared
 
+    private let defaultCheckTimeout: TimeInterval = 60
+    private var retainedStubs: [StubUpdateChecker] = []
+
     override func setUp() {
         super.setUp()
         manager.state = .idle
         manager.hasPendingUpdate = false
+        manager.checkTimeout = defaultCheckTimeout
     }
 
     override func tearDown() {
+        manager.finishUpdateSession()
         manager.state = .idle
         manager.hasPendingUpdate = false
+        manager.checkTimeout = defaultCheckTimeout
         super.tearDown()
     }
 
@@ -42,6 +49,72 @@ final class UpdateManagerTests: XCTestCase {
         XCTAssertEqual(manager.state, .checking)
     }
 
+    func testCheckForUpdatesDoesNotEnterCheckingUntilSparkleStartsOne() {
+        let updater = StubUpdateChecker(canCheckForUpdates: true)
+        retainedStubs.append(updater)
+        manager.setUpdater(updater)
+
+        manager.checkForUpdates()
+
+        XCTAssertEqual(updater.checkCount, 1)
+        XCTAssertEqual(
+            manager.state,
+            .idle,
+            "Sparkle can silently no-op, so .checking must come from showUserInitiatedUpdateCheck"
+        )
+
+        manager.beginChecking()
+        XCTAssertEqual(manager.state, .checking)
+    }
+
+    func testCheckForUpdatesIsNotForwardedWhenSparkleCannotCheck() {
+        let updater = StubUpdateChecker(canCheckForUpdates: false)
+        retainedStubs.append(updater)
+        manager.setUpdater(updater)
+
+        manager.checkForUpdates()
+
+        XCTAssertEqual(updater.checkCount, 0)
+        XCTAssertEqual(manager.state, .idle)
+    }
+
+    func testStalledCheckTimesOutBackToIdleAndCancelsSparkleSession() async {
+        var cancellationCount = 0
+        manager.checkTimeout = 0.1
+
+        manager.beginChecking { cancellationCount += 1 }
+        XCTAssertEqual(manager.state, .checking)
+
+        try? await Task.sleep(nanoseconds: 600_000_000)
+
+        XCTAssertEqual(manager.state, .idle)
+        XCTAssertEqual(cancellationCount, 1)
+    }
+
+    func testTerminalOutcomeCancelsTheTimeoutSoStateIsNotReset() async {
+        var cancellationCount = 0
+        manager.checkTimeout = 0.1
+
+        manager.beginChecking { cancellationCount += 1 }
+        manager.updateFound(version: "9.9.9")
+
+        try? await Task.sleep(nanoseconds: 600_000_000)
+
+        XCTAssertEqual(manager.state, .updateAvailable(version: "9.9.9"))
+        XCTAssertEqual(cancellationCount, 0)
+    }
+
+    func testTimeOutCheckingLeavesSettledStateAlone() {
+        var cancellationCount = 0
+
+        manager.beginChecking { cancellationCount += 1 }
+        manager.noUpdateFound()
+        manager.timeOutChecking()
+
+        XCTAssertEqual(manager.state, .upToDate)
+        XCTAssertEqual(cancellationCount, 0)
+    }
+
     func testClearTransientStatusClearsUpToDateAndErrorStates() {
         manager.noUpdateFound()
         manager.clearTransientStatus()
@@ -50,5 +123,21 @@ final class UpdateManagerTests: XCTestCase {
         manager.updateError()
         manager.clearTransientStatus()
         XCTAssertEqual(manager.state, .idle)
+    }
+}
+
+@MainActor
+private final class StubUpdateChecker: UpdateChecking {
+    let canCheckForUpdates: Bool
+    let sessionInProgress: Bool
+    private(set) var checkCount = 0
+
+    init(canCheckForUpdates: Bool, sessionInProgress: Bool = false) {
+        self.canCheckForUpdates = canCheckForUpdates
+        self.sessionInProgress = sessionInProgress
+    }
+
+    func checkForUpdates() {
+        checkCount += 1
     }
 }

--- a/notchi/notchi/AppDelegate.swift
+++ b/notchi/notchi/AppDelegate.swift
@@ -24,6 +24,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
     private lazy var updateUserDriver = NotchiUpdateUserDriver(
         standardUserDriver: standardUserDriver,
         shouldHandleUpdaterErrorsInline: { UpdateManager.shared.shouldHandleUpdaterErrorInline },
+        didBeginUpdateCheck: { cancellation in
+            UpdateManager.shared.beginChecking(cancellation: cancellation)
+        },
         didFinishCustomSession: { [weak self] in
             UpdateManager.shared.finishUpdateSession()
             self?.restoreAccessoryModeIfNeeded()
@@ -213,13 +216,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate, SP
     private func startUpdater() {
         guard !updaterStarted else { return }
 
-        UpdateManager.shared.setUpdater(updater)
         do {
             try updater.start()
         } catch {
             logger.error("Failed to start Sparkle updater: \(error.localizedDescription, privacy: .public)")
             return
         }
+        UpdateManager.shared.setUpdater(updater)
         updaterStarted = true
     }
 
@@ -281,6 +284,10 @@ extension AppDelegate {
     ) -> Bool {
         UpdateManager.shared.readyToInstall(version: item.displayVersionString)
         return false
+    }
+
+    func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: Error?) {
+        UpdateManager.shared.finishUpdateSession()
     }
 
     func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {

--- a/notchi/notchi/Resources/notchi-codex-hook.sh
+++ b/notchi/notchi/Resources/notchi-codex-hook.sh
@@ -5,7 +5,7 @@ SOCKET_PATH="/tmp/notchi.sock"
 
 [ -S "$SOCKET_PATH" ] || exit 0
 
-/usr/bin/python3 -c "
+/usr/bin/python3 -I -c "
 import json
 import os
 import socket
@@ -173,3 +173,5 @@ try:
 except Exception:
     pass
 "
+
+exit 0

--- a/notchi/notchi/Resources/notchi-hook.sh
+++ b/notchi/notchi/Resources/notchi-hook.sh
@@ -17,7 +17,7 @@ done
 export NOTCHI_INTERACTIVE=$IS_INTERACTIVE
 
 # Parse input and send to socket using Python
-/usr/bin/python3 -c "
+/usr/bin/python3 -I -c "
 import json
 import os
 import socket
@@ -161,3 +161,5 @@ try:
 except:
     pass
 "
+
+exit 0

--- a/notchi/notchi/Services/Update/NotchiUpdateUserDriver.swift
+++ b/notchi/notchi/Services/Update/NotchiUpdateUserDriver.swift
@@ -5,15 +5,18 @@ import Sparkle
 final class NotchiUpdateUserDriver: NSObject, SPUUserDriver {
     private let standardUserDriver: SPUStandardUserDriver
     private let shouldHandleUpdaterErrorsInline: () -> Bool
+    private let didBeginUpdateCheck: (@escaping () -> Void) -> Void
     private let didFinishCustomSession: () -> Void
 
     init(
         standardUserDriver: SPUStandardUserDriver,
         shouldHandleUpdaterErrorsInline: @escaping () -> Bool,
+        didBeginUpdateCheck: @escaping (@escaping () -> Void) -> Void,
         didFinishCustomSession: @escaping () -> Void
     ) {
         self.standardUserDriver = standardUserDriver
         self.shouldHandleUpdaterErrorsInline = shouldHandleUpdaterErrorsInline
+        self.didBeginUpdateCheck = didBeginUpdateCheck
         self.didFinishCustomSession = didFinishCustomSession
     }
 
@@ -22,6 +25,7 @@ final class NotchiUpdateUserDriver: NSObject, SPUUserDriver {
     }
 
     func showUserInitiatedUpdateCheck(cancellation: @escaping () -> Void) {
+        didBeginUpdateCheck(cancellation)
         standardUserDriver.showUserInitiatedUpdateCheck(cancellation: cancellation)
     }
 

--- a/notchi/notchi/Services/Update/UpdateManager.swift
+++ b/notchi/notchi/Services/Update/UpdateManager.swift
@@ -1,5 +1,8 @@
 import Combine
+import os.log
 import Sparkle
+
+nonisolated private let logger = Logger(subsystem: "com.ruban.notchi", category: "UpdateManager")
 
 struct UpdateFailurePresentation: Equatable {
     let label: String
@@ -20,6 +23,15 @@ enum UpdateState: Equatable {
     case error(UpdateFailurePresentation)
 }
 
+@MainActor
+protocol UpdateChecking: AnyObject {
+    var canCheckForUpdates: Bool { get }
+    var sessionInProgress: Bool { get }
+    func checkForUpdates()
+}
+
+extension SPUUpdater: UpdateChecking {}
+
 /// Observable update manager that mirrors Sparkle state into SwiftUI.
 /// The real install/relaunch flow is handled by Sparkle's standard UI.
 @MainActor
@@ -31,30 +43,49 @@ final class UpdateManager: ObservableObject {
     @Published var state: UpdateState = .idle
     @Published var hasPendingUpdate: Bool = false
 
-    private var resetTask: Task<Void, Never>?
+    var checkTimeout: TimeInterval = 60
 
-    private var updater: SPUUpdater?
+    private var resetTask: Task<Void, Never>?
+    private var cancelActiveCheck: (() -> Void)?
+
+    private var updater: UpdateChecking?
 
     private init() {}
 
-    func setUpdater(_ updater: SPUUpdater) {
+    func setUpdater(_ updater: UpdateChecking) {
         self.updater = updater
     }
 
     // MARK: - Public (UI actions)
 
     func checkForUpdates() {
-        guard let updater, updater.canCheckForUpdates else { return }
-        resetTask?.cancel()
-        beginChecking()
+        guard let updater else {
+            logger.warning("Update check requested before the updater was available")
+            return
+        }
+
+        guard updater.canCheckForUpdates else {
+            logger.warning(
+                "Update check skipped: canCheckForUpdates=false sessionInProgress=\(updater.sessionInProgress, privacy: .public)"
+            )
+            return
+        }
+
+        logger.notice(
+            "Update check requested: sessionInProgress=\(updater.sessionInProgress, privacy: .public)"
+        )
         updater.checkForUpdates()
     }
 
-    func beginChecking() {
+    func beginChecking(cancellation: (() -> Void)? = nil) {
+        logger.notice("Update check started by Sparkle")
+        cancelActiveCheck = cancellation
         state = .checking
+        scheduleCheckTimeout()
     }
 
     func updateFound(version: String) {
+        endCheckSession()
         hasPendingUpdate = true
 
         if case .downloading = state {
@@ -86,28 +117,47 @@ final class UpdateManager: ObservableObject {
     }
 
     func downloadStarted() {
+        endCheckSession()
         hasPendingUpdate = true
         state = .downloading(progress: 0)
     }
 
     func readyToInstall(version: String) {
+        endCheckSession()
         hasPendingUpdate = true
         state = .readyToInstall(version: version)
     }
 
     func noUpdateFound() {
+        endCheckSession()
         clearPendingUpdate(showIdleImmediately: false)
         state = .upToDate
     }
 
     func updateError() {
+        endCheckSession()
         state = .error(UpdateFailurePresentation())
     }
 
     func finishUpdateSession() {
+        endCheckSession()
+
         if case .checking = state {
             state = .idle
         }
+    }
+
+    func timeOutChecking() {
+        guard case .checking = state else { return }
+
+        logger.error(
+            "Update check never reported an outcome within \(self.checkTimeout, privacy: .public)s; resetting to idle"
+        )
+
+        let cancellation = cancelActiveCheck
+        endCheckSession()
+        cancellation?()
+        state = .idle
     }
 
     func clearTransientStatus() {
@@ -126,6 +176,23 @@ final class UpdateManager: ObservableObject {
     static func shouldIgnoreAbortError(_ error: NSError) -> Bool {
         error.domain == SUSparkleErrorDomain &&
             (error.code == noUpdateErrorCode || error.code == installationCanceledErrorCode)
+    }
+
+    private func scheduleCheckTimeout() {
+        resetTask?.cancel()
+
+        let timeout = checkTimeout
+        resetTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.timeOutChecking()
+        }
+    }
+
+    private func endCheckSession() {
+        resetTask?.cancel()
+        resetTask = nil
+        cancelActiveCheck = nil
     }
 
     private func clearPendingUpdate(showIdleImmediately: Bool = true) {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -49,6 +49,7 @@ if [[ "$preset" == "focused" ]]; then
         "-only-testing:Tests/DailyCostReportTests"
         "-only-testing:Tests/CostHistoryStoreTests"
         "-only-testing:Tests/ClaudeModelPricingTests"
+        "-only-testing:Tests/HookScriptImportIsolationTests"
     )
 fi
 


### PR DESCRIPTION
Two independent fixes for the symptoms reported in #100. Deliberately no closing keyword, the issue should stay open (see Status below).

### 1. Hook scripts ran Python with the session cwd on `sys.path`

`notchi-hook.sh` and `notchi-codex-hook.sh` invoked `/usr/bin/python3 -c`, which prepends the current directory to `sys.path`. Any project containing `json.py`, `socket.py`, `subprocess.py`, or a `socket.so` build output shadowed the stdlib.

Confirmed by running the real scripts against a real socket from a shadowed directory: the planted `json.py` **executed**, and no event reached the app. This is arbitrary code execution on every hook event, not just a crash. The blocking `PermissionRequest` round-trip was also fully broken in such directories, so permission prompts silently never appeared.

`-I` (isolated mode) drops cwd from `sys.path` and ignores `PYTHONPATH`. `-P` is narrower but needs 3.11+, and macOS ships 3.9.6. A trailing `exit 0` keeps a Python failure fail-open instead of leaking a traceback into the agent transcript.

Thanks to @NoahBPeterson for diagnosing this and proposing `-I`.

### 2. "Check for Updates" could stick on "Checking..." forever

`UpdateManager` set `.checking` *before* calling `SPUUpdater.checkForUpdates`. Sparkle returns early with **no callback at all** when an update is already on screen, and deliberately keeps `canCheckForUpdates == true` in that state for user drivers implementing `showUpdateInFocus`, which ours does (`SPUUpdater.m:894`). So the guard passed, `.checking` was set, and nothing ever cleared it.

Reproduced against real Sparkle 2.9.4 (the version in the shipped 1.2.2 DMG): while an update is showing, `canCheckForUpdates=true, sessionInProgress=true`, and a second check yields zero user-driver and zero delegate callbacks.

`.checking` now comes from `showUserInitiatedUpdateCheck`, which Sparkle calls only when a check genuinely starts. A timeout cancels the Sparkle session and falls back to idle if no outcome arrives.

### Testing

- New `HookScriptImportIsolationTests` runs both bundled scripts against a real Unix socket from a directory shadowing the stdlib, asserting the event is delivered, the shadow never executes, and the permission response reaches stdout. Wired into the focused preset.
- New `UpdateManager` tests pin that `.checking` is never entered optimistically, and cover the timeout.
- Both suites verified to fail with the fixes reverted.
- `./scripts/test.sh all`: 587 passed, 0 failed.

### Status

The hook half is fully diagnosed and fixed. The updater half is **not fully explained** for the original reporter: they were on 1.2.2 when 1.2.2 was newest, so no update alert would have been showing for them. The bug fixed here is real and reproducible, and the new timeout makes a permanently stuck "Checking..." unreachable regardless of cause, but I can't confirm it's the path they hit.

New `os.log` output at notice/error level records check requested / started / timed out, so a recurrence leaves a retrievable trace (a `requested` line with no `started` after it):

```
log show --predicate 'subsystem == "com.ruban.notchi"' --last 1h
```

Refs #100.
