### PR TITLE
feat: usage panel polish, auto-review pricing, and settings regroup

### DIFF
--- a/notchi/Tests/CodexModelPricingTests.swift
+++ b/notchi/Tests/CodexModelPricingTests.swift
@@ -79,6 +79,10 @@ final class CodexModelPricingTests: XCTestCase {
         XCTAssertEqual(CostPricing.normalizeOpenAIModel("openai/gpt-5.4-2025-03-15"), "gpt-5.4")
     }
 
+    func testNormalizeOpenAIModelAliasesAutoReviewToSol() {
+        XCTAssertEqual(CostPricing.normalizeOpenAIModel("codex-auto-review"), "gpt-5.6-sol")
+    }
+
     func testPlausibilityGuardAcceptsGpt5TableAndRejectsClaudeOnly() {
         let anyPricing = ClaudeModelPricing(
             inputPerToken: 5e-6, outputPerToken: 3e-5,

--- a/notchi/notchi/Services/Cost/ClaudeModelPricing.swift
+++ b/notchi/notchi/Services/Cost/ClaudeModelPricing.swift
@@ -29,6 +29,7 @@ nonisolated enum CostPricing {
         var s = raw
         if s.hasPrefix("openai/") { s = String(s.dropFirst("openai/".count)) }
         if let r = s.range(of: #"-\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) { s.removeSubrange(r) }
+        if s == "codex-auto-review" { return "gpt-5.6-sol" }
         return s
     }
 

--- a/notchi/notchi/Services/Cost/CostUsageCache.swift
+++ b/notchi/notchi/Services/Cost/CostUsageCache.swift
@@ -15,7 +15,7 @@ nonisolated struct CostUsageCache: Codable, Equatable {
         var codexResume: CodexResume? = nil
     }
 
-    static let currentVersion = 1
+    static let currentVersion = 2
     var version: Int
     var files: [String: FileState]
     var buckets: DayModelBuckets

--- a/notchi/notchi/Views/Cost/CostDashboardView.swift
+++ b/notchi/notchi/Views/Cost/CostDashboardView.swift
@@ -49,11 +49,12 @@ struct CostDashboardView: View {
     let report: DailyCostReport?
     var sizingPeerReports: [DailyCostReport] = []
     var combinesProviders = false
+    var chartHeight: CGFloat = Self.defaultChartHeight
 
     @Environment(\.panelScale) private var panelScale
     @State private var selected: DailyCostReport.DayEntry?
 
-    private var scaledChartHeight: CGFloat { Self.chartHeight * panelScale }
+    private var scaledChartHeight: CGFloat { chartHeight * panelScale }
     private var scaledStatRowHeight: CGFloat { Self.statRowHeight * panelScale }
 
     private func currentEntry(_ r: DailyCostReport) -> DailyCostReport.DayEntry? {
@@ -66,11 +67,14 @@ struct CostDashboardView: View {
         VStack(alignment: .leading, spacing: Self.sectionSpacing) {
             if let report {
                 statsRow(report)
-                chart(report)
-                if report.entries.contains(where: { $0.requestCount > 0 && $0.pricedFraction < 1 }) {
-                    Text("Some models lack pricing — cost is partial")
-                        .panelFont(size: 10)
-                        .foregroundStyle(.orange)
+                VStack(alignment: .leading, spacing: 5) {
+                    chart(report)
+                    if report.entries.contains(where: { $0.requestCount > 0 && $0.pricedFraction < 1 }) {
+                        Text("Some models lack pricing — cost is partial")
+                            .panelFont(size: 10)
+                            .foregroundStyle(.orange)
+                            .padding(.bottom, -9)
+                    }
                 }
             } else {
                 Text("Scanning usage…")
@@ -215,7 +219,7 @@ struct CostDashboardView: View {
         var id: Int { segment.rank }
     }
 
-    private static let chartHeight: CGFloat = 105
+    static let defaultChartHeight: CGFloat = 105
     private static let segmentGapPixels = 1.0
     private static let hoverGracePixels: CGFloat = 12
     private static let halfDay: TimeInterval = 43_200

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -791,19 +791,20 @@ struct PanelHeaderButton: View {
     @State private var isHovered = false
 
     var body: some View {
+        let buttonScale: CGFloat = panelScale > 1 ? 17 / 16 : 1
         Button(action: action) {
             Image(systemName: sfSymbol)
-                .panelIcon(size: 16, weight: .medium)
+                .font(.system(size: 16 * buttonScale, weight: .medium))
                 .foregroundColor(.white.opacity(0.7))
-                .frame(width: Self.baseSize * panelScale, height: Self.baseSize * panelScale)
+                .frame(width: Self.baseSize * buttonScale, height: Self.baseSize * buttonScale)
                 .background(isHovered ? TerminalColors.hoverBackground : TerminalColors.subtleBackground)
                 .clipShape(Circle())
                 .overlay(alignment: .topTrailing) {
                     if showsIndicator {
                         Circle()
                             .fill(TerminalColors.red)
-                            .frame(width: 6 * panelScale, height: 6 * panelScale)
-                            .offset(x: -6 * panelScale, y: 6 * panelScale)
+                            .frame(width: 6 * buttonScale, height: 6 * buttonScale)
+                            .offset(x: -6 * buttonScale, y: 6 * buttonScale)
                     }
                 }
         }

--- a/notchi/notchi/Views/SettingsAppearanceView.swift
+++ b/notchi/notchi/Views/SettingsAppearanceView.swift
@@ -3,10 +3,15 @@ import SwiftUI
 struct SettingsAppearanceView: View {
     @AppStorage(AppSettings.hideSpriteWhenIdleKey) private var hideSpriteWhenIdle = false
     @AppStorage(AppSettings.hideGrassIslandKey) private var hideGrassIsland = false
-    @AppStorage(AppSettings.expandOnHoverKey) private var expandOnHover = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
+            ScreenPickerRow(screenSelector: ScreenSelector.shared)
+
+            PanelSizeSettingsView()
+
+            Divider().background(Color.white.opacity(0.08))
+
             Button(action: { hideSpriteWhenIdle.toggle() }) {
                 SettingsRowView(icon: "pip.exit", title: "Hide Sprite When Idle") {
                     ToggleSwitch(isOn: hideSpriteWhenIdle)
@@ -21,14 +26,7 @@ struct SettingsAppearanceView: View {
             }
             .buttonStyle(.plain)
 
-            Button(action: { expandOnHover.toggle() }) {
-                SettingsRowView(icon: "cursorarrow.motionlines", title: "Expand on Hover") {
-                    ToggleSwitch(isOn: expandOnHover)
-                }
-            }
-            .buttonStyle(.plain)
-
-            PanelSizeSettingsView()
+            Divider().background(Color.white.opacity(0.08))
 
             NotchLayoutSettingsView()
         }

--- a/notchi/notchi/Views/SettingsGeneralView.swift
+++ b/notchi/notchi/Views/SettingsGeneralView.swift
@@ -7,11 +7,10 @@ private let logger = Logger(subsystem: "com.ruban.notchi", category: "SettingsGe
 struct SettingsGeneralView: View {
     @State private var panelToggleShortcut = AppSettings.panelToggleShortcut
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+    @AppStorage(AppSettings.expandOnHoverKey) private var expandOnHover = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: SettingsLayout.sectionSpacing) {
-            ScreenPickerRow(screenSelector: ScreenSelector.shared)
-
             SoundPickerView()
 
             SettingsRowView(icon: "keyboard", title: "Toggle Panel") {
@@ -23,6 +22,15 @@ struct SettingsGeneralView: View {
                     onShortcutChange: updatePanelToggleShortcut
                 )
             }
+
+            Divider().background(Color.white.opacity(0.08))
+
+            Button(action: { expandOnHover.toggle() }) {
+                SettingsRowView(icon: "cursorarrow.motionlines", title: "Expand on Hover") {
+                    ToggleSwitch(isOn: expandOnHover)
+                }
+            }
+            .buttonStyle(.plain)
 
             Button(action: toggleLaunchAtLogin) {
                 SettingsRowView(icon: "power", title: "Launch at Login") {

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -121,7 +121,16 @@ struct UsageDetailView: View {
             windowStart: windowStart, today: today, calendar: calendar)
     }
 
+    static func chartHeight(hideGrassIsland: Bool) -> CGFloat {
+        hideGrassIsland ? 150 : CostDashboardView.defaultChartHeight
+    }
+
+    static func sectionSpacing(hideGrassIsland: Bool) -> CGFloat {
+        hideGrassIsland ? 15 : 10
+    }
+
     @ViewBuilder private var costDashboard: some View {
+        let chartHeight = Self.chartHeight(hideGrassIsland: hideGrassIsland)
         switch resolvedTab {
         case .provider(let provider):
             let stores = provider == .codex
@@ -129,12 +138,14 @@ struct UsageDetailView: View {
                 : (main: costStore, peer: codexCostStore)
             CostDashboardView(
                 report: stores.main.report,
-                sizingPeerReports: [stores.peer.report, combinedReport].compactMap { $0 })
+                sizingPeerReports: [stores.peer.report, combinedReport].compactMap { $0 },
+                chartHeight: chartHeight)
         case .all:
             CostDashboardView(
                 report: combinedReport,
                 sizingPeerReports: [costStore.report, codexCostStore.report].compactMap { $0 },
-                combinesProviders: true)
+                combinesProviders: true,
+                chartHeight: chartHeight)
         }
     }
 
@@ -162,12 +173,12 @@ struct UsageDetailView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: Self.sectionSpacing(hideGrassIsland: hideGrassIsland)) {
             header
                 .padding(.bottom, -4)
 
             costDashboard
-                .padding(.bottom, 2)
+                .padding(.bottom, hideGrassIsland ? 2 : -4)
 
             if case .provider = resolvedTab {
                 if Self.usesTwoColumnLayout(


### PR DESCRIPTION
## Summary

Four small quality changes to the expanded panel and settings.

### Header buttons scale with the font factor
In Large panel size the header buttons (back, gear, close) previously grew by the full panel scale (32pt to 40pt) while their icons only grew with the font scale, leaving the glyphs looking undersized. Buttons now use a 17/16 factor: a 17pt icon in a 34pt circle, keeping the same fill proportion as Standard.

### Compact panel fills its space
With the grass island hidden, the usage detail page left a large dead zone at the bottom. The cost chart now grows from 105pt to 150pt and section spacing from 10pt to 15pt in that mode. Grass-island mode also tightens the chart-to-quota-rows gap to 6pt, and the "Some models lack pricing" label now sits close under the chart instead of pushing rows below out of the panel.

### codex-auto-review runs are now priced
Codex logs record automatic reviews under the pseudo-model `codex-auto-review`, which has no catalog entry, so any day containing one showed the partial-pricing warning. Auto-review resolves to `gpt-5.6-sol` server-side (openai/codex#20981, openai/codex#19420), so the normalizer now aliases it to that model's pricing. The cost cache version is bumped so existing unpriced buckets rebuild once on launch.

### Settings regroup
Appearance now covers placement and looks: Screen, Panel Size, then the hide toggles, then the notch slot pickers. General covers interaction: Notification Sound, Toggle Panel, Expand on Hover, Launch at Login. No rows were renamed, so no localization changes.

## Testing
- Full suite passes (587 tests), including a new test for the auto-review pricing alias.
- Layout changes eyeballed in both panel sizes, with the grass island shown and hidden.
