### PR TITLE
feat(settings): fetch emotion analysis models from the configured endpoint

### DIFF
--- a/notchi/Tests/APIErrorMessageTests.swift
+++ b/notchi/Tests/APIErrorMessageTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import XCTest
+@testable import notchi
+
+/// A model or base-URL mismatch used to surface as a bare "HTTP 400", which is close to
+/// undiagnosable. These cover the shapes the readable part actually arrives in.
+final class APIErrorMessageTests: XCTestCase {
+
+    // MARK: - Extraction
+
+    func testReadsTheNestedOpenAIShape() throws {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "error": [
+                "message": "The model `gpt-9` does not exist or you do not have access to it.",
+                "type": "invalid_request_error",
+            ]
+        ])
+
+        XCTAssertEqual(
+            APIErrorMessageReader.message(from: data),
+            "The model `gpt-9` does not exist or you do not have access to it."
+        )
+    }
+
+    func testReadsTheNestedAnthropicShape() throws {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "type": "error",
+            "error": ["type": "authentication_error", "message": "invalid x-api-key"],
+        ])
+
+        XCTAssertEqual(APIErrorMessageReader.message(from: data), "invalid x-api-key")
+    }
+
+    /// LM Studio and several gateways put a bare string under "error".
+    func testReadsABareStringError() throws {
+        let data = try JSONSerialization.data(withJSONObject: ["error": "Model unloaded"])
+
+        XCTAssertEqual(APIErrorMessageReader.message(from: data), "Model unloaded")
+    }
+
+    func testFallsBackToTypeWhenNoMessageIsPresent() throws {
+        let data = try JSONSerialization.data(withJSONObject: ["error": ["type": "overloaded_error"]])
+
+        XCTAssertEqual(APIErrorMessageReader.message(from: data), "overloaded_error")
+    }
+
+    func testReadsATopLevelMessage() throws {
+        let data = try JSONSerialization.data(withJSONObject: ["message": "Not Found"])
+
+        XCTAssertEqual(APIErrorMessageReader.message(from: data), "Not Found")
+    }
+
+    /// A reverse proxy in front of a local server often answers with HTML rather than JSON.
+    func testFallsBackToTheRawBody() throws {
+        let data = try XCTUnwrap("upstream connect error".data(using: .utf8))
+
+        XCTAssertEqual(APIErrorMessageReader.message(from: data), "upstream connect error")
+    }
+
+    func testCollapsesWhitespaceSoTheLineStaysReadable() throws {
+        let data = try XCTUnwrap("<html>\n  <body>502\n\tBad Gateway</body>\n</html>".data(using: .utf8))
+
+        XCTAssertEqual(APIErrorMessageReader.message(from: data), "<html> <body>502 Bad Gateway</body> </html>")
+    }
+
+    func testEmptyBodyYieldsNoMessage() {
+        XCTAssertNil(APIErrorMessageReader.message(from: Data()))
+        XCTAssertNil(APIErrorMessageReader.message(from: Data("   \n ".utf8)))
+    }
+
+    // MARK: - Bounding
+
+    func testAnOversizedBodyIsTruncatedRatherThanFloodingTheUI() throws {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "error": ["message": String(repeating: "a", count: 5_000)]
+        ])
+
+        let message = try XCTUnwrap(APIErrorMessageReader.message(from: data))
+
+        XCTAssertEqual(message.count, APIErrorMessageReader.maxLength + 1)
+        XCTAssertTrue(message.hasSuffix("\u{2026}"))
+    }
+
+    func testAMessageAtTheLimitIsLeftIntact() throws {
+        let exact = String(repeating: "b", count: APIErrorMessageReader.maxLength)
+        let data = try JSONSerialization.data(withJSONObject: ["error": ["message": exact]])
+
+        XCTAssertEqual(APIErrorMessageReader.message(from: data), exact)
+    }
+
+    // MARK: - Surfacing
+
+    func testErrorDescriptionCarriesTheEndpointMessage() {
+        let error = EmotionAnalysisRequestError.httpStatus(
+            provider: "OpenAI",
+            statusCode: 404,
+            message: "model not found"
+        )
+
+        XCTAssertEqual(error.errorDescription, "OpenAI API returned HTTP 404: model not found")
+    }
+
+    func testErrorDescriptionStaysCleanWithoutAMessage() {
+        let error = EmotionAnalysisRequestError.httpStatus(provider: "Claude", statusCode: 500, message: nil)
+
+        XCTAssertEqual(error.errorDescription, "Claude API returned HTTP 500")
+    }
+
+    /// The status badge is a few characters wide, so it must not inherit the body text.
+    func testShortLabelIgnoresTheMessage() {
+        let error = EmotionAnalysisRequestError.httpStatus(
+            provider: "OpenAI",
+            statusCode: 400,
+            message: String(repeating: "noise ", count: 40)
+        )
+
+        XCTAssertEqual(error.shortLabel, "HTTP 400")
+    }
+}

--- a/notchi/Tests/CustomEndpointScopingTests.swift
+++ b/notchi/Tests/CustomEndpointScopingTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import XCTest
+@testable import notchi
+
+/// The settings panel hides model refresh and custom model-id entry unless a base URL is set, and
+/// renames the provider row to match what requests are actually going to.
+final class CustomEndpointScopingTests: XCTestCase {
+
+    // MARK: - Detecting a custom endpoint
+
+    func testAnEmptyBaseURLIsNotACustomEndpoint() {
+        XCTAssertFalse(EmotionAnalysisProvider.hasCustomEndpoint(baseURL: nil))
+        XCTAssertFalse(EmotionAnalysisProvider.hasCustomEndpoint(baseURL: ""))
+    }
+
+    /// The field holds raw keystrokes, so whitespace alone must not switch the panel over.
+    func testWhitespaceOnlyIsNotACustomEndpoint() {
+        XCTAssertFalse(EmotionAnalysisProvider.hasCustomEndpoint(baseURL: "   "))
+        XCTAssertFalse(EmotionAnalysisProvider.hasCustomEndpoint(baseURL: "\n\t "))
+    }
+
+    func testAnyRealBaseURLIsACustomEndpoint() {
+        XCTAssertTrue(EmotionAnalysisProvider.hasCustomEndpoint(baseURL: "localhost:1234/v1"))
+        XCTAssertTrue(EmotionAnalysisProvider.hasCustomEndpoint(baseURL: "  https://relay.example.com  "))
+    }
+
+    /// The same predicate drives whether a catalog request would even be built.
+    func testTheDefaultEndpointIsStillReachableWithoutACustomBaseURL() {
+        XCTAssertFalse(EmotionAnalysisProvider.hasCustomEndpoint(baseURL: nil))
+        XCTAssertNotNil(EmotionAnalysisProvider.openAI.modelsEndpointURL(fromBaseURL: nil))
+    }
+
+    // MARK: - Provider label
+
+    func testStockProvidersKeepTheirVendorName() {
+        XCTAssertEqual(EmotionAnalysisProvider.openAI.displayName(forBaseURL: nil), "OpenAI")
+        XCTAssertEqual(EmotionAnalysisProvider.openAI.displayName(forBaseURL: "  "), "OpenAI")
+        XCTAssertEqual(EmotionAnalysisProvider.claude.displayName(forBaseURL: nil), "Claude")
+    }
+
+    func testACustomOpenAIEndpointIsLabelledByItsRequestShape() {
+        XCTAssertEqual(
+            EmotionAnalysisProvider.openAI.displayName(forBaseURL: "http://localhost:1234/v1"),
+            "OpenAI-compatible"
+        )
+    }
+
+    /// A proxied Anthropic endpoint still speaks the Anthropic shape, so it keeps its name.
+    func testACustomClaudeEndpointKeepsItsName() {
+        XCTAssertEqual(
+            EmotionAnalysisProvider.claude.displayName(forBaseURL: "https://relay.example.com"),
+            "Claude"
+        )
+    }
+
+    func testTheLabelNeverCollapsesToAnEmptyString() {
+        for provider in EmotionAnalysisProvider.allCases {
+            for baseURL in [nil, "", "   ", "localhost:1234/v1"] as [String?] {
+                XCTAssertFalse(
+                    provider.displayName(forBaseURL: baseURL).isEmpty,
+                    "\(provider) with base URL \(baseURL ?? "nil") produced an empty label"
+                )
+            }
+        }
+    }
+}

--- a/notchi/Tests/ModelCatalogTests.swift
+++ b/notchi/Tests/ModelCatalogTests.swift
@@ -34,7 +34,7 @@ final class ModelCatalogTests: XCTestCase {
     func testModelsEndpointURLDefaultsWhenBaseURLMissing() {
         XCTAssertEqual(
             EmotionAnalysisProvider.claude.modelsEndpointURL(fromBaseURL: nil),
-            URL(string: "https://api.anthropic.com/v1/models")
+            URL(string: "https://api.anthropic.com/v1/models?limit=1000")
         )
         XCTAssertEqual(
             EmotionAnalysisProvider.openAI.modelsEndpointURL(fromBaseURL: "   "),
@@ -61,7 +61,7 @@ final class ModelCatalogTests: XCTestCase {
     func testModelsEndpointURLStripsAChatRouteFromTheBaseURL() {
         XCTAssertEqual(
             EmotionAnalysisProvider.claude.modelsEndpointURL(fromBaseURL: "https://relay.example.com/v1/messages"),
-            URL(string: "https://relay.example.com/v1/models")
+            URL(string: "https://relay.example.com/v1/models?limit=1000")
         )
         XCTAssertEqual(
             EmotionAnalysisProvider.openAI.modelsEndpointURL(fromBaseURL: "https://relay.example.com/v1/chat/completions"),
@@ -69,7 +69,7 @@ final class ModelCatalogTests: XCTestCase {
         )
         XCTAssertEqual(
             EmotionAnalysisProvider.claude.modelsEndpointURL(fromBaseURL: "https://relay.example.com/proxy/v1/messages"),
-            URL(string: "https://relay.example.com/proxy/v1/models")
+            URL(string: "https://relay.example.com/proxy/v1/models?limit=1000")
         )
     }
 
@@ -83,6 +83,44 @@ final class ModelCatalogTests: XCTestCase {
             EmotionAnalysisProvider.openAI.endpointURL(fromBaseURL: "https://relay.example.com/v1"),
             URL(string: "https://relay.example.com/v1/chat/completions")
         )
+    }
+
+    /// Anthropic pages /v1/models and defaults to 20, so an unqualified request quietly returns a
+    /// fraction of the catalog.
+    func testClaudeCatalogRequestsTheFullPage() throws {
+        let url = try XCTUnwrap(EmotionAnalysisProvider.claude.modelsEndpointURL(fromBaseURL: nil))
+        let items = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+
+        XCTAssertEqual(items, [URLQueryItem(name: "limit", value: "1000")])
+    }
+
+    /// OpenAI's /v1/models is unpaginated, so a limit would just be noise on the wire.
+    func testOpenAICatalogSendsNoQuery() throws {
+        let url = try XCTUnwrap(EmotionAnalysisProvider.openAI.modelsEndpointURL(fromBaseURL: nil))
+
+        XCTAssertNil(URLComponents(url: url, resolvingAgainstBaseURL: false)?.query)
+    }
+
+    func testCatalogLimitSurvivesAQueryAlreadyOnTheBaseURL() throws {
+        let url = try XCTUnwrap(
+            EmotionAnalysisProvider.claude.modelsEndpointURL(fromBaseURL: "https://relay.example.com?tenant=acme")
+        )
+        let items = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+
+        XCTAssertEqual(
+            items,
+            [URLQueryItem(name: "tenant", value: "acme"), URLQueryItem(name: "limit", value: "1000")]
+        )
+    }
+
+    /// A gateway that pages differently keeps control of its own parameter.
+    func testAnExplicitLimitOnTheBaseURLIsNotOverridden() throws {
+        let url = try XCTUnwrap(
+            EmotionAnalysisProvider.claude.modelsEndpointURL(fromBaseURL: "https://relay.example.com?limit=25")
+        )
+        let items = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+
+        XCTAssertEqual(items, [URLQueryItem(name: "limit", value: "25")])
     }
 
     func testModelsEndpointURLRejectsGarbage() {

--- a/notchi/Tests/ModelCatalogTests.swift
+++ b/notchi/Tests/ModelCatalogTests.swift
@@ -91,53 +91,61 @@ final class ModelCatalogTests: XCTestCase {
 
     // MARK: - Response parsing
 
-    func testParsesOpenAIAndAnthropicCatalogShape() {
+    func testParsesOpenAIAndAnthropicCatalogShape() throws {
         let data = Data("""
         {"object": "list", "data": [{"id": "gpt-4.1-mini"}, {"id": "local-llama"}]}
         """.utf8)
 
-        let models = ModelCatalogService.models(from: data, for: .openAI)
+        let models = try ModelCatalogService.models(from: data, for: .openAI)
 
         XCTAssertEqual(models.map(\.rawValue), ["gpt-4.1-mini", "local-llama"])
     }
 
-    func testParsesGatewaysThatKeyTheListOnModels() {
+    func testParsesGatewaysThatKeyTheListOnModels() throws {
         let data = Data("""
         {"models": [{"id": "mixtral"}, {"name": "qwen-chat"}]}
         """.utf8)
 
-        let models = ModelCatalogService.models(from: data, for: .openAI)
+        let models = try ModelCatalogService.models(from: data, for: .openAI)
 
         XCTAssertEqual(models.map(\.rawValue), ["mixtral", "qwen-chat"])
     }
 
-    func testParsesABareArray() {
+    func testParsesABareArray() throws {
         let data = Data("""
         [{"id": "solo-model"}]
         """.utf8)
 
-        XCTAssertEqual(ModelCatalogService.models(from: data, for: .openAI).map(\.rawValue), ["solo-model"])
+        XCTAssertEqual(try ModelCatalogService.models(from: data, for: .openAI).map(\.rawValue), ["solo-model"])
     }
 
-    func testMalformedPayloadYieldsNoModels() {
-        XCTAssertTrue(ModelCatalogService.models(from: Data("not json".utf8), for: .openAI).isEmpty)
-        XCTAssertTrue(ModelCatalogService.models(from: Data("{}".utf8), for: .openAI).isEmpty)
+    /// An undecodable body must not masquerade as an endpoint that simply lists nothing.
+    func testMalformedPayloadThrowsInvalidResponse() {
+        for payload in ["not json", "{}"] {
+            XCTAssertThrowsError(try ModelCatalogService.models(from: Data(payload.utf8), for: .openAI)) { error in
+                XCTAssertEqual(error as? EmotionAnalysisRequestError, .invalidResponse)
+            }
+        }
     }
 
-    func testCatalogDropsDuplicateIds() {
+    func testSuccessfullyDecodedEmptyCatalogIsNotAnError() throws {
+        XCTAssertTrue(try ModelCatalogService.models(from: Data(#"{"data": []}"#.utf8), for: .openAI).isEmpty)
+    }
+
+    func testCatalogDropsDuplicateIds() throws {
         let data = Data("""
         {"data": [{"id": "gpt-4.1-mini"}, {"id": "gpt-4.1-mini"}]}
         """.utf8)
 
-        XCTAssertEqual(ModelCatalogService.models(from: data, for: .openAI).count, 1)
+        XCTAssertEqual(try ModelCatalogService.models(from: data, for: .openAI).count, 1)
     }
 
-    func testFetchedIdsKeepPresetDisplayNames() {
+    func testFetchedIdsKeepPresetDisplayNames() throws {
         let data = Data("""
         {"data": [{"id": "claude-haiku-4-5-20251001"}]}
         """.utf8)
 
-        let models = ModelCatalogService.models(from: data, for: .claude)
+        let models = try ModelCatalogService.models(from: data, for: .claude)
 
         XCTAssertEqual(models, [.claudeHaiku45])
         XCTAssertEqual(models.first?.displayName, "Claude Haiku 4.5")
@@ -208,11 +216,10 @@ final class ModelCatalogTests: XCTestCase {
 
     @MainActor
     func testModelsAreNotWrittenAcrossProviders() {
+        AppSettings.setEmotionAnalysisModel(.openAIGPT54Nano, for: .openAI)
+
         AppSettings.setEmotionAnalysisModel(.claudeHaiku45, for: .openAI)
 
-        XCTAssertNotEqual(
-            UserDefaults.standard.string(forKey: Self.openAIModelKey),
-            EmotionAnalysisModel.claudeHaiku45.rawValue
-        )
+        XCTAssertEqual(AppSettings.selectedEmotionAnalysisModel(for: .openAI), .openAIGPT54Nano)
     }
 }

--- a/notchi/Tests/ModelCatalogTests.swift
+++ b/notchi/Tests/ModelCatalogTests.swift
@@ -1,0 +1,218 @@
+import Foundation
+import XCTest
+@testable import notchi
+
+final class ModelCatalogTests: XCTestCase {
+    private static let claudeModelKey = "emotionAnalysisClaudeModel"
+    private static let openAIModelKey = "emotionAnalysisOpenAIModel"
+
+    private var savedClaudeModel: String?
+    private var savedOpenAIModel: String?
+
+    override func setUp() {
+        super.setUp()
+        savedClaudeModel = UserDefaults.standard.string(forKey: Self.claudeModelKey)
+        savedOpenAIModel = UserDefaults.standard.string(forKey: Self.openAIModelKey)
+    }
+
+    override func tearDown() {
+        restore(savedClaudeModel, forKey: Self.claudeModelKey)
+        restore(savedOpenAIModel, forKey: Self.openAIModelKey)
+        super.tearDown()
+    }
+
+    private func restore(_ value: String?, forKey key: String) {
+        if let value {
+            UserDefaults.standard.set(value, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    // MARK: - Catalog endpoint
+
+    func testModelsEndpointURLDefaultsWhenBaseURLMissing() {
+        XCTAssertEqual(
+            EmotionAnalysisProvider.claude.modelsEndpointURL(fromBaseURL: nil),
+            URL(string: "https://api.anthropic.com/v1/models")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.openAI.modelsEndpointURL(fromBaseURL: "   "),
+            URL(string: "https://api.openai.com/v1/models")
+        )
+    }
+
+    func testModelsEndpointURLNormalizesCommonBaseURLShapes() {
+        XCTAssertEqual(
+            EmotionAnalysisProvider.openAI.modelsEndpointURL(fromBaseURL: "https://relay.example.com"),
+            URL(string: "https://relay.example.com/v1/models")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.openAI.modelsEndpointURL(fromBaseURL: "https://relay.example.com/v1"),
+            URL(string: "https://relay.example.com/v1/models")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.openAI.modelsEndpointURL(fromBaseURL: "relay.example.com/proxy/"),
+            URL(string: "https://relay.example.com/proxy/v1/models")
+        )
+    }
+
+    /// A base URL pasted as the full chat route must not produce ".../v1/messages/v1/models".
+    func testModelsEndpointURLStripsAChatRouteFromTheBaseURL() {
+        XCTAssertEqual(
+            EmotionAnalysisProvider.claude.modelsEndpointURL(fromBaseURL: "https://relay.example.com/v1/messages"),
+            URL(string: "https://relay.example.com/v1/models")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.openAI.modelsEndpointURL(fromBaseURL: "https://relay.example.com/v1/chat/completions"),
+            URL(string: "https://relay.example.com/v1/models")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.claude.modelsEndpointURL(fromBaseURL: "https://relay.example.com/proxy/v1/messages"),
+            URL(string: "https://relay.example.com/proxy/v1/models")
+        )
+    }
+
+    /// Stripping the chat route must not change how the chat endpoint itself is built.
+    func testChatEndpointURLIsUnchangedByCatalogSupport() {
+        XCTAssertEqual(
+            EmotionAnalysisProvider.claude.endpointURL(fromBaseURL: "https://relay.example.com/v1/messages"),
+            URL(string: "https://relay.example.com/v1/messages")
+        )
+        XCTAssertEqual(
+            EmotionAnalysisProvider.openAI.endpointURL(fromBaseURL: "https://relay.example.com/v1"),
+            URL(string: "https://relay.example.com/v1/chat/completions")
+        )
+    }
+
+    func testModelsEndpointURLRejectsGarbage() {
+        XCTAssertNil(EmotionAnalysisProvider.openAI.modelsEndpointURL(fromBaseURL: "http://"))
+    }
+
+    // MARK: - Response parsing
+
+    func testParsesOpenAIAndAnthropicCatalogShape() {
+        let data = Data("""
+        {"object": "list", "data": [{"id": "gpt-4.1-mini"}, {"id": "local-llama"}]}
+        """.utf8)
+
+        let models = ModelCatalogService.models(from: data, for: .openAI)
+
+        XCTAssertEqual(models.map(\.rawValue), ["gpt-4.1-mini", "local-llama"])
+    }
+
+    func testParsesGatewaysThatKeyTheListOnModels() {
+        let data = Data("""
+        {"models": [{"id": "mixtral"}, {"name": "qwen-chat"}]}
+        """.utf8)
+
+        let models = ModelCatalogService.models(from: data, for: .openAI)
+
+        XCTAssertEqual(models.map(\.rawValue), ["mixtral", "qwen-chat"])
+    }
+
+    func testParsesABareArray() {
+        let data = Data("""
+        [{"id": "solo-model"}]
+        """.utf8)
+
+        XCTAssertEqual(ModelCatalogService.models(from: data, for: .openAI).map(\.rawValue), ["solo-model"])
+    }
+
+    func testMalformedPayloadYieldsNoModels() {
+        XCTAssertTrue(ModelCatalogService.models(from: Data("not json".utf8), for: .openAI).isEmpty)
+        XCTAssertTrue(ModelCatalogService.models(from: Data("{}".utf8), for: .openAI).isEmpty)
+    }
+
+    func testCatalogDropsDuplicateIds() {
+        let data = Data("""
+        {"data": [{"id": "gpt-4.1-mini"}, {"id": "gpt-4.1-mini"}]}
+        """.utf8)
+
+        XCTAssertEqual(ModelCatalogService.models(from: data, for: .openAI).count, 1)
+    }
+
+    func testFetchedIdsKeepPresetDisplayNames() {
+        let data = Data("""
+        {"data": [{"id": "claude-haiku-4-5-20251001"}]}
+        """.utf8)
+
+        let models = ModelCatalogService.models(from: data, for: .claude)
+
+        XCTAssertEqual(models, [.claudeHaiku45])
+        XCTAssertEqual(models.first?.displayName, "Claude Haiku 4.5")
+    }
+
+    // MARK: - Filtering
+
+    func testFilterDropsModelsThatCannotChat() {
+        let ids = ["gpt-4.1-mini", "text-embedding-3-small", "whisper-1", "dall-e-3", "omni-moderation-latest"]
+
+        XCTAssertEqual(ModelCatalogFilter.chatCapable(ids), ["gpt-4.1-mini"])
+    }
+
+    /// An unfamiliar catalog is better shown in full than hidden behind an empty picker.
+    func testFilterKeepsEverythingWhenItWouldOtherwiseEmptyTheList() {
+        let ids = ["my-embedding-only-server"]
+
+        XCTAssertEqual(ModelCatalogFilter.chatCapable(ids), ids)
+    }
+
+    // MARK: - Output token budget
+
+    /// Presets keep the budget the app shipped with, so nothing gets more expensive by default.
+    func testPresetsKeepTheirOriginalTokenBudget() {
+        XCTAssertEqual(EmotionAnalysisModel.claudeHaiku45.maxOutputTokens, 50)
+        XCTAssertEqual(EmotionAnalysisModel.openAIGPT54Mini.maxOutputTokens, 80)
+    }
+
+    /// A local reasoning model can spend 77 reasoning tokens before writing a character, so an
+    /// unknown model needs far more room than the curated ones.
+    func testCustomModelsGetABudgetThatSurvivesReasoningTokens() {
+        let custom = EmotionAnalysisModel.custom("gemma-4-26b-a4b-it", provider: .openAI)
+
+        XCTAssertEqual(custom.maxOutputTokens, EmotionAnalysisModel.customModelOutputTokens)
+        XCTAssertGreaterThan(custom.maxOutputTokens, EmotionAnalysisModel.openAIGPT54Mini.maxOutputTokens)
+    }
+
+    // MARK: - Custom model persistence
+
+    func testResolveMapsKnownIdsToPresetsAndKeepsUnknownOnes() {
+        XCTAssertEqual(EmotionAnalysisModel.resolve("gpt-5.4-mini", for: .openAI), .openAIGPT54Mini)
+        XCTAssertTrue(EmotionAnalysisModel.resolve("gpt-5.4-mini", for: .openAI).isPreset)
+
+        let custom = EmotionAnalysisModel.resolve("llama3.2:latest", for: .openAI)
+        XCTAssertFalse(custom.isPreset)
+        XCTAssertEqual(custom.displayName, "llama3.2:latest")
+    }
+
+    /// The bug this change fixes: an id outside the curated list used to be discarded on read,
+    /// so the picker silently snapped back to the default model.
+    @MainActor
+    func testCustomModelIdSurvivesAStorageRoundTrip() {
+        let custom = EmotionAnalysisModel.custom("llama3.2:latest", provider: .openAI)
+
+        AppSettings.setEmotionAnalysisModel(custom, for: .openAI)
+
+        XCTAssertEqual(AppSettings.storedEmotionAnalysisModel(for: .openAI), custom)
+        XCTAssertEqual(AppSettings.selectedEmotionAnalysisModel(for: .openAI).rawValue, "llama3.2:latest")
+    }
+
+    @MainActor
+    func testBlankStoredModelFallsBackToTheDefault() {
+        UserDefaults.standard.set("   ", forKey: Self.openAIModelKey)
+
+        XCTAssertNil(AppSettings.storedEmotionAnalysisModel(for: .openAI))
+        XCTAssertEqual(AppSettings.selectedEmotionAnalysisModel(for: .openAI), .openAIGPT54Mini)
+    }
+
+    @MainActor
+    func testModelsAreNotWrittenAcrossProviders() {
+        AppSettings.setEmotionAnalysisModel(.claudeHaiku45, for: .openAI)
+
+        XCTAssertNotEqual(
+            UserDefaults.standard.string(forKey: Self.openAIModelKey),
+            EmotionAnalysisModel.claudeHaiku45.rawValue
+        )
+    }
+}

--- a/notchi/Tests/OpenAIResponseHandlingTests.swift
+++ b/notchi/Tests/OpenAIResponseHandlingTests.swift
@@ -4,34 +4,6 @@ import XCTest
 
 final class OpenAIResponseHandlingTests: XCTestCase {
 
-    // MARK: - Reasoning suppression gating
-
-    func testSuppressionIsOffForOpenAIItself() {
-        XCTAssertFalse(OpenAISettingsConfig.suppressesReasoning(at: OpenAISettingsConfig.defaultAPIURL))
-        XCTAssertFalse(
-            OpenAISettingsConfig.suppressesReasoning(
-                at: URL(string: "https://API.OpenAI.com/v1/chat/completions")!
-            )
-        )
-    }
-
-    func testSuppressionIsOnForCustomEndpoints() {
-        XCTAssertTrue(
-            OpenAISettingsConfig.suppressesReasoning(at: URL(string: "http://localhost:1234/v1/chat/completions")!)
-        )
-        XCTAssertTrue(
-            OpenAISettingsConfig.suppressesReasoning(at: URL(string: "https://openrouter.ai/api/v1/chat/completions")!)
-        )
-    }
-
-    /// A fine-tuned id is still served by OpenAI, so it must not cost a rejected request and a retry.
-    func testCustomModelIdOnOpenAIDoesNotTriggerSuppression() {
-        let model = EmotionAnalysisModel.custom("ft:gpt-4.1-mini:acme::abc123", provider: .openAI)
-
-        XCTAssertFalse(model.isPreset)
-        XCTAssertFalse(OpenAISettingsConfig.suppressesReasoning(at: OpenAISettingsConfig.defaultAPIURL))
-    }
-
     // MARK: - Response reading
 
     func testReadsJSONFromContent() throws {

--- a/notchi/Tests/OpenAIResponseHandlingTests.swift
+++ b/notchi/Tests/OpenAIResponseHandlingTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import XCTest
+@testable import notchi
+
+final class OpenAIResponseHandlingTests: XCTestCase {
+
+    // MARK: - Reasoning suppression gating
+
+    func testSuppressionIsOffForOpenAIItself() {
+        XCTAssertFalse(OpenAISettingsConfig.suppressesReasoning(at: OpenAISettingsConfig.defaultAPIURL))
+        XCTAssertFalse(
+            OpenAISettingsConfig.suppressesReasoning(
+                at: URL(string: "https://API.OpenAI.com/v1/chat/completions")!
+            )
+        )
+    }
+
+    func testSuppressionIsOnForCustomEndpoints() {
+        XCTAssertTrue(
+            OpenAISettingsConfig.suppressesReasoning(at: URL(string: "http://localhost:1234/v1/chat/completions")!)
+        )
+        XCTAssertTrue(
+            OpenAISettingsConfig.suppressesReasoning(at: URL(string: "https://openrouter.ai/api/v1/chat/completions")!)
+        )
+    }
+
+    /// A fine-tuned id is still served by OpenAI, so it must not cost a rejected request and a retry.
+    func testCustomModelIdOnOpenAIDoesNotTriggerSuppression() {
+        let model = EmotionAnalysisModel.custom("ft:gpt-4.1-mini:acme::abc123", provider: .openAI)
+
+        XCTAssertFalse(model.isPreset)
+        XCTAssertFalse(OpenAISettingsConfig.suppressesReasoning(at: OpenAISettingsConfig.defaultAPIURL))
+    }
+
+    // MARK: - Response reading
+
+    func testReadsJSONFromContent() throws {
+        let result = try OpenAIChatResponseReader.emotion(
+            from: payload(content: #"{"emotion": "happy", "intensity": 0.8}"#, finishReason: "stop")
+        )
+
+        XCTAssertEqual(result.emotion, "happy")
+        XCTAssertEqual(result.intensity, 0.8, accuracy: 0.0001)
+    }
+
+    func testEmptyContentStoppedOnLengthReportsTruncation() throws {
+        XCTAssertThrowsError(
+            try OpenAIChatResponseReader.emotion(from: payload(content: "", finishReason: "length"))
+        ) { error in
+            XCTAssertEqual(error as? EmotionAnalysisRequestError, .truncatedResponse)
+        }
+    }
+
+    /// A model that hit the cap mid-answer leaves partial JSON, which is truncation rather than
+    /// malformed output. Only empty content was checked before.
+    func testPartialJSONStoppedOnLengthReportsTruncation() throws {
+        XCTAssertThrowsError(
+            try OpenAIChatResponseReader.emotion(from: payload(content: #"{"emotion": "hap"#, finishReason: "length"))
+        ) { error in
+            XCTAssertEqual(error as? EmotionAnalysisRequestError, .truncatedResponse)
+        }
+    }
+
+    /// Genuinely malformed output that stopped normally must not be blamed on the token budget.
+    func testPartialJSONStoppedNormallyIsNotTruncation() throws {
+        XCTAssertThrowsError(
+            try OpenAIChatResponseReader.emotion(from: payload(content: #"{"emotion": "hap"#, finishReason: "stop"))
+        ) { error in
+            XCTAssertNotEqual(error as? EmotionAnalysisRequestError, .truncatedResponse)
+        }
+    }
+
+    func testAnswerDeliveredInTheReasoningChannelIsUsed() throws {
+        let result = try OpenAIChatResponseReader.emotion(
+            from: payload(
+                content: "",
+                reasoningContent: #"{"emotion": "sad", "intensity": 0.4}"#,
+                finishReason: "stop"
+            )
+        )
+
+        XCTAssertEqual(result.emotion, "sad")
+        XCTAssertEqual(result.intensity, 0.4, accuracy: 0.0001)
+    }
+
+    func testResponseWithoutChoicesIsInvalid() throws {
+        let data = try JSONSerialization.data(withJSONObject: ["choices": []])
+
+        XCTAssertThrowsError(try OpenAIChatResponseReader.emotion(from: data)) { error in
+            XCTAssertEqual(error as? EmotionAnalysisRequestError, .invalidResponse)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func payload(
+        content: String?,
+        reasoningContent: String? = nil,
+        finishReason: String
+    ) throws -> Data {
+        var message: [String: Any] = [:]
+        if let content {
+            message["content"] = content
+        }
+        if let reasoningContent {
+            message["reasoning_content"] = reasoningContent
+        }
+
+        return try JSONSerialization.data(
+            withJSONObject: ["choices": [["message": message, "finish_reason": finishReason]]]
+        )
+    }
+}

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -43,38 +43,55 @@ enum EmotionAnalysisProvider: String, CaseIterable, Identifiable {
     }
 }
 
-enum EmotionAnalysisModel: String, CaseIterable, Identifiable {
-    case claudeHaiku45 = "claude-haiku-4-5-20251001"
-    case claudeSonnet46 = "claude-sonnet-4-6"
-    case openAIGPT54Nano = "gpt-5.4-nano"
-    case openAIGPT54Mini = "gpt-5.4-mini"
-    case openAIGPT41Mini = "gpt-4.1-mini"
+nonisolated struct EmotionAnalysisModel: Identifiable, Hashable {
+    let rawValue: String
+    let provider: EmotionAnalysisProvider
+    private let presetName: String?
 
     var id: String { rawValue }
 
-    var provider: EmotionAnalysisProvider {
-        switch self {
-        case .claudeHaiku45, .claudeSonnet46:
-            .claude
-        case .openAIGPT54Nano, .openAIGPT54Mini, .openAIGPT41Mini:
-            .openAI
+    var displayName: String { presetName ?? rawValue }
+
+    var isPreset: Bool { presetName != nil }
+
+    var maxOutputTokens: Int {
+        guard isPreset else {
+            return Self.customModelOutputTokens
+        }
+        switch provider {
+        case .claude:
+            return 50
+        case .openAI:
+            return 80
         }
     }
 
-    var displayName: String {
-        switch self {
-        case .claudeHaiku45:
-            "Claude Haiku 4.5"
-        case .claudeSonnet46:
-            "Claude Sonnet 4.6"
-        case .openAIGPT54Nano:
-            "GPT-5.4 nano"
-        case .openAIGPT54Mini:
-            "GPT-5.4 mini"
-        case .openAIGPT41Mini:
-            "GPT-4.1 mini"
-        }
+    // Reasoning models spend most of this on reasoning tokens: ~266 for a one-sentence prompt.
+    static let customModelOutputTokens = 1024
+
+    private init(rawValue: String, provider: EmotionAnalysisProvider, presetName: String?) {
+        self.rawValue = rawValue
+        self.provider = provider
+        self.presetName = presetName
     }
+
+    static func custom(_ rawValue: String, provider: EmotionAnalysisProvider) -> EmotionAnalysisModel {
+        EmotionAnalysisModel(rawValue: rawValue, provider: provider, presetName: nil)
+    }
+
+    private static func preset(
+        _ rawValue: String,
+        _ presetName: String,
+        _ provider: EmotionAnalysisProvider
+    ) -> EmotionAnalysisModel {
+        EmotionAnalysisModel(rawValue: rawValue, provider: provider, presetName: presetName)
+    }
+
+    static let claudeHaiku45 = preset("claude-haiku-4-5-20251001", "Claude Haiku 4.5", .claude)
+    static let claudeSonnet46 = preset("claude-sonnet-4-6", "Claude Sonnet 4.6", .claude)
+    static let openAIGPT54Nano = preset("gpt-5.4-nano", "GPT-5.4 nano", .openAI)
+    static let openAIGPT54Mini = preset("gpt-5.4-mini", "GPT-5.4 mini", .openAI)
+    static let openAIGPT41Mini = preset("gpt-4.1-mini", "GPT-4.1 mini", .openAI)
 
     static func models(for provider: EmotionAnalysisProvider) -> [EmotionAnalysisModel] {
         switch provider {
@@ -92,6 +109,20 @@ enum EmotionAnalysisModel: String, CaseIterable, Identifiable {
         case .openAI:
             .openAIGPT54Mini
         }
+    }
+
+    static func resolve(_ rawValue: String, for provider: EmotionAnalysisProvider) -> EmotionAnalysisModel {
+        models(for: provider).first { $0.rawValue == rawValue } ?? custom(rawValue, provider: provider)
+    }
+
+    // Identity is the id/provider pair: a fetched model and its preset are the same selection.
+    static func == (lhs: EmotionAnalysisModel, rhs: EmotionAnalysisModel) -> Bool {
+        lhs.rawValue == rhs.rawValue && lhs.provider == rhs.provider
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
+        hasher.combine(provider)
     }
 }
 
@@ -421,12 +452,12 @@ struct AppSettings {
     }
 
     static func storedEmotionAnalysisModel(for provider: EmotionAnalysisProvider) -> EmotionAnalysisModel? {
-        guard let rawValue = UserDefaults.standard.string(forKey: emotionAnalysisModelKey(for: provider)),
-              let model = EmotionAnalysisModel(rawValue: rawValue),
-              model.provider == provider else {
+        guard let rawValue = UserDefaults.standard.string(forKey: emotionAnalysisModelKey(for: provider))?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawValue.isEmpty else {
             return nil
         }
-        return model
+        return EmotionAnalysisModel.resolve(rawValue, for: provider)
     }
 
     static func setEmotionAnalysisModel(_ model: EmotionAnalysisModel, for provider: EmotionAnalysisProvider) {

--- a/notchi/notchi/Localizable.xcstrings
+++ b/notchi/notchi/Localizable.xcstrings
@@ -4882,6 +4882,278 @@
           }
         }
       }
+    },
+    "Could not list models: %@" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "モデルを一覧表示できませんでした: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "모델을 나열할 수 없습니다: %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Không thể liệt kê mô hình: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无法列出模型：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無法列出模型：%@"
+          }
+        }
+      }
+    },
+    "Custom model id" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "カスタムモデル ID"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "사용자 지정 모델 ID"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ID mô hình tùy chỉnh"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "自定义模型 ID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "自訂模型 ID"
+          }
+        }
+      }
+    },
+    "Fetch the models this endpoint serves" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "このエンドポイントが提供するモデルを取得"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이 엔드포인트가 제공하는 모델 가져오기"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tải các mô hình mà điểm cuối này cung cấp"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "获取此端点提供的模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "取得此端點提供的模型"
+          }
+        }
+      }
+    },
+    "Found %lld models at this endpoint." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "このエンドポイントで %lld 個のモデルが見つかりました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이 엔드포인트에서 모델 %lld개를 찾았습니다."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Đã tìm thấy %lld mô hình tại điểm cuối này."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在此端点找到 %lld 个模型。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在此端點找到 %lld 個模型。"
+          }
+        }
+      }
+    },
+    "No models" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "モデルなし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "모델 없음"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Không có mô hình"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "无模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "無模型"
+          }
+        }
+      }
+    },
+    "The endpoint listed no models" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "エンドポイントにモデルがありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "엔드포인트에 모델이 없습니다"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Điểm cuối không liệt kê mô hình nào"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "该端点未列出任何模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "該端點未列出任何模型"
+          }
+        }
+      }
+    },
+    "The model ran out of output tokens before answering" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "モデルが回答する前に出力トークンを使い切りました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "모델이 답변하기 전에 출력 토큰을 모두 사용했습니다"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mô hình đã hết token đầu ra trước khi trả lời"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "模型在作答前耗尽了输出令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "模型在作答前耗盡了輸出 token"
+          }
+        }
+      }
+    },
+    "Truncated" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "切り詰め"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "잘림"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bị cắt ngắn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已截断"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已截斷"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/notchi/notchi/Localizable.xcstrings
+++ b/notchi/notchi/Localizable.xcstrings
@@ -2871,6 +2871,40 @@
         }
       }
     },
+    "OpenAI-compatible" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "OpenAI 互換"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "OpenAI 호환"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tương thích OpenAI"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "OpenAI 兼容"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "OpenAI 相容"
+          }
+        }
+      }
+    },
     "Other" : {
       "localizations" : {
         "ja" : {

--- a/notchi/notchi/Services/EmotionAnalyzer.swift
+++ b/notchi/notchi/Services/EmotionAnalyzer.swift
@@ -71,6 +71,46 @@ enum OpenAISettingsConfig {
     nonisolated static let defaultHost = "api.openai.com"
     nonisolated static let defaultAPIURL = URL(string: "https://api.openai.com/v1/chat/completions")!
     nonisolated static let defaultModelsURL = URL(string: "https://api.openai.com/v1/models")!
+
+    /// OpenAI rejects unrecognised body parameters, so gate suppression on the endpoint rather than
+    /// the model: a custom model id on api.openai.com must not pay for a failed request and a retry.
+    nonisolated static func suppressesReasoning(at apiURL: URL) -> Bool {
+        apiURL.host?.lowercased() != defaultHost
+    }
+}
+
+/// Reads an OpenAI-compatible chat completion, tolerating reasoning models that answer in a
+/// separate channel or stop before finishing.
+enum OpenAIChatResponseReader {
+    nonisolated static func emotion(from data: Data) throws -> (emotion: String, intensity: Double) {
+        let chatResponse = try JSONDecoder().decode(OpenAIChatCompletionResponse.self, from: data)
+
+        guard let choice = chatResponse.choices.first else {
+            throw EmotionAnalysisRequestError.invalidResponse
+        }
+
+        if let text = choice.message.content, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            do {
+                return try EmotionAnalysisResponseParser.parse(text)
+            } catch {
+                // Partial JSON from a model that hit the cap mid-answer is truncation, not bad output.
+                guard choice.finishReason == "length" else { throw error }
+                throw EmotionAnalysisRequestError.truncatedResponse
+            }
+        }
+
+        if let reasoning = choice.message.reasoningContent,
+           let result = try? EmotionAnalysisResponseParser.parse(reasoning) {
+            return result
+        }
+
+        if choice.finishReason == "length" {
+            logger.warning("OpenAI response hit the completion token limit before producing content")
+            throw EmotionAnalysisRequestError.truncatedResponse
+        }
+
+        throw EmotionAnalysisRequestError.invalidResponse
+    }
 }
 
 extension EmotionAnalysisProvider {
@@ -331,12 +371,6 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
 
     var providerName: String { "OpenAI" }
 
-    /// OpenAI itself rejects unrecognised body parameters, so gate on the endpoint rather than the
-    /// model: a custom model id on api.openai.com must not pay for a failed request plus a retry.
-    nonisolated static func suppressesReasoning(at apiURL: URL) -> Bool {
-        apiURL.host?.lowercased() != OpenAISettingsConfig.defaultHost
-    }
-
     private static let reasoningSuppressionFields: [String: Any] = [
         "reasoning_effort": "minimal",
         "chat_template_kwargs": ["enable_thinking": false],
@@ -429,33 +463,7 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
             throw EmotionAnalysisRequestError.httpStatus(provider: providerName, statusCode: httpResponse.statusCode)
         }
 
-        let chatResponse = try JSONDecoder().decode(OpenAIChatCompletionResponse.self, from: data)
-
-        guard let choice = chatResponse.choices.first else {
-            throw EmotionAnalysisRequestError.invalidResponse
-        }
-
-        if let text = choice.message.content, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            do {
-                return try EmotionAnalysisResponseParser.parse(text)
-            } catch {
-                // Partial JSON from a model that hit the cap mid-answer is truncation, not bad output.
-                guard choice.finishReason == "length" else { throw error }
-                throw EmotionAnalysisRequestError.truncatedResponse
-            }
-        }
-
-        if let reasoning = choice.message.reasoningContent,
-           let result = try? EmotionAnalysisResponseParser.parse(reasoning) {
-            return result
-        }
-
-        if choice.finishReason == "length" {
-            logger.warning("OpenAI response hit the completion token limit before producing content")
-            throw EmotionAnalysisRequestError.truncatedResponse
-        }
-
-        throw EmotionAnalysisRequestError.invalidResponse
+        return try OpenAIChatResponseReader.emotion(from: data)
     }
 }
 
@@ -555,7 +563,7 @@ final class EmotionAnalyzer {
             apiKey: apiKey,
             model: model.rawValue,
             maxOutputTokens: model.maxOutputTokens,
-            suppressesReasoning: OpenAIEmotionAnalysisProvider.suppressesReasoning(at: apiURL)
+            suppressesReasoning: OpenAISettingsConfig.suppressesReasoning(at: apiURL)
         )
     }
 
@@ -624,7 +632,7 @@ final class EmotionAnalyzer {
                 apiKey: trimmedKey,
                 model: model.rawValue,
                 maxOutputTokens: model.maxOutputTokens,
-                suppressesReasoning: OpenAIEmotionAnalysisProvider.suppressesReasoning(at: apiURL)
+                suppressesReasoning: OpenAISettingsConfig.suppressesReasoning(at: apiURL)
             )
         }
     }

--- a/notchi/notchi/Services/EmotionAnalyzer.swift
+++ b/notchi/notchi/Services/EmotionAnalyzer.swift
@@ -72,6 +72,54 @@ enum OpenAISettingsConfig {
     nonisolated static let defaultModelsURL = URL(string: "https://api.openai.com/v1/models")!
 }
 
+/// Pulls the readable part out of a non-2xx body. Without it a base-URL or model mismatch shows
+/// only "HTTP 400", which is close to undiagnosable from the settings panel.
+nonisolated enum APIErrorMessageReader {
+    /// Long enough to carry a real explanation, short enough that an HTML error page or a stack
+    /// trace cannot flood the UI.
+    static let maxLength = 160
+
+    static func message(from data: Data) -> String? {
+        guard let text = extract(from: data) else { return nil }
+
+        let collapsed = text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        guard !collapsed.isEmpty else { return nil }
+        guard collapsed.count > maxLength else { return collapsed }
+        return collapsed.prefix(maxLength).trimmingCharacters(in: .whitespaces) + "\u{2026}"
+    }
+
+    /// OpenAI and Anthropic both nest under "error", gateways vary, and a proxy may not send JSON
+    /// at all, so fall back to the raw body.
+    private static func extract(from data: Data) -> String? {
+        if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let message = readable(object["error"]) {
+                return message
+            }
+            if let message = object["message"] as? String {
+                return message
+            }
+            if let message = readable(object["detail"]) {
+                return message
+            }
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func readable(_ field: Any?) -> String? {
+        if let text = field as? String {
+            return text
+        }
+        if let nested = field as? [String: Any] {
+            return nested["message"] as? String ?? nested["type"] as? String
+        }
+        return nil
+    }
+}
+
 /// Reads an OpenAI-compatible chat completion, tolerating reasoning models that answer in a
 /// separate channel or stop before finishing.
 enum OpenAIChatResponseReader {
@@ -143,7 +191,42 @@ extension EmotionAnalysisProvider {
     }
 
     nonisolated func modelsEndpointURL(fromBaseURL baseURL: String?) -> URL? {
-        url(fromBaseURL: baseURL, appending: modelsPathComponents, fallingBackTo: defaultModelsEndpointURL)
+        guard let url = url(
+            fromBaseURL: baseURL,
+            appending: modelsPathComponents,
+            fallingBackTo: defaultModelsEndpointURL
+        ) else {
+            return nil
+        }
+        return Self.appending(catalogQueryItems, to: url)
+    }
+
+    /// Anthropic pages /v1/models and defaults to 20, so an unqualified request silently returns a
+    /// fraction of the catalog. 1000 is the documented maximum and comfortably covers the list.
+    nonisolated private var catalogQueryItems: [URLQueryItem] {
+        switch self {
+        case .claude:
+            [URLQueryItem(name: "limit", value: "1000")]
+        case .openAI:
+            []
+        }
+    }
+
+    /// Keeps whatever query a custom base URL already carries, and yields to it on a name clash so
+    /// a gateway with its own paging rules stays in control.
+    nonisolated private static func appending(_ items: [URLQueryItem], to url: URL) -> URL {
+        guard !items.isEmpty,
+              var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url
+        }
+
+        let existing = components.queryItems ?? []
+        let existingNames = Set(existing.map(\.name))
+        let additions = items.filter { !existingNames.contains($0.name) }
+        guard !additions.isEmpty else { return url }
+
+        components.queryItems = existing + additions
+        return components.url ?? url
     }
 
     nonisolated private func url(
@@ -228,7 +311,7 @@ struct EmotionAnalysisTestResult {
 enum EmotionAnalysisRequestError: LocalizedError, Equatable {
     case missingAPIKey(EmotionAnalysisProvider)
     case invalidBaseURL
-    case httpStatus(provider: String, statusCode: Int)
+    case httpStatus(provider: String, statusCode: Int, message: String?)
     case invalidResponse
     case emptyModelCatalog
     case truncatedResponse
@@ -239,8 +322,9 @@ enum EmotionAnalysisRequestError: LocalizedError, Equatable {
             String(localized: "Missing \(provider.displayName) API key")
         case .invalidBaseURL:
             String(localized: "Invalid API base URL")
-        case .httpStatus(let provider, let statusCode):
+        case .httpStatus(let provider, let statusCode, let message):
             String(localized: "\(provider) API returned HTTP \(statusCode)")
+                + (message.map { ": \($0)" } ?? "")
         case .invalidResponse:
             String(localized: "Invalid emotion analysis response")
         case .emptyModelCatalog:
@@ -256,7 +340,7 @@ enum EmotionAnalysisRequestError: LocalizedError, Equatable {
             String(localized: "Missing")
         case .invalidBaseURL:
             String(localized: "Bad URL")
-        case .httpStatus(_, let statusCode):
+        case .httpStatus(_, let statusCode, _):
             String(localized: "HTTP \(statusCode)")
         case .invalidResponse:
             String(localized: "Invalid")
@@ -342,7 +426,11 @@ private struct ClaudeEmotionAnalysisProvider: EmotionAnalysisProviding {
 
         guard httpResponse.statusCode == 200 else {
             logger.warning("Claude API returned HTTP \(httpResponse.statusCode)")
-            throw EmotionAnalysisRequestError.httpStatus(provider: providerName, statusCode: httpResponse.statusCode)
+            throw EmotionAnalysisRequestError.httpStatus(
+                provider: providerName,
+                statusCode: httpResponse.statusCode,
+                message: APIErrorMessageReader.message(from: data)
+            )
         }
 
         let haikuResponse = try JSONDecoder().decode(HaikuResponse.self, from: data)
@@ -411,7 +499,11 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
 
         guard httpResponse.statusCode == 200 else {
             logger.warning("OpenAI API returned HTTP \(httpResponse.statusCode)")
-            throw EmotionAnalysisRequestError.httpStatus(provider: providerName, statusCode: httpResponse.statusCode)
+            throw EmotionAnalysisRequestError.httpStatus(
+                provider: providerName,
+                statusCode: httpResponse.statusCode,
+                message: APIErrorMessageReader.message(from: data)
+            )
         }
 
         return try OpenAIChatResponseReader.emotion(from: data)

--- a/notchi/notchi/Services/EmotionAnalyzer.swift
+++ b/notchi/notchi/Services/EmotionAnalyzer.swift
@@ -68,15 +68,8 @@ struct ClaudeSettingsConfig {
 }
 
 enum OpenAISettingsConfig {
-    nonisolated static let defaultHost = "api.openai.com"
     nonisolated static let defaultAPIURL = URL(string: "https://api.openai.com/v1/chat/completions")!
     nonisolated static let defaultModelsURL = URL(string: "https://api.openai.com/v1/models")!
-
-    /// OpenAI rejects unrecognised body parameters, so gate suppression on the endpoint rather than
-    /// the model: a custom model id on api.openai.com must not pay for a failed request and a retry.
-    nonisolated static func suppressesReasoning(at apiURL: URL) -> Bool {
-        apiURL.host?.lowercased() != defaultHost
-    }
 }
 
 /// Reads an OpenAI-compatible chat completion, tolerating reasoning models that answer in a
@@ -367,46 +360,16 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
     let apiKey: String
     let model: String
     let maxOutputTokens: Int
-    let suppressesReasoning: Bool
 
     var providerName: String { "OpenAI" }
 
-    private static let reasoningSuppressionFields: [String: Any] = [
-        "reasoning_effort": "minimal",
-        "chat_template_kwargs": ["enable_thinking": false],
-    ]
-
     func analyze(prompt: String, systemPrompt: String) async throws -> (emotion: String, intensity: Double) {
-        let (data, httpResponse) = try await send(
-            prompt: prompt,
-            systemPrompt: systemPrompt,
-            suppressingReasoning: suppressesReasoning
-        )
-
-        if httpResponse.statusCode == 400, suppressesReasoning {
-            logger.info("Endpoint rejected reasoning suppression; retrying without it")
-            let (retryData, retryResponse) = try await send(
-                prompt: prompt,
-                systemPrompt: systemPrompt,
-                suppressingReasoning: false
-            )
-            return try Self.parse(data: retryData, response: retryResponse, providerName: providerName)
-        }
-
-        return try Self.parse(data: data, response: httpResponse, providerName: providerName)
-    }
-
-    private func send(
-        prompt: String,
-        systemPrompt: String,
-        suppressingReasoning: Bool
-    ) async throws -> (Data, HTTPURLResponse) {
         var request = URLRequest(url: apiURL)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "content-type")
 
-        var body: [String: Any] = [
+        let body: [String: Any] = [
             "model": model,
             "max_completion_tokens": maxOutputTokens,
             "response_format": [
@@ -438,10 +401,6 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
             ]
         ]
 
-        if suppressingReasoning {
-            body.merge(Self.reasoningSuppressionFields) { current, _ in current }
-        }
-
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -450,14 +409,6 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
             throw EmotionAnalysisRequestError.invalidResponse
         }
 
-        return (data, httpResponse)
-    }
-
-    private static func parse(
-        data: Data,
-        response httpResponse: HTTPURLResponse,
-        providerName: String
-    ) throws -> (emotion: String, intensity: Double) {
         guard httpResponse.statusCode == 200 else {
             logger.warning("OpenAI API returned HTTP \(httpResponse.statusCode)")
             throw EmotionAnalysisRequestError.httpStatus(provider: providerName, statusCode: httpResponse.statusCode)
@@ -562,8 +513,7 @@ final class EmotionAnalyzer {
             apiURL: apiURL,
             apiKey: apiKey,
             model: model.rawValue,
-            maxOutputTokens: model.maxOutputTokens,
-            suppressesReasoning: OpenAISettingsConfig.suppressesReasoning(at: apiURL)
+            maxOutputTokens: model.maxOutputTokens
         )
     }
 
@@ -631,8 +581,7 @@ final class EmotionAnalyzer {
                 apiURL: apiURL,
                 apiKey: trimmedKey,
                 model: model.rawValue,
-                maxOutputTokens: model.maxOutputTokens,
-                suppressesReasoning: OpenAISettingsConfig.suppressesReasoning(at: apiURL)
+                maxOutputTokens: model.maxOutputTokens
             )
         }
     }

--- a/notchi/notchi/Services/EmotionAnalyzer.swift
+++ b/notchi/notchi/Services/EmotionAnalyzer.swift
@@ -68,6 +68,7 @@ struct ClaudeSettingsConfig {
 }
 
 enum OpenAISettingsConfig {
+    nonisolated static let defaultHost = "api.openai.com"
     nonisolated static let defaultAPIURL = URL(string: "https://api.openai.com/v1/chat/completions")!
     nonisolated static let defaultModelsURL = URL(string: "https://api.openai.com/v1/models")!
 }
@@ -191,7 +192,7 @@ struct EmotionAnalysisTestResult {
     let latencyMilliseconds: Int
 }
 
-enum EmotionAnalysisRequestError: LocalizedError {
+enum EmotionAnalysisRequestError: LocalizedError, Equatable {
     case missingAPIKey(EmotionAnalysisProvider)
     case invalidBaseURL
     case httpStatus(provider: String, statusCode: Int)
@@ -330,7 +331,12 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
 
     var providerName: String { "OpenAI" }
 
-    /// Never sent to api.openai.com, which rejects unrecognised body parameters outright.
+    /// OpenAI itself rejects unrecognised body parameters, so gate on the endpoint rather than the
+    /// model: a custom model id on api.openai.com must not pay for a failed request plus a retry.
+    nonisolated static func suppressesReasoning(at apiURL: URL) -> Bool {
+        apiURL.host?.lowercased() != OpenAISettingsConfig.defaultHost
+    }
+
     private static let reasoningSuppressionFields: [String: Any] = [
         "reasoning_effort": "minimal",
         "chat_template_kwargs": ["enable_thinking": false],
@@ -430,7 +436,13 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
         }
 
         if let text = choice.message.content, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return try EmotionAnalysisResponseParser.parse(text)
+            do {
+                return try EmotionAnalysisResponseParser.parse(text)
+            } catch {
+                // Partial JSON from a model that hit the cap mid-answer is truncation, not bad output.
+                guard choice.finishReason == "length" else { throw error }
+                throw EmotionAnalysisRequestError.truncatedResponse
+            }
         }
 
         if let reasoning = choice.message.reasoningContent,
@@ -543,7 +555,7 @@ final class EmotionAnalyzer {
             apiKey: apiKey,
             model: model.rawValue,
             maxOutputTokens: model.maxOutputTokens,
-            suppressesReasoning: !model.isPreset
+            suppressesReasoning: OpenAIEmotionAnalysisProvider.suppressesReasoning(at: apiURL)
         )
     }
 
@@ -612,7 +624,7 @@ final class EmotionAnalyzer {
                 apiKey: trimmedKey,
                 model: model.rawValue,
                 maxOutputTokens: model.maxOutputTokens,
-                suppressesReasoning: !model.isPreset
+                suppressesReasoning: OpenAIEmotionAnalysisProvider.suppressesReasoning(at: apiURL)
             )
         }
     }

--- a/notchi/notchi/Services/EmotionAnalyzer.swift
+++ b/notchi/notchi/Services/EmotionAnalyzer.swift
@@ -69,6 +69,7 @@ struct ClaudeSettingsConfig {
 
 enum OpenAISettingsConfig {
     nonisolated static let defaultAPIURL = URL(string: "https://api.openai.com/v1/chat/completions")!
+    nonisolated static let defaultModelsURL = URL(string: "https://api.openai.com/v1/models")!
 }
 
 extension EmotionAnalysisProvider {
@@ -81,6 +82,15 @@ extension EmotionAnalysisProvider {
         }
     }
 
+    nonisolated var defaultModelsEndpointURL: URL {
+        switch self {
+        case .claude:
+            URL(string: "\(ClaudeSettingsConfig.defaultBaseURL)/v1/models")!
+        case .openAI:
+            OpenAISettingsConfig.defaultModelsURL
+        }
+    }
+
     nonisolated private var endpointPathComponents: [String] {
         switch self {
         case .claude:
@@ -90,10 +100,26 @@ extension EmotionAnalysisProvider {
         }
     }
 
+    nonisolated private var modelsPathComponents: [String] {
+        ["v1", "models"]
+    }
+
     nonisolated func endpointURL(fromBaseURL baseURL: String?) -> URL? {
+        url(fromBaseURL: baseURL, appending: endpointPathComponents, fallingBackTo: defaultEndpointURL)
+    }
+
+    nonisolated func modelsEndpointURL(fromBaseURL baseURL: String?) -> URL? {
+        url(fromBaseURL: baseURL, appending: modelsPathComponents, fallingBackTo: defaultModelsEndpointURL)
+    }
+
+    nonisolated private func url(
+        fromBaseURL baseURL: String?,
+        appending endpoint: [String],
+        fallingBackTo defaultURL: URL
+    ) -> URL? {
         let trimmed = baseURL?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else {
-            return defaultEndpointURL
+            return defaultURL
         }
 
         let urlString = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
@@ -103,13 +129,22 @@ extension EmotionAnalysisProvider {
             return nil
         }
 
-        let baseComponents = components.path.split(separator: "/").map(String.init)
-        let endpoint = endpointPathComponents
+        let baseComponents = strippingChatEndpoint(from: components.path.split(separator: "/").map(String.init))
         let overlap = (0...min(baseComponents.count, endpoint.count))
             .reversed()
             .first { Array(baseComponents.suffix($0)) == Array(endpoint.prefix($0)) } ?? 0
         components.path = "/" + (baseComponents + endpoint.dropFirst(overlap)).joined(separator: "/")
         return components.url
+    }
+
+    /// Without this, a base URL of ".../v1/messages" yields ".../v1/messages/v1/models".
+    nonisolated private func strippingChatEndpoint(from components: [String]) -> [String] {
+        let chat = endpointPathComponents
+        guard components.count >= chat.count,
+              Array(components.suffix(chat.count)) == chat else {
+            return components
+        }
+        return Array(components.dropLast(chat.count))
     }
 }
 
@@ -126,10 +161,22 @@ private struct OpenAIChatCompletionResponse: Decodable {
 
     struct Choice: Decodable {
         let message: Message
+        let finishReason: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case message
+            case finishReason = "finish_reason"
+        }
     }
 
     struct Message: Decodable {
         let content: String?
+        let reasoningContent: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case content
+            case reasoningContent = "reasoning_content"
+        }
     }
 }
 
@@ -149,6 +196,8 @@ enum EmotionAnalysisRequestError: LocalizedError {
     case invalidBaseURL
     case httpStatus(provider: String, statusCode: Int)
     case invalidResponse
+    case emptyModelCatalog
+    case truncatedResponse
 
     var errorDescription: String? {
         switch self {
@@ -160,6 +209,10 @@ enum EmotionAnalysisRequestError: LocalizedError {
             String(localized: "\(provider) API returned HTTP \(statusCode)")
         case .invalidResponse:
             String(localized: "Invalid emotion analysis response")
+        case .emptyModelCatalog:
+            String(localized: "The endpoint listed no models")
+        case .truncatedResponse:
+            String(localized: "The model ran out of output tokens before answering")
         }
     }
 
@@ -173,6 +226,10 @@ enum EmotionAnalysisRequestError: LocalizedError {
             String(localized: "HTTP \(statusCode)")
         case .invalidResponse:
             String(localized: "Invalid")
+        case .emptyModelCatalog:
+            String(localized: "No models")
+        case .truncatedResponse:
+            String(localized: "Truncated")
         }
     }
 }
@@ -222,6 +279,7 @@ private struct ClaudeEmotionAnalysisProvider: EmotionAnalysisProviding {
     let apiURL: URL
     let apiKey: String
     let model: String
+    let maxOutputTokens: Int
 
     var providerName: String { "Claude" }
 
@@ -234,7 +292,7 @@ private struct ClaudeEmotionAnalysisProvider: EmotionAnalysisProviding {
 
         let body: [String: Any] = [
             "model": model,
-            "max_tokens": 50,
+            "max_tokens": maxOutputTokens,
             "system": systemPrompt,
             "messages": [
                 ["role": "user", "content": prompt]
@@ -267,18 +325,50 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
     let apiURL: URL
     let apiKey: String
     let model: String
+    let maxOutputTokens: Int
+    let suppressesReasoning: Bool
 
     var providerName: String { "OpenAI" }
 
+    /// Never sent to api.openai.com, which rejects unrecognised body parameters outright.
+    private static let reasoningSuppressionFields: [String: Any] = [
+        "reasoning_effort": "minimal",
+        "chat_template_kwargs": ["enable_thinking": false],
+    ]
+
     func analyze(prompt: String, systemPrompt: String) async throws -> (emotion: String, intensity: Double) {
+        let (data, httpResponse) = try await send(
+            prompt: prompt,
+            systemPrompt: systemPrompt,
+            suppressingReasoning: suppressesReasoning
+        )
+
+        if httpResponse.statusCode == 400, suppressesReasoning {
+            logger.info("Endpoint rejected reasoning suppression; retrying without it")
+            let (retryData, retryResponse) = try await send(
+                prompt: prompt,
+                systemPrompt: systemPrompt,
+                suppressingReasoning: false
+            )
+            return try Self.parse(data: retryData, response: retryResponse, providerName: providerName)
+        }
+
+        return try Self.parse(data: data, response: httpResponse, providerName: providerName)
+    }
+
+    private func send(
+        prompt: String,
+        systemPrompt: String,
+        suppressingReasoning: Bool
+    ) async throws -> (Data, HTTPURLResponse) {
         var request = URLRequest(url: apiURL)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "content-type")
 
-        let body: [String: Any] = [
+        var body: [String: Any] = [
             "model": model,
-            "max_completion_tokens": 80,
+            "max_completion_tokens": maxOutputTokens,
             "response_format": [
                 "type": "json_schema",
                 "json_schema": [
@@ -307,6 +397,11 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
                 ["role": "user", "content": prompt]
             ]
         ]
+
+        if suppressingReasoning {
+            body.merge(Self.reasoningSuppressionFields) { current, _ in current }
+        }
+
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -315,6 +410,14 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
             throw EmotionAnalysisRequestError.invalidResponse
         }
 
+        return (data, httpResponse)
+    }
+
+    private static func parse(
+        data: Data,
+        response httpResponse: HTTPURLResponse,
+        providerName: String
+    ) throws -> (emotion: String, intensity: Double) {
         guard httpResponse.statusCode == 200 else {
             logger.warning("OpenAI API returned HTTP \(httpResponse.statusCode)")
             throw EmotionAnalysisRequestError.httpStatus(provider: providerName, statusCode: httpResponse.statusCode)
@@ -322,11 +425,25 @@ private struct OpenAIEmotionAnalysisProvider: EmotionAnalysisProviding {
 
         let chatResponse = try JSONDecoder().decode(OpenAIChatCompletionResponse.self, from: data)
 
-        guard let text = chatResponse.choices.first?.message.content else {
+        guard let choice = chatResponse.choices.first else {
             throw EmotionAnalysisRequestError.invalidResponse
         }
 
-        return try EmotionAnalysisResponseParser.parse(text)
+        if let text = choice.message.content, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return try EmotionAnalysisResponseParser.parse(text)
+        }
+
+        if let reasoning = choice.message.reasoningContent,
+           let result = try? EmotionAnalysisResponseParser.parse(reasoning) {
+            return result
+        }
+
+        if choice.finishReason == "length" {
+            logger.warning("OpenAI response hit the completion token limit before producing content")
+            throw EmotionAnalysisRequestError.truncatedResponse
+        }
+
+        throw EmotionAnalysisRequestError.invalidResponse
     }
 }
 
@@ -389,10 +506,12 @@ final class EmotionAnalyzer {
             guard let apiURL = Self.manualEndpointURL(for: .claude) else {
                 return nil
             }
+            let model = AppSettings.selectedEmotionAnalysisModel(for: .claude)
             return ClaudeEmotionAnalysisProvider(
                 apiURL: apiURL,
                 apiKey: apiKey,
-                model: AppSettings.selectedEmotionAnalysisModel(for: .claude).rawValue
+                model: model.rawValue,
+                maxOutputTokens: model.maxOutputTokens
             )
         }
 
@@ -400,10 +519,13 @@ final class EmotionAnalyzer {
             return nil
         }
 
+        let model = AppSettings.storedEmotionAnalysisModel(for: .claude)
+            ?? EmotionAnalysisModel.resolve(config.model, for: .claude)
         return ClaudeEmotionAnalysisProvider(
             apiURL: config.apiURL,
             apiKey: config.apiKey,
-            model: AppSettings.storedEmotionAnalysisModel(for: .claude)?.rawValue ?? config.model
+            model: model.rawValue,
+            maxOutputTokens: model.maxOutputTokens
         )
     }
 
@@ -415,10 +537,13 @@ final class EmotionAnalyzer {
             return nil
         }
 
+        let model = AppSettings.selectedEmotionAnalysisModel(for: .openAI)
         return OpenAIEmotionAnalysisProvider(
             apiURL: apiURL,
             apiKey: apiKey,
-            model: AppSettings.selectedEmotionAnalysisModel(for: .openAI).rawValue
+            model: model.rawValue,
+            maxOutputTokens: model.maxOutputTokens,
+            suppressesReasoning: !model.isPreset
         )
     }
 
@@ -458,7 +583,8 @@ final class EmotionAnalyzer {
                 return ClaudeEmotionAnalysisProvider(
                     apiURL: apiURL,
                     apiKey: trimmedKey,
-                    model: model.rawValue
+                    model: model.rawValue,
+                    maxOutputTokens: model.maxOutputTokens
                 )
             }
 
@@ -466,7 +592,8 @@ final class EmotionAnalyzer {
                 return ClaudeEmotionAnalysisProvider(
                     apiURL: config.apiURL,
                     apiKey: config.apiKey,
-                    model: model.rawValue
+                    model: model.rawValue,
+                    maxOutputTokens: model.maxOutputTokens
                 )
             }
 
@@ -483,7 +610,9 @@ final class EmotionAnalyzer {
             return OpenAIEmotionAnalysisProvider(
                 apiURL: apiURL,
                 apiKey: trimmedKey,
-                model: model.rawValue
+                model: model.rawValue,
+                maxOutputTokens: model.maxOutputTokens,
+                suppressesReasoning: !model.isPreset
             )
         }
     }

--- a/notchi/notchi/Services/EmotionAnalyzer.swift
+++ b/notchi/notchi/Services/EmotionAnalyzer.swift
@@ -186,6 +186,21 @@ extension EmotionAnalysisProvider {
         ["v1", "models"]
     }
 
+    /// Catalog refresh and free-form model ids only make sense against a self-hosted or proxied
+    /// endpoint, so the settings panel keys those affordances off this.
+    nonisolated static func hasCustomEndpoint(baseURL: String?) -> Bool {
+        !(baseURL?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "").isEmpty
+    }
+
+    /// A custom base URL means the row should name the request shape that is configured rather than
+    /// the vendor whose presets happen to be listed.
+    nonisolated func displayName(forBaseURL baseURL: String?) -> String {
+        guard self == .openAI, Self.hasCustomEndpoint(baseURL: baseURL) else {
+            return displayName
+        }
+        return String(localized: "OpenAI-compatible")
+    }
+
     nonisolated func endpointURL(fromBaseURL baseURL: String?) -> URL? {
         url(fromBaseURL: baseURL, appending: endpointPathComponents, fallingBackTo: defaultEndpointURL)
     }

--- a/notchi/notchi/Services/ModelCatalogService.swift
+++ b/notchi/notchi/Services/ModelCatalogService.swift
@@ -108,7 +108,7 @@ final class ModelCatalogService {
             )
         }
 
-        let models = Self.models(from: data, for: provider)
+        let models = try Self.models(from: data, for: provider)
 
         guard !models.isEmpty else {
             throw EmotionAnalysisRequestError.emptyModelCatalog
@@ -117,9 +117,11 @@ final class ModelCatalogService {
         return models
     }
 
-    nonisolated static func models(from data: Data, for provider: EmotionAnalysisProvider) -> [EmotionAnalysisModel] {
+    /// Throws on an undecodable body so a catalog that is genuinely empty stays distinguishable
+    /// from one that never parsed.
+    nonisolated static func models(from data: Data, for provider: EmotionAnalysisProvider) throws -> [EmotionAnalysisModel] {
         guard let response = try? JSONDecoder().decode(ModelCatalogResponse.self, from: data) else {
-            return []
+            throw EmotionAnalysisRequestError.invalidResponse
         }
 
         var seen = Set<String>()

--- a/notchi/notchi/Services/ModelCatalogService.swift
+++ b/notchi/notchi/Services/ModelCatalogService.swift
@@ -1,0 +1,131 @@
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.ruban.notchi", category: "ModelCatalog")
+
+private nonisolated struct ModelCatalogResponse: Decodable {
+    let ids: [String]
+
+    private struct Entry: Decodable {
+        let id: String?
+        let name: String?
+
+        var identifier: String? {
+            let value = (id ?? name)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return value?.isEmpty == false ? value : nil
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+        case models
+    }
+
+    init(from decoder: Decoder) throws {
+        if let container = try? decoder.container(keyedBy: CodingKeys.self) {
+            let entries = (try? container.decode([Entry].self, forKey: .data))
+                ?? (try? container.decode([Entry].self, forKey: .models))
+            if let entries {
+                ids = entries.compactMap(\.identifier)
+                return
+            }
+        }
+
+        if let entries = try? [Entry](from: decoder) {
+            ids = entries.compactMap(\.identifier)
+            return
+        }
+
+        throw EmotionAnalysisRequestError.invalidResponse
+    }
+}
+
+nonisolated enum ModelCatalogFilter {
+    private static let nonChatFragments = [
+        "embed",
+        "whisper",
+        "tts",
+        "text-to-speech",
+        "dall-e",
+        "moderation",
+        "transcribe",
+        "realtime",
+        "rerank",
+    ]
+
+    /// Returns everything rather than nothing when the filter would empty an unfamiliar catalog.
+    static func chatCapable(_ ids: [String]) -> [String] {
+        let filtered = ids.filter { id in
+            let lowercased = id.lowercased()
+            return !nonChatFragments.contains { lowercased.contains($0) }
+        }
+        return filtered.isEmpty ? ids : filtered
+    }
+}
+
+@MainActor
+final class ModelCatalogService {
+    static let shared = ModelCatalogService()
+
+    private init() {}
+
+    func fetchModels(
+        provider: EmotionAnalysisProvider,
+        apiKey: String?,
+        baseURL: String?
+    ) async throws -> [EmotionAnalysisModel] {
+        let trimmedKey = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        guard !trimmedKey.isEmpty else {
+            throw EmotionAnalysisRequestError.missingAPIKey(provider)
+        }
+
+        guard let url = provider.modelsEndpointURL(fromBaseURL: baseURL) else {
+            throw EmotionAnalysisRequestError.invalidBaseURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        switch provider {
+        case .claude:
+            request.setValue(trimmedKey, forHTTPHeaderField: "x-api-key")
+            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        case .openAI:
+            request.setValue("Bearer \(trimmedKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw EmotionAnalysisRequestError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            logger.warning("\(provider.displayName, privacy: .public) model list returned HTTP \(httpResponse.statusCode)")
+            throw EmotionAnalysisRequestError.httpStatus(
+                provider: provider.displayName,
+                statusCode: httpResponse.statusCode
+            )
+        }
+
+        let models = Self.models(from: data, for: provider)
+
+        guard !models.isEmpty else {
+            throw EmotionAnalysisRequestError.emptyModelCatalog
+        }
+
+        return models
+    }
+
+    nonisolated static func models(from data: Data, for provider: EmotionAnalysisProvider) -> [EmotionAnalysisModel] {
+        guard let response = try? JSONDecoder().decode(ModelCatalogResponse.self, from: data) else {
+            return []
+        }
+
+        var seen = Set<String>()
+        return ModelCatalogFilter.chatCapable(response.ids)
+            .filter { seen.insert($0).inserted }
+            .map { EmotionAnalysisModel.resolve($0, for: provider) }
+    }
+
+}

--- a/notchi/notchi/Services/ModelCatalogService.swift
+++ b/notchi/notchi/Services/ModelCatalogService.swift
@@ -104,7 +104,8 @@ final class ModelCatalogService {
             logger.warning("\(provider.displayName, privacy: .public) model list returned HTTP \(httpResponse.statusCode)")
             throw EmotionAnalysisRequestError.httpStatus(
                 provider: provider.displayName,
-                statusCode: httpResponse.statusCode
+                statusCode: httpResponse.statusCode,
+                message: APIErrorMessageReader.message(from: data)
             )
         }
 

--- a/notchi/notchi/Views/EmotionAnalysisSettingsView.swift
+++ b/notchi/notchi/Views/EmotionAnalysisSettingsView.swift
@@ -5,7 +5,7 @@ struct EmotionAnalysisSettingsView: View {
         case idle
         case testing
         case success(EmotionAnalysisTestResult)
-        case failure(String)
+        case failure(label: String, detail: String)
     }
 
     private enum CatalogState {
@@ -313,8 +313,8 @@ struct EmotionAnalysisSettingsView: View {
             Image(systemName: "checkmark.circle.fill")
                 .panelFont(size: 13)
                 .foregroundColor(TerminalColors.green)
-        case .failure(let message):
-            statusBadge(message, color: TerminalColors.red)
+        case .failure(let label, _):
+            statusBadge(label, color: TerminalColors.red)
         }
     }
 
@@ -327,17 +327,18 @@ struct EmotionAnalysisSettingsView: View {
             testDetailText(String(localized: "Testing \(provider.displayName) with \(model.displayName)..."))
         case .success(let result):
             testDetailText(String(localized: "Result: \(testResultText(result))"))
-        case .failure:
-            testDetailText(canTest ? String(localized: "Could not verify this configuration.") : String(localized: "Add an API key to test this configuration."))
+        case .failure(_, let detail):
+            testDetailText(detail, lineLimit: 3)
         }
     }
 
-    private func testDetailText(_ text: String) -> some View {
+    private func testDetailText(_ text: String, lineLimit: Int = 1) -> some View {
         Text(text)
             .panelFont(size: 10)
             .foregroundColor(TerminalColors.dimmedText)
-            .lineLimit(1)
+            .lineLimit(lineLimit)
             .truncationMode(.tail)
+            .fixedSize(horizontal: false, vertical: true)
             .padding(.leading, 28)
     }
 
@@ -402,7 +403,7 @@ struct EmotionAnalysisSettingsView: View {
         case .loaded(let count):
             testDetailText(String(localized: "Found \(count) models at this endpoint."))
         case .failure(let message):
-            testDetailText(String(localized: "Could not list models: \(message)"))
+            testDetailText(String(localized: "Could not list models: \(message)"), lineLimit: 3)
         }
     }
 
@@ -558,7 +559,7 @@ struct EmotionAnalysisSettingsView: View {
                 isModelPickerExpanded = true
             } catch {
                 guard isCurrentCatalogSnapshot(provider: currentProvider, apiKey: currentAPIKey, baseURL: currentBaseURL) else { return }
-                catalogState = .failure(testErrorText(error))
+                catalogState = .failure(errorDetailText(error, fallback: testErrorText(error)))
             }
         }
     }
@@ -612,7 +613,12 @@ struct EmotionAnalysisSettingsView: View {
                 testState = .success(result)
             } catch {
                 guard isCurrentTestSnapshot(provider: currentProvider, model: currentModel, apiKey: currentAPIKey, baseURL: currentBaseURL) else { return }
-                testState = .failure(testErrorText(error))
+                testState = .failure(
+                    label: testErrorText(error),
+                    detail: canTest
+                        ? errorDetailText(error, fallback: String(localized: "Could not verify this configuration."))
+                        : String(localized: "Add an API key to test this configuration.")
+                )
             }
         }
     }
@@ -636,6 +642,16 @@ struct EmotionAnalysisSettingsView: View {
 
     private func testResultText(_ result: EmotionAnalysisTestResult) -> String {
         "\(result.emotion.capitalized) \(String(format: "%.2f", result.intensity)) - \(result.latencyMilliseconds)ms"
+    }
+
+    /// The badge stays terse; the line under it carries whatever the endpoint actually said, which
+    /// is the only way to tell a model or base-URL mismatch apart from a plain bad key.
+    private func errorDetailText(_ error: Error, fallback: String) -> String {
+        guard let requestError = error as? EmotionAnalysisRequestError,
+              let description = requestError.errorDescription else {
+            return fallback
+        }
+        return description
     }
 
     private func testErrorText(_ error: Error) -> String {

--- a/notchi/notchi/Views/EmotionAnalysisSettingsView.swift
+++ b/notchi/notchi/Views/EmotionAnalysisSettingsView.swift
@@ -8,6 +8,13 @@ struct EmotionAnalysisSettingsView: View {
         case failure(String)
     }
 
+    private enum CatalogState {
+        case idle
+        case loading
+        case loaded(Int)
+        case failure(String)
+    }
+
     @State private var provider = AppSettings.emotionAnalysisProvider
     @State private var model = AppSettings.selectedEmotionAnalysisModel(for: AppSettings.emotionAnalysisProvider)
     @State private var apiKeyInput = AppSettings.apiKey(for: AppSettings.emotionAnalysisProvider) ?? ""
@@ -15,12 +22,29 @@ struct EmotionAnalysisSettingsView: View {
     @State private var isProviderPickerExpanded = false
     @State private var isModelPickerExpanded = false
     @State private var testState: TestState = .idle
+    @State private var catalogState: CatalogState = .idle
+    @State private var fetchedModels: [EmotionAnalysisModel] = []
+    @State private var customModelInput = ""
     @State private var setupLinkShakePhase: CGFloat = 0
     @FocusState private var isAPIKeyFocused: Bool
     @FocusState private var isBaseURLFocused: Bool
+    @FocusState private var isCustomModelFocused: Bool
 
     private var hasApiKey: Bool {
         !apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var modelOptions: [EmotionAnalysisModel] {
+        var seen = Set<EmotionAnalysisModel>()
+        return (EmotionAnalysisModel.models(for: provider) + fetchedModels + [model])
+            .filter { $0.provider == provider && seen.insert($0).inserted }
+    }
+
+    private var isFetchingModels: Bool {
+        if case .loading = catalogState {
+            return true
+        }
+        return false
     }
 
     var body: some View {
@@ -44,9 +68,11 @@ struct EmotionAnalysisSettingsView: View {
         .animation(.spring(response: 0.3), value: isModelPickerExpanded)
         .onChange(of: apiKeyInput) { _, _ in
             resetTestState()
+            resetCatalogState()
         }
         .onChange(of: baseURLInput) { _, _ in
             resetTestState()
+            resetCatalogState()
         }
         .onChange(of: isBaseURLFocused) { _, focused in
             guard !focused else { return }
@@ -317,35 +343,114 @@ struct EmotionAnalysisSettingsView: View {
 
     private var modelSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Button(action: {
-                blurAPIKeyField()
-                isModelPickerExpanded.toggle()
-            }) {
-                SettingsRowView(icon: "cpu", title: "Model") {
-                    HStack(spacing: 4) {
-                        Text(model.displayName)
-                            .panelFont(size: 11)
-                            .foregroundColor(TerminalColors.secondaryText)
-                        Image(systemName: isModelPickerExpanded ? "chevron.up" : "chevron.down")
-                            .panelFont(size: 9)
-                            .foregroundColor(TerminalColors.dimmedText)
+            HStack(spacing: 8) {
+                Button(action: {
+                    blurAPIKeyField()
+                    isModelPickerExpanded.toggle()
+                }) {
+                    SettingsRowView(icon: "cpu", title: "Model") {
+                        HStack(spacing: 4) {
+                            Text(model.displayName)
+                                .panelFont(size: 11)
+                                .foregroundColor(TerminalColors.secondaryText)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Image(systemName: isModelPickerExpanded ? "chevron.up" : "chevron.down")
+                                .panelFont(size: 9)
+                                .foregroundColor(TerminalColors.dimmedText)
+                        }
                     }
                 }
+                .buttonStyle(.plain)
+
+                refreshModelsButton
             }
-            .buttonStyle(.plain)
 
             if isModelPickerExpanded {
                 modelPicker
             }
+
+            catalogDetailView
+        }
+    }
+
+    private var refreshModelsButton: some View {
+        Button(action: refreshModelCatalog) {
+            Group {
+                if isFetchingModels {
+                    ProgressView()
+                        .controlSize(.mini)
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                        .panelFont(size: 11)
+                        .foregroundColor(hasApiKey ? TerminalColors.secondaryText : TerminalColors.dimmedText)
+                }
+            }
+            .frame(width: 16, height: 16)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isFetchingModels || !hasApiKey)
+        .help("Fetch the models this endpoint serves")
+    }
+
+    @ViewBuilder
+    private var catalogDetailView: some View {
+        switch catalogState {
+        case .idle, .loading:
+            EmptyView()
+        case .loaded(let count):
+            testDetailText(String(localized: "Found \(count) models at this endpoint."))
+        case .failure(let message):
+            testDetailText(String(localized: "Could not list models: \(message)"))
         }
     }
 
     private var modelPicker: some View {
-        SettingsPicker(rowCount: EmotionAnalysisModel.models(for: provider).count) {
-            ForEach(EmotionAnalysisModel.models(for: provider)) { option in
+        SettingsPicker(rowCount: modelOptions.count + 1) {
+            ForEach(modelOptions) { option in
                 modelRow(option)
             }
+            customModelRow
         }
+    }
+
+    private var customModelRow: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(Color.clear)
+                .frame(width: 6, height: 6)
+
+            ZStack(alignment: .leading) {
+                TextField("", text: $customModelInput)
+                    .textFieldStyle(.plain)
+                    .panelFont(size: 11, design: .monospaced)
+                    .foregroundColor(TerminalColors.primaryText)
+                    .focused($isCustomModelFocused)
+                    .onSubmit(commitCustomModel)
+
+                if customModelInput.isEmpty {
+                    Text("Custom model id")
+                        .panelFont(size: 11, design: .monospaced)
+                        .foregroundColor(TerminalColors.dimmedText)
+                        .allowsHitTesting(false)
+                }
+            }
+
+            Button(action: commitCustomModel) {
+                Image(systemName: "arrow.right.circle")
+                    .panelFont(size: 12)
+                    .foregroundColor(hasCustomModelInput ? TerminalColors.green : TerminalColors.dimmedText)
+            }
+            .buttonStyle(.plain)
+            .disabled(!hasCustomModelInput)
+        }
+        .padding(.horizontal, SettingsLayout.pickerOptionHorizontalPadding)
+        .padding(.vertical, SettingsLayout.pickerOptionVerticalPadding)
+    }
+
+    private var hasCustomModelInput: Bool {
+        !customModelInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private func modelRow(_ option: EmotionAnalysisModel) -> some View {
@@ -408,15 +513,67 @@ struct EmotionAnalysisSettingsView: View {
         model = AppSettings.selectedEmotionAnalysisModel(for: newProvider)
         apiKeyInput = AppSettings.apiKey(for: newProvider) ?? ""
         baseURLInput = AppSettings.apiBaseURL(for: newProvider) ?? ""
+        customModelInput = ""
         resetTestState()
+        resetCatalogState()
     }
 
     private func selectModel(_ newModel: EmotionAnalysisModel) {
         blurAPIKeyField()
+        isCustomModelFocused = false
         guard newModel != model else { return }
         model = newModel
         AppSettings.setEmotionAnalysisModel(newModel, for: provider)
         resetTestState()
+    }
+
+    private func commitCustomModel() {
+        let trimmed = customModelInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        selectModel(EmotionAnalysisModel.resolve(trimmed, for: provider))
+        customModelInput = ""
+        isCustomModelFocused = false
+    }
+
+    private func refreshModelCatalog() {
+        blurAPIKeyField()
+        guard !isFetchingModels else { return }
+        // Deliberately does not persist the base URL: a refresh could then clear a stored one.
+        catalogState = .loading
+
+        let currentProvider = provider
+        let currentAPIKey = apiKeyInput
+        let currentBaseURL = baseURLInput
+
+        Task { @MainActor in
+            do {
+                let models = try await ModelCatalogService.shared.fetchModels(
+                    provider: currentProvider,
+                    apiKey: currentAPIKey,
+                    baseURL: currentBaseURL
+                )
+                guard isCurrentCatalogSnapshot(provider: currentProvider, apiKey: currentAPIKey, baseURL: currentBaseURL) else { return }
+                fetchedModels = models
+                catalogState = .loaded(models.count)
+                isModelPickerExpanded = true
+            } catch {
+                guard isCurrentCatalogSnapshot(provider: currentProvider, apiKey: currentAPIKey, baseURL: currentBaseURL) else { return }
+                catalogState = .failure(testErrorText(error))
+            }
+        }
+    }
+
+    private func resetCatalogState() {
+        catalogState = .idle
+        fetchedModels = []
+    }
+
+    private func isCurrentCatalogSnapshot(
+        provider: EmotionAnalysisProvider,
+        apiKey: String,
+        baseURL: String
+    ) -> Bool {
+        self.provider == provider && apiKeyInput == apiKey && baseURLInput == baseURL
     }
 
     private func saveApiKey(for provider: EmotionAnalysisProvider) {

--- a/notchi/notchi/Views/EmotionAnalysisSettingsView.swift
+++ b/notchi/notchi/Views/EmotionAnalysisSettingsView.swift
@@ -34,6 +34,15 @@ struct EmotionAnalysisSettingsView: View {
         !apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    /// Against stock OpenAI a refresh would bury the curated picker under ~90 models.
+    private var hasCustomEndpoint: Bool {
+        EmotionAnalysisProvider.hasCustomEndpoint(baseURL: baseURLInput)
+    }
+
+    private var providerLabel: String {
+        provider.displayName(forBaseURL: baseURLInput)
+    }
+
     private var modelOptions: [EmotionAnalysisModel] {
         var seen = Set<EmotionAnalysisModel>()
         return (EmotionAnalysisModel.models(for: provider) + fetchedModels + [model])
@@ -73,6 +82,9 @@ struct EmotionAnalysisSettingsView: View {
         .onChange(of: baseURLInput) { _, _ in
             resetTestState()
             resetCatalogState()
+            if !hasCustomEndpoint {
+                customModelInput = ""
+            }
         }
         .onChange(of: isBaseURLFocused) { _, focused in
             guard !focused else { return }
@@ -101,9 +113,10 @@ struct EmotionAnalysisSettingsView: View {
             }) {
                 SettingsRowView(icon: "switch.2", title: "Provider") {
                     HStack(spacing: 4) {
-                        Text(provider.displayName)
+                        Text(providerLabel)
                             .panelFont(size: 11)
                             .foregroundColor(TerminalColors.secondaryText)
+                            .lineLimit(1)
                         Image(systemName: isProviderPickerExpanded ? "chevron.up" : "chevron.down")
                             .panelFont(size: 9)
                             .foregroundColor(TerminalColors.dimmedText)
@@ -324,7 +337,7 @@ struct EmotionAnalysisSettingsView: View {
         case .idle:
             EmptyView()
         case .testing:
-            testDetailText(String(localized: "Testing \(provider.displayName) with \(model.displayName)..."))
+            testDetailText(String(localized: "Testing \(providerLabel) with \(model.displayName)..."))
         case .success(let result):
             testDetailText(String(localized: "Result: \(testResultText(result))"))
         case .failure(_, let detail):
@@ -364,7 +377,9 @@ struct EmotionAnalysisSettingsView: View {
                 }
                 .buttonStyle(.plain)
 
-                refreshModelsButton
+                if hasCustomEndpoint {
+                    refreshModelsButton
+                }
             }
 
             if isModelPickerExpanded {
@@ -408,11 +423,13 @@ struct EmotionAnalysisSettingsView: View {
     }
 
     private var modelPicker: some View {
-        SettingsPicker(rowCount: modelOptions.count + 1) {
+        SettingsPicker(rowCount: modelOptions.count + (hasCustomEndpoint ? 1 : 0)) {
             ForEach(modelOptions) { option in
                 modelRow(option)
             }
-            customModelRow
+            if hasCustomEndpoint {
+                customModelRow
+            }
         }
     }
 


### PR DESCRIPTION
Closes #105

Adds model discovery for custom endpoints.

- ↻ next to the model picker calls `GET /v1/models` and lists what the endpoint serves
- free-text model id row for servers that don't expose a catalog route
- `EmotionAnalysisModel` becomes an open value type rather than a closed enum, so presets keep their friendly names while any other id round-trips unchanged. Also fixes unknown stored ids being discarded on read.
- the decoder tolerates the `data` / `models` / bare-array shapes different gateways return, and filters out embedding/audio/image models that can't serve a chat completion

Reasoning models served from custom endpoints spend the completion budget on reasoning tokens before writing anything, so the request had to survive that: the output token budget is per-model now (presets unchanged), the answer is read from `reasoning_content` when a model replies there, and a truncated reply reports as such instead of dying in JSON parsing.

- no new dependencies
- 19 new tests, full suite green via `./scripts/test.sh all`
- ja/zh-Hans/zh-Hant/ko/vi added for the new strings, marked `needs_review` since I'm not a native speaker
