### PR TITLE
feat(usage): add a setting to choose the main usage bar period

### DIFF
--- a/notchi/Tests/ClaudeUsageServiceTests+HeadersFallback.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests+HeadersFallback.swift
@@ -58,6 +58,25 @@ extension ClaudeUsageServiceTests {
         XCTAssertEqual(scheduler.intervals, [60])
     }
 
+    func testWeeklyUsageIsHeldOverWhileHeadersFallbackIsActive() async throws {
+        let recorder = RequestRecorder()
+        let (service, _) = makeService(
+            fetchUsage: oauth403ThenHeaders(
+                recorder: recorder,
+                oauthResponse: { (Data(), self.makeResponse(statusCode: 403)) }
+            ) { _, _ in
+                (Data(), self.makeHeadersResponse(
+                    utilization: "0.42",
+                    reset: "2099-01-01T01:00:00Z"
+                ))
+            }
+        )
+        await service.performFetch(with: "token")
+
+        XCTAssertFalse(service.isUsageStale)
+        XCTAssertTrue(service.isWeeklyUsageHeldOver)
+    }
+
     func testOAuth403HeadersFallbackDoesNotPersist429RecoveryState() async throws {
         let scheduler = PollSchedulerSpy()
         var savedSnapshots: [ClaudeUsageRecoverySnapshot] = []

--- a/notchi/Tests/ClaudeUsageServiceTests+Polling.swift
+++ b/notchi/Tests/ClaudeUsageServiceTests+Polling.swift
@@ -20,6 +20,57 @@ extension ClaudeUsageServiceTests {
         XCTAssertEqual(service.currentWeeklyUsage?.usagePercentage, 58)
     }
 
+    func testFailedRefreshMarksWeeklyOnlyUsageAsStaleInsteadOfFresh() async throws {
+        var calls = 0
+        let (service, _) = makeService(fetchUsage: { _ in
+            calls += 1
+            if calls == 1 {
+                let weeklyOnly = try JSONSerialization.data(withJSONObject: [
+                    "seven_day": ["utilization": 58.0, "resets_at": "2099-01-08T01:00:00Z"]
+                ])
+                return (weeklyOnly, self.makeResponse(statusCode: 200))
+            }
+            throw URLError(.notConnectedToInternet)
+        })
+
+        await service.performFetch(with: "token")
+        XCTAssertNil(service.currentUsage)
+        XCTAssertEqual(service.currentWeeklyUsage?.usagePercentage, 58)
+
+        await service.performFetch(with: "token")
+
+        XCTAssertEqual(service.recoveryAction, .retry)
+        XCTAssertNil(service.error)
+        XCTAssertNotNil(service.statusMessage)
+        XCTAssertTrue(service.isUsageStale)
+        XCTAssertTrue(service.isWeeklyUsageHeldOver)
+    }
+
+    func testFailedRefreshMarksModelOnlyUsageAsStaleInsteadOfFresh() async throws {
+        var calls = 0
+        let (service, _) = makeService(fetchUsage: { _ in
+            calls += 1
+            if calls == 1 {
+                let modelOnly = try JSONSerialization.data(withJSONObject: [
+                    "seven_day_sonnet": ["utilization": 63.0]
+                ])
+                return (modelOnly, self.makeResponse(statusCode: 200))
+            }
+            throw URLError(.notConnectedToInternet)
+        })
+
+        await service.performFetch(with: "token")
+        XCTAssertNil(service.currentUsage)
+        XCTAssertNil(service.currentWeeklyUsage)
+        XCTAssertEqual(service.currentModelUsage?.usagePercentage, 63)
+
+        await service.performFetch(with: "token")
+
+        XCTAssertNil(service.error)
+        XCTAssertNotNil(service.statusMessage)
+        XCTAssertTrue(service.isUsageStale)
+    }
+
     func testSuccessfulFetchReenablesUsageFlag() async throws {
         AppSettings.isUsageEnabled = false
         let dependencies = makeDependencies(

--- a/notchi/Tests/CodexUsageServiceTests.swift
+++ b/notchi/Tests/CodexUsageServiceTests.swift
@@ -90,6 +90,43 @@ final class CodexUsageServiceTests: XCTestCase {
         XCTAssertTrue(service.hasUsageData)
     }
 
+    func testRefreshDropsExpiredSessionQuotaWhenWeeklyQuotaStillValid() async {
+        let service = CodexUsageService(dependencies: CodexUsageServiceDependencies(
+            resolveUsage: { _ in
+                CodexUsageSnapshot(
+                    usage: QuotaPeriod(utilization: 61, resetDate: Date(timeIntervalSince1970: 1_000)),
+                    weeklyUsage: QuotaPeriod(utilization: 22, resetDate: Date(timeIntervalSince1970: 5_000)),
+                    observedAt: Date(timeIntervalSince1970: 900)
+                )
+            },
+            now: { Date(timeIntervalSince1970: 1_010) }
+        ))
+
+        await service.refresh(transcriptPaths: ["/tmp/rollout.jsonl"])
+
+        XCTAssertNil(service.currentUsage)
+        XCTAssertEqual(service.currentWeeklyUsage?.usagePercentage, 22)
+        XCTAssertEqual(service.displayUsage?.usagePercentage, 22)
+    }
+
+    func testRefreshDropsExpiredWeeklyQuotaWhenSessionQuotaStillValid() async {
+        let service = CodexUsageService(dependencies: CodexUsageServiceDependencies(
+            resolveUsage: { _ in
+                CodexUsageSnapshot(
+                    usage: QuotaPeriod(utilization: 61, resetDate: Date(timeIntervalSince1970: 1_500)),
+                    weeklyUsage: QuotaPeriod(utilization: 22, resetDate: Date(timeIntervalSince1970: 1_000)),
+                    observedAt: Date(timeIntervalSince1970: 900)
+                )
+            },
+            now: { Date(timeIntervalSince1970: 1_010) }
+        ))
+
+        await service.refresh(transcriptPaths: ["/tmp/rollout.jsonl"])
+
+        XCTAssertEqual(service.currentUsage?.usagePercentage, 61)
+        XCTAssertNil(service.currentWeeklyUsage)
+    }
+
     func testDisplayUsageFallsBackToWeeklyWhenSessionQuotaMissing() async {
         let service = CodexUsageService(dependencies: CodexUsageServiceDependencies(
             resolveUsage: { _ in

--- a/notchi/Tests/ExpandedPanelViewTests.swift
+++ b/notchi/Tests/ExpandedPanelViewTests.swift
@@ -103,6 +103,61 @@ final class ExpandedPanelViewTests: XCTestCase {
         XCTAssertEqual(state?.usage?.usagePercentage, 11)
     }
 
+    func testContextSessionProviderFallsBackWhenItHasNoDataForSelectedPeriod() {
+        // e.g. Weekly is selected, the context session is Codex, but Codex has no weekly quota
+        // yet while Claude does — the bar should show Claude's data rather than an empty Codex bar.
+        let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
+        let claude = makeUsageState(provider: .claude, usage: 42, observedAt: Date(timeIntervalSince1970: 100))
+        let codexWithoutDataForPeriod = makeUsageState(provider: .codex, usage: nil, observedAt: Date(timeIntervalSince1970: 200))
+
+        let state = ExpandedPanelView.sharedUsageBarState(
+            contextSession: codexSession,
+            claude: claude,
+            codex: codexWithoutDataForPeriod
+        )
+
+        XCTAssertEqual(state?.provider, .claude)
+        XCTAssertEqual(state?.usage?.usagePercentage, 42)
+    }
+
+    func testContextSessionProviderWinsWhenNeitherProviderHasDataForSelectedPeriod() {
+        let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
+        let claude = makeUsageState(provider: .claude, usage: nil, observedAt: Date(timeIntervalSince1970: 100))
+        let codex = makeUsageState(provider: .codex, usage: nil, observedAt: Date(timeIntervalSince1970: 200))
+
+        let state = ExpandedPanelView.sharedUsageBarState(
+            contextSession: codexSession,
+            claude: claude,
+            codex: codex
+        )
+
+        XCTAssertEqual(state?.provider, .codex)
+        XCTAssertNil(state?.usage)
+    }
+
+    func testRecencyArbitrationFallsBackWhenTheNewerProviderHasNoDataForSelectedPeriod() {
+        let claude = makeUsageState(provider: .claude, usage: 42, observedAt: Date(timeIntervalSince1970: 100))
+        let codexNewerButWithoutDataForPeriod = makeUsageState(
+            provider: .codex, usage: nil, observedAt: Date(timeIntervalSince1970: 200)
+        )
+
+        let state = ExpandedPanelView.sharedUsageBarState(
+            contextSession: nil,
+            claude: claude,
+            codex: codexNewerButWithoutDataForPeriod
+        )
+
+        XCTAssertEqual(state?.provider, .claude)
+        XCTAssertEqual(state?.usage?.usagePercentage, 42)
+    }
+
+    func testExtraUsageIndicatorOnlyAppliesToTheSessionPeriod() {
+        XCTAssertTrue(ExpandedPanelView.mainUsageIsUsingExtraUsage(for: .session, isUsingExtraUsage: true))
+        XCTAssertFalse(ExpandedPanelView.mainUsageIsUsingExtraUsage(for: .weekly, isUsingExtraUsage: true))
+        XCTAssertFalse(ExpandedPanelView.mainUsageIsUsingExtraUsage(for: .session, isUsingExtraUsage: false))
+        XCTAssertFalse(ExpandedPanelView.mainUsageIsUsingExtraUsage(for: .weekly, isUsingExtraUsage: false))
+    }
+
     func testHoveredSessionProviderDrivesUsageState() {
         let hoveredCodexSession = SessionData(sessionId: "hovered-codex-session", provider: .codex, cwd: "/tmp/project")
         let claude = makeUsageState(provider: .claude, usage: 42, observedAt: Date(timeIntervalSince1970: 200))
@@ -260,12 +315,12 @@ final class ExpandedPanelViewTests: XCTestCase {
 
     private func makeUsageState(
         provider: AgentProvider,
-        usage: Double,
+        usage: Double?,
         observedAt: Date
     ) -> SharedUsageBarState {
         SharedUsageBarState(
             provider: provider,
-            usage: QuotaPeriod(utilization: usage, resetDate: Date(timeIntervalSince1970: 1_000)),
+            usage: usage.map { QuotaPeriod(utilization: $0, resetDate: Date(timeIntervalSince1970: 1_000)) },
             isUsingExtraUsage: false,
             isLoading: false,
             error: nil,

--- a/notchi/Tests/ExpandedPanelViewTests.swift
+++ b/notchi/Tests/ExpandedPanelViewTests.swift
@@ -151,6 +151,46 @@ final class ExpandedPanelViewTests: XCTestCase {
         XCTAssertEqual(state?.usage?.usagePercentage, 42)
     }
 
+    func testFallbackDoesNotOverrideAPreferredProviderThatIsStillLoading() {
+        let claudeSession = SessionData(sessionId: "claude-session", provider: .claude, cwd: "/tmp/project")
+        let claudeLoading = makeUsageState(provider: .claude, usage: nil, observedAt: Date(timeIntervalSince1970: 100), isLoading: true)
+        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 200))
+
+        let state = ExpandedPanelView.sharedUsageBarState(
+            contextSession: claudeSession,
+            claude: claudeLoading,
+            codex: codex
+        )
+
+        XCTAssertEqual(state?.provider, .claude)
+        XCTAssertTrue(state?.isLoading ?? false)
+    }
+
+    func testFallbackDoesNotOverrideAPreferredProviderShowingAnError() {
+        let claudeSession = SessionData(sessionId: "claude-session", provider: .claude, cwd: "/tmp/project")
+        let claudeErrored = makeUsageState(
+            provider: .claude, usage: nil, observedAt: Date(timeIntervalSince1970: 100), error: "Connection failed"
+        )
+        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 200))
+
+        let state = ExpandedPanelView.sharedUsageBarState(
+            contextSession: claudeSession,
+            claude: claudeErrored,
+            codex: codex
+        )
+
+        XCTAssertEqual(state?.provider, .claude)
+        XCTAssertEqual(state?.error, "Connection failed")
+    }
+
+    func testMainUsageIsStaleAppliesHeadersFallbackOnlyToWeeklyPeriod() {
+        XCTAssertFalse(ExpandedPanelView.mainUsageIsStale(for: .session, isUsageStale: false, isUsingHeadersFallback: true))
+        XCTAssertTrue(ExpandedPanelView.mainUsageIsStale(for: .weekly, isUsageStale: false, isUsingHeadersFallback: true))
+        XCTAssertTrue(ExpandedPanelView.mainUsageIsStale(for: .session, isUsageStale: true, isUsingHeadersFallback: false))
+        XCTAssertTrue(ExpandedPanelView.mainUsageIsStale(for: .weekly, isUsageStale: true, isUsingHeadersFallback: false))
+        XCTAssertFalse(ExpandedPanelView.mainUsageIsStale(for: .weekly, isUsageStale: false, isUsingHeadersFallback: false))
+    }
+
     func testExtraUsageIndicatorOnlyAppliesToTheSessionPeriod() {
         XCTAssertTrue(ExpandedPanelView.mainUsageIsUsingExtraUsage(for: .session, isUsingExtraUsage: true))
         XCTAssertFalse(ExpandedPanelView.mainUsageIsUsingExtraUsage(for: .weekly, isUsingExtraUsage: true))
@@ -285,6 +325,35 @@ final class ExpandedPanelViewTests: XCTestCase {
         XCTAssertEqual(provider, .codex)
     }
 
+    func testUsageDetailPrefersTheDisplayedFallbackProviderOverContextSession() {
+        // Mirrors the shared-bar fallback: context session is Codex, but the bar is actually
+        // showing Claude because Codex had no data for the selected period. Tapping it should
+        // open the detail view on Claude, not silently reopen on Codex.
+        let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
+
+        let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            requestedProvider: nil,
+            contextSession: codexSession,
+            displayedSharedUsageProvider: .claude,
+            lastUsedProvider: .codex
+        )
+
+        XCTAssertEqual(provider, .claude)
+    }
+
+    func testUsageDetailStillPrefersAnExplicitRequestOverTheDisplayedFallbackProvider() {
+        let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
+
+        let provider = ExpandedPanelView.usageDetailDefaultProvider(
+            requestedProvider: .codex,
+            contextSession: codexSession,
+            displayedSharedUsageProvider: .claude,
+            lastUsedProvider: .codex
+        )
+
+        XCTAssertEqual(provider, .codex)
+    }
+
     func testUsageDetailOpensOnRequestedProviderOverContextSession() {
         let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
 
@@ -316,14 +385,16 @@ final class ExpandedPanelViewTests: XCTestCase {
     private func makeUsageState(
         provider: AgentProvider,
         usage: Double?,
-        observedAt: Date
+        observedAt: Date,
+        isLoading: Bool = false,
+        error: String? = nil
     ) -> SharedUsageBarState {
         SharedUsageBarState(
             provider: provider,
             usage: usage.map { QuotaPeriod(utilization: $0, resetDate: Date(timeIntervalSince1970: 1_000)) },
             isUsingExtraUsage: false,
-            isLoading: false,
-            error: nil,
+            isLoading: isLoading,
+            error: error,
             statusMessage: nil,
             isStale: false,
             recoveryAction: .none,

--- a/notchi/Tests/ExpandedPanelViewTests.swift
+++ b/notchi/Tests/ExpandedPanelViewTests.swift
@@ -164,6 +164,60 @@ final class ExpandedPanelViewTests: XCTestCase {
         )
     }
 
+    func testWeeklyPeriodAddsPrefixEvenForSingleProviderSessions() {
+        let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
+        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 100))
+
+        XCTAssertEqual(
+            ExpandedPanelView.sharedUsageResetLabelPrefix(
+                state: codex,
+                activeSessions: [codexSession],
+                period: .weekly
+            ),
+            "Weekly"
+        )
+    }
+
+    func testWeeklyPeriodCombinesWithProviderPrefixForMixedSessions() {
+        let claudeSession = SessionData(sessionId: "claude-session", provider: .claude, cwd: "/tmp/project")
+        let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
+        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 100))
+
+        XCTAssertEqual(
+            ExpandedPanelView.sharedUsageResetLabelPrefix(
+                state: codex,
+                activeSessions: [codexSession, claudeSession],
+                period: .weekly
+            ),
+            "Codex Weekly"
+        )
+    }
+
+    func testMainUsageSelectsSessionQuotaForSessionPeriod() {
+        let session = QuotaPeriod(utilization: 10, resetDate: Date(timeIntervalSince1970: 1_000))
+        let weekly = QuotaPeriod(utilization: 20, resetDate: Date(timeIntervalSince1970: 2_000))
+
+        let usage = ExpandedPanelView.mainUsage(for: .session, sessionUsage: session, weeklyUsage: weekly)
+
+        XCTAssertEqual(usage?.usagePercentage, 10)
+    }
+
+    func testMainUsageSelectsWeeklyQuotaForWeeklyPeriod() {
+        let session = QuotaPeriod(utilization: 10, resetDate: Date(timeIntervalSince1970: 1_000))
+        let weekly = QuotaPeriod(utilization: 20, resetDate: Date(timeIntervalSince1970: 2_000))
+
+        let usage = ExpandedPanelView.mainUsage(for: .weekly, sessionUsage: session, weeklyUsage: weekly)
+
+        XCTAssertEqual(usage?.usagePercentage, 20)
+    }
+
+    func testMainUsageReturnsNilWhenSelectedPeriodHasNoData() {
+        let weekly = QuotaPeriod(utilization: 20, resetDate: Date(timeIntervalSince1970: 2_000))
+
+        XCTAssertNil(ExpandedPanelView.mainUsage(for: .session, sessionUsage: nil, weeklyUsage: weekly))
+        XCTAssertNil(ExpandedPanelView.mainUsage(for: .weekly, sessionUsage: weekly, weeklyUsage: nil))
+    }
+
     func testUsageDetailOpensOnContextSessionProviderRegardlessOfLastUsed() {
         let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
 

--- a/notchi/Tests/ExpandedPanelViewTests.swift
+++ b/notchi/Tests/ExpandedPanelViewTests.swift
@@ -103,21 +103,19 @@ final class ExpandedPanelViewTests: XCTestCase {
         XCTAssertEqual(state?.usage?.usagePercentage, 11)
     }
 
-    func testContextSessionProviderFallsBackWhenItHasNoDataForSelectedPeriod() {
-        // e.g. Weekly is selected, the context session is Codex, but Codex has no weekly quota
-        // yet while Claude does — the bar should show Claude's data rather than an empty Codex bar.
+    func testContextSessionProviderIsNeverSwappedEvenWhenItHasNoData() {
         let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
         let claude = makeUsageState(provider: .claude, usage: 42, observedAt: Date(timeIntervalSince1970: 100))
-        let codexWithoutDataForPeriod = makeUsageState(provider: .codex, usage: nil, observedAt: Date(timeIntervalSince1970: 200))
+        let codexWithoutData = makeUsageState(provider: .codex, usage: nil, observedAt: Date(timeIntervalSince1970: 200))
 
         let state = ExpandedPanelView.sharedUsageBarState(
             contextSession: codexSession,
             claude: claude,
-            codex: codexWithoutDataForPeriod
+            codex: codexWithoutData
         )
 
-        XCTAssertEqual(state?.provider, .claude)
-        XCTAssertEqual(state?.usage?.usagePercentage, 42)
+        XCTAssertEqual(state?.provider, .codex)
+        XCTAssertNil(state?.usage)
     }
 
     func testContextSessionProviderWinsWhenNeitherProviderHasDataForSelectedPeriod() {
@@ -183,12 +181,125 @@ final class ExpandedPanelViewTests: XCTestCase {
         XCTAssertEqual(state?.error, "Connection failed")
     }
 
-    func testMainUsageIsStaleAppliesHeadersFallbackOnlyToWeeklyPeriod() {
-        XCTAssertFalse(ExpandedPanelView.mainUsageIsStale(for: .session, isUsageStale: false, isUsingHeadersFallback: true))
-        XCTAssertTrue(ExpandedPanelView.mainUsageIsStale(for: .weekly, isUsageStale: false, isUsingHeadersFallback: true))
-        XCTAssertTrue(ExpandedPanelView.mainUsageIsStale(for: .session, isUsageStale: true, isUsingHeadersFallback: false))
-        XCTAssertTrue(ExpandedPanelView.mainUsageIsStale(for: .weekly, isUsageStale: true, isUsingHeadersFallback: false))
-        XCTAssertFalse(ExpandedPanelView.mainUsageIsStale(for: .weekly, isUsageStale: false, isUsingHeadersFallback: false))
+    func testFallbackDoesNotOverrideADisabledClaudeProvider() {
+        let claudeSession = SessionData(sessionId: "claude-session", provider: .claude, cwd: "/tmp/project")
+        let claudeDisabled = makeUsageState(provider: .claude, usage: nil, observedAt: Date(timeIntervalSince1970: 100))
+        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 200))
+
+        let state = ExpandedPanelView.sharedUsageBarState(
+            contextSession: claudeSession,
+            claude: claudeDisabled,
+            codex: codex,
+            claudeUsageEnabled: false
+        )
+
+        XCTAssertEqual(state?.provider, .claude)
+        XCTAssertNil(state?.usage)
+    }
+
+    func testFallbackDoesNotOverrideAPreferredProviderWithAStatusMessage() {
+        let claudeSession = SessionData(sessionId: "claude-session", provider: .claude, cwd: "/tmp/project")
+        let claudeUpdating = makeUsageState(
+            provider: .claude, usage: nil, observedAt: Date(timeIntervalSince1970: 100), statusMessage: "Updating in 30s"
+        )
+        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 200))
+
+        let state = ExpandedPanelView.sharedUsageBarState(
+            contextSession: claudeSession,
+            claude: claudeUpdating,
+            codex: codex,
+            claudeUsageEnabled: true
+        )
+
+        XCTAssertEqual(state?.provider, .claude)
+        XCTAssertEqual(state?.statusMessage, "Updating in 30s")
+    }
+
+    func testFallbackDoesNotOverrideAPreferredProviderWithARecoveryAction() {
+        let claudeSession = SessionData(sessionId: "claude-session", provider: .claude, cwd: "/tmp/project")
+        let claudeNeedsReconnect = makeUsageState(
+            provider: .claude, usage: nil, observedAt: Date(timeIntervalSince1970: 100), recoveryAction: .reconnect
+        )
+        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 200))
+
+        let state = ExpandedPanelView.sharedUsageBarState(
+            contextSession: claudeSession,
+            claude: claudeNeedsReconnect,
+            codex: codex,
+            claudeUsageEnabled: true
+        )
+
+        XCTAssertEqual(state?.provider, .claude)
+        XCTAssertEqual(state?.recoveryAction, .reconnect)
+    }
+
+    func testFallbackDoesNotOverrideADisabledClaudeProviderWithoutContextSession() {
+        let sharedTimestamp = Date(timeIntervalSince1970: 100)
+        let claudeDisabled = makeUsageState(provider: .claude, usage: nil, observedAt: sharedTimestamp)
+        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: sharedTimestamp)
+
+        let state = ExpandedPanelView.sharedUsageBarState(
+            contextSession: nil,
+            claude: claudeDisabled,
+            codex: codex,
+            claudeUsageEnabled: false
+        )
+
+        XCTAssertEqual(state?.provider, .claude)
+        XCTAssertNil(state?.usage)
+    }
+
+    func testEffectivePeriodFallsBackToSessionWhenWeeklyQuotaMissing() {
+        let session = QuotaPeriod(utilization: 10, resetDate: Date(timeIntervalSince1970: 1_000))
+
+        XCTAssertEqual(
+            ExpandedPanelView.effectiveMainUsagePeriod(for: .weekly, sessionUsage: session, weeklyUsage: nil),
+            .session
+        )
+    }
+
+    func testEffectivePeriodFallsBackToWeeklyWhenSessionQuotaMissing() {
+        let weekly = QuotaPeriod(utilization: 20, resetDate: Date(timeIntervalSince1970: 2_000))
+
+        XCTAssertEqual(
+            ExpandedPanelView.effectiveMainUsagePeriod(for: .session, sessionUsage: nil, weeklyUsage: weekly),
+            .weekly
+        )
+    }
+
+    func testEffectivePeriodKeepsWeeklyWhenWeeklyQuotaPresent() {
+        let session = QuotaPeriod(utilization: 10, resetDate: Date(timeIntervalSince1970: 1_000))
+        let weekly = QuotaPeriod(utilization: 20, resetDate: Date(timeIntervalSince1970: 2_000))
+
+        XCTAssertEqual(
+            ExpandedPanelView.effectiveMainUsagePeriod(for: .weekly, sessionUsage: session, weeklyUsage: weekly),
+            .weekly
+        )
+    }
+
+    func testEffectivePeriodKeepsSelectionWhenNoQuotaAvailable() {
+        XCTAssertEqual(
+            ExpandedPanelView.effectiveMainUsagePeriod(for: .weekly, sessionUsage: nil, weeklyUsage: nil),
+            .weekly
+        )
+        XCTAssertEqual(
+            ExpandedPanelView.effectiveMainUsagePeriod(for: .session, sessionUsage: nil, weeklyUsage: nil),
+            .session
+        )
+    }
+
+    func testMainUsageBarPeriodDecodingFallsBackToSession() {
+        XCTAssertEqual(AppSettings.mainUsageBarPeriod(fromRaw: nil), .session)
+        XCTAssertEqual(AppSettings.mainUsageBarPeriod(fromRaw: "garbage"), .session)
+        XCTAssertEqual(AppSettings.mainUsageBarPeriod(fromRaw: "weekly"), .weekly)
+        XCTAssertEqual(AppSettings.mainUsageBarPeriod(fromRaw: "session"), .session)
+    }
+
+    func testMainUsageIsStaleUsesHeldOverStateOnlyForWeeklyPeriod() {
+        XCTAssertFalse(ExpandedPanelView.mainUsageIsStale(for: .session, isUsageStale: false, isWeeklyUsageHeldOver: true))
+        XCTAssertTrue(ExpandedPanelView.mainUsageIsStale(for: .weekly, isUsageStale: false, isWeeklyUsageHeldOver: true))
+        XCTAssertTrue(ExpandedPanelView.mainUsageIsStale(for: .session, isUsageStale: true, isWeeklyUsageHeldOver: true))
+        XCTAssertFalse(ExpandedPanelView.mainUsageIsStale(for: .weekly, isUsageStale: false, isWeeklyUsageHeldOver: false))
     }
 
     func testExtraUsageIndicatorOnlyAppliesToTheSessionPeriod() {
@@ -241,7 +352,8 @@ final class ExpandedPanelViewTests: XCTestCase {
         XCTAssertEqual(
             ExpandedPanelView.sharedUsageResetLabelPrefix(
                 state: codex,
-                activeSessions: [codexSession, claudeSession]
+                activeSessions: [codexSession, claudeSession],
+                requestedPeriod: .session
             ),
             "Codex"
         )
@@ -254,37 +366,66 @@ final class ExpandedPanelViewTests: XCTestCase {
         XCTAssertNil(
             ExpandedPanelView.sharedUsageResetLabelPrefix(
                 state: codex,
-                activeSessions: [codexSession]
+                activeSessions: [codexSession],
+                requestedPeriod: .session
             )
         )
     }
 
-    func testWeeklyPeriodAddsPrefixEvenForSingleProviderSessions() {
+    func testWeeklyStateAddsPrefixEvenForSingleProviderSessions() {
         let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
-        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 100))
+        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 100), period: .weekly)
 
         XCTAssertEqual(
             ExpandedPanelView.sharedUsageResetLabelPrefix(
                 state: codex,
                 activeSessions: [codexSession],
-                period: .weekly
+                requestedPeriod: .weekly
             ),
             "Weekly"
         )
     }
 
-    func testWeeklyPeriodCombinesWithProviderPrefixForMixedSessions() {
+    func testWeeklyStateCombinesWithProviderPrefixForMixedSessions() {
         let claudeSession = SessionData(sessionId: "claude-session", provider: .claude, cwd: "/tmp/project")
         let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
-        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 100))
+        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 100), period: .weekly)
 
         XCTAssertEqual(
             ExpandedPanelView.sharedUsageResetLabelPrefix(
                 state: codex,
                 activeSessions: [codexSession, claudeSession],
-                period: .weekly
+                requestedPeriod: .weekly
             ),
-            "Codex Weekly"
+            "Codex weekly"
+        )
+    }
+
+    func testWeeklySelectionFallingBackToSessionLabelsThePeriod() {
+        let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
+        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 100), period: .session)
+
+        XCTAssertEqual(
+            ExpandedPanelView.sharedUsageResetLabelPrefix(
+                state: codex,
+                activeSessions: [codexSession],
+                requestedPeriod: .weekly
+            ),
+            "Session"
+        )
+    }
+
+    func testSessionSelectionFallingBackToWeeklyStillLabelsWeekly() {
+        let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
+        let codex = makeUsageState(provider: .codex, usage: 11, observedAt: Date(timeIntervalSince1970: 100), period: .weekly)
+
+        XCTAssertEqual(
+            ExpandedPanelView.sharedUsageResetLabelPrefix(
+                state: codex,
+                activeSessions: [codexSession],
+                requestedPeriod: .session
+            ),
+            "Weekly"
         )
     }
 
@@ -325,35 +466,6 @@ final class ExpandedPanelViewTests: XCTestCase {
         XCTAssertEqual(provider, .codex)
     }
 
-    func testUsageDetailPrefersTheDisplayedFallbackProviderOverContextSession() {
-        // Mirrors the shared-bar fallback: context session is Codex, but the bar is actually
-        // showing Claude because Codex had no data for the selected period. Tapping it should
-        // open the detail view on Claude, not silently reopen on Codex.
-        let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
-
-        let provider = ExpandedPanelView.usageDetailDefaultProvider(
-            requestedProvider: nil,
-            contextSession: codexSession,
-            displayedSharedUsageProvider: .claude,
-            lastUsedProvider: .codex
-        )
-
-        XCTAssertEqual(provider, .claude)
-    }
-
-    func testUsageDetailStillPrefersAnExplicitRequestOverTheDisplayedFallbackProvider() {
-        let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
-
-        let provider = ExpandedPanelView.usageDetailDefaultProvider(
-            requestedProvider: .codex,
-            contextSession: codexSession,
-            displayedSharedUsageProvider: .claude,
-            lastUsedProvider: .codex
-        )
-
-        XCTAssertEqual(provider, .codex)
-    }
-
     func testUsageDetailOpensOnRequestedProviderOverContextSession() {
         let codexSession = SessionData(sessionId: "codex-session", provider: .codex, cwd: "/tmp/project")
 
@@ -387,7 +499,10 @@ final class ExpandedPanelViewTests: XCTestCase {
         usage: Double?,
         observedAt: Date,
         isLoading: Bool = false,
-        error: String? = nil
+        error: String? = nil,
+        statusMessage: String? = nil,
+        recoveryAction: ClaudeUsageRecoveryAction = .none,
+        period: MainUsageBarPeriod = .session
     ) -> SharedUsageBarState {
         SharedUsageBarState(
             provider: provider,
@@ -395,10 +510,11 @@ final class ExpandedPanelViewTests: XCTestCase {
             isUsingExtraUsage: false,
             isLoading: isLoading,
             error: error,
-            statusMessage: nil,
+            statusMessage: statusMessage,
             isStale: false,
-            recoveryAction: .none,
-            lastObservedAt: observedAt
+            recoveryAction: recoveryAction,
+            lastObservedAt: observedAt,
+            period: period
         )
     }
 }

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -273,10 +273,12 @@ struct AppSettings {
     }
 
     static var mainUsageBarPeriod: MainUsageBarPeriod {
-        get {
-            MainUsageBarPeriod(rawValue: UserDefaults.standard.string(forKey: mainUsageBarPeriodKey) ?? "") ?? .session
-        }
+        get { mainUsageBarPeriod(fromRaw: UserDefaults.standard.string(forKey: mainUsageBarPeriodKey)) }
         set { UserDefaults.standard.set(newValue.rawValue, forKey: mainUsageBarPeriodKey) }
+    }
+
+    static func mainUsageBarPeriod(fromRaw raw: String?) -> MainUsageBarPeriod {
+        MainUsageBarPeriod(rawValue: raw ?? "") ?? .session
     }
 
     static func expandedPanelScale(in defaults: UserDefaults) -> ExpandedPanelScale {

--- a/notchi/notchi/Core/AppSettings.swift
+++ b/notchi/notchi/Core/AppSettings.swift
@@ -135,6 +135,20 @@ enum NotchSlotContent: String, CaseIterable, Identifiable {
     }
 }
 
+enum MainUsageBarPeriod: String, CaseIterable, Identifiable {
+    case session
+    case weekly
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .session: String(localized: "Session")
+        case .weekly: String(localized: "Weekly")
+        }
+    }
+}
+
 enum ExpandedPanelMode: String, CaseIterable {
     case full
     case compact
@@ -179,6 +193,7 @@ struct AppSettings {
     static let notchLeftContentKey = "notchLeftContent"
     static let notchRightContentKey = "notchRightContent"
     static let expandedPanelScaleKey = "expandedPanelScale"
+    static let mainUsageBarPeriodKey = "mainUsageBarPeriod"
 
     private static let notificationSoundKey = "notificationSound"
     private static let notificationSoundSelectionKey = "notificationSoundSelection"
@@ -255,6 +270,13 @@ struct AppSettings {
             let resolved: NotchSlotContent = other == newValue ? previous : .ring
             UserDefaults.standard.set(resolved.rawValue, forKey: otherKey)
         }
+    }
+
+    static var mainUsageBarPeriod: MainUsageBarPeriod {
+        get {
+            MainUsageBarPeriod(rawValue: UserDefaults.standard.string(forKey: mainUsageBarPeriodKey) ?? "") ?? .session
+        }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: mainUsageBarPeriodKey) }
     }
 
     static func expandedPanelScale(in defaults: UserDefaults) -> ExpandedPanelScale {

--- a/notchi/notchi/Localizable.xcstrings
+++ b/notchi/notchi/Localizable.xcstrings
@@ -2144,6 +2144,40 @@
         }
       }
     },
+    "Main Usage Bar" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "メイン使用量バー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "메인 사용량 바"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Thanh sử dụng chính"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "主用量条"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "主用量條"
+          }
+        }
+      }
+    },
     "Missing" : {
       "localizations" : {
         "ja" : {

--- a/notchi/notchi/Services/ClaudeUsageService.swift
+++ b/notchi/notchi/Services/ClaudeUsageService.swift
@@ -695,6 +695,10 @@ final class ClaudeUsageService {
     var isConnected = false
     var isUsageStale = false
     var isUsingHeadersFallback: Bool { isHeadersFallbackActive }
+
+    // Headers refreshes only carry session usage, so in either headers mode (backoff-driven or
+    // enterprise preferred) weekly data is held over from the last OAuth success.
+    var isWeeklyUsageHeldOver: Bool { isUsageStale || isHeadersFallbackActive || preferHeadersFallback }
     var hasUsageData: Bool {
         UsageMetrics.claudeHasData(
             usage: currentUsage,
@@ -1859,7 +1863,7 @@ final class ClaudeUsageService {
         recoveryAction = .retry
         let roundedDelay = Int(ceil(remaining))
 
-        if currentUsage == nil {
+        if currentUsage == nil, currentWeeklyUsage == nil, currentModelUsage == nil {
             error = String(localized: "Rate limited, retrying in \(roundedDelay)s")
             statusMessage = nil
             isUsageStale = false
@@ -2045,7 +2049,7 @@ final class ClaudeUsageService {
     private func presentRetryableIssue(noUsageMessage: String, staleMessage: String) {
         clearPendingResumeReconnect()
         recoveryAction = .retry
-        if currentUsage == nil {
+        if currentUsage == nil, currentWeeklyUsage == nil, currentModelUsage == nil {
             error = noUsageMessage
             statusMessage = nil
             isUsageStale = false
@@ -2060,7 +2064,7 @@ final class ClaudeUsageService {
         clearPendingResumeReconnect()
         recoveryAction = .reconnect
         isConnected = false
-        if currentUsage == nil {
+        if currentUsage == nil, currentWeeklyUsage == nil, currentModelUsage == nil {
             error = message
             statusMessage = nil
             isUsageStale = false
@@ -2075,7 +2079,7 @@ final class ClaudeUsageService {
         clearPendingResumeReconnect()
         recoveryAction = .waitForClaudeCode
         isConnected = false
-        if currentUsage == nil {
+        if currentUsage == nil, currentWeeklyUsage == nil, currentModelUsage == nil {
             error = message
             statusMessage = nil
             isUsageStale = false

--- a/notchi/notchi/Services/CodexUsageService.swift
+++ b/notchi/notchi/Services/CodexUsageService.swift
@@ -176,8 +176,8 @@ final class CodexUsageService {
         let now = dependencies.now()
 
         if let snapshot, hasUnexpiredQuota(snapshot.usage, snapshot.weeklyUsage, now: now) {
-            currentUsage = snapshot.usage
-            currentWeeklyUsage = snapshot.weeklyUsage
+            currentUsage = unexpiredOnly(snapshot.usage, now: now)
+            currentWeeklyUsage = unexpiredOnly(snapshot.weeklyUsage, now: now)
             lastObservedAt = snapshot.observedAt
             isUsageStale = now.timeIntervalSince(snapshot.observedAt) > Self.staleObservationInterval
             statusMessage = nil
@@ -191,6 +191,11 @@ final class CodexUsageService {
 
         isUsageStale = true
         statusMessage = nil
+    }
+
+    private func unexpiredOnly(_ usage: QuotaPeriod?, now: Date) -> QuotaPeriod? {
+        guard let resetDate = usage?.resetDate, resetDate <= now else { return usage }
+        return nil
     }
 
     private func hasUnexpiredQuota(_ usage: QuotaPeriod?, _ weeklyUsage: QuotaPeriod?, now: Date) -> Bool {

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -310,7 +310,7 @@ struct ExpandedPanelView: View {
         let claude = includesClaude ? SharedUsageBarState(
             provider: .claude,
             usage: Self.mainUsage(for: period, sessionUsage: usageService.currentUsage, weeklyUsage: usageService.currentWeeklyUsage),
-            isUsingExtraUsage: usageService.isUsingExtraUsage,
+            isUsingExtraUsage: Self.mainUsageIsUsingExtraUsage(for: period, isUsingExtraUsage: usageService.isUsingExtraUsage),
             isLoading: usageService.isLoading,
             error: usageService.error,
             statusMessage: usageService.statusMessage,
@@ -615,6 +615,13 @@ struct ExpandedPanelView: View {
         }
     }
 
+    /// The "Extra Usage" badge reflects overflow past the five-hour session quota, so it's only
+    /// meaningful when the session period is the one being displayed — showing it next to the
+    /// weekly percentage would misleadingly imply the weekly quota is what's overflowing.
+    static func mainUsageIsUsingExtraUsage(for period: MainUsageBarPeriod, isUsingExtraUsage: Bool) -> Bool {
+        period == .session && isUsingExtraUsage
+    }
+
     static func sharedUsageBarIsEnabled(
         provider: AgentProvider,
         appUsageEnabled: Bool = AppSettings.isUsageEnabled
@@ -640,18 +647,17 @@ struct ExpandedPanelView: View {
         }
 
         if let contextSession {
-            switch contextSession.provider {
-            case .claude:
-                return claude
-            case .codex:
-                return codex
-            }
+            let preferred = contextSession.provider == .claude ? claude : codex
+            let fallback = contextSession.provider == .claude ? codex : claude
+            return preferredOrFallback(preferred, fallback)
         }
 
         if let claudeObservedAt = claude.lastObservedAt,
            let codexObservedAt = codex.lastObservedAt,
            claudeObservedAt != codexObservedAt {
-            return codexObservedAt > claudeObservedAt ? codex : claude
+            let newer = codexObservedAt > claudeObservedAt ? codex : claude
+            let older = codexObservedAt > claudeObservedAt ? claude : codex
+            return preferredOrFallback(newer, older)
         }
 
         if claude.usage == nil, codex.usage != nil {
@@ -662,6 +668,16 @@ struct ExpandedPanelView: View {
         }
 
         return claude
+    }
+
+    /// Picks `preferred`, unless it has no quota data for the currently selected period while
+    /// `fallback` does — in which case showing `fallback` beats leaving the bar empty when a
+    /// usable quota exists for the other active provider.
+    private static func preferredOrFallback(
+        _ preferred: SharedUsageBarState,
+        _ fallback: SharedUsageBarState
+    ) -> SharedUsageBarState {
+        preferred.usage == nil && fallback.usage != nil ? fallback : preferred
     }
 
     private var activitySection: some View {

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -231,9 +231,11 @@ struct ExpandedPanelView: View {
     }
 
     private var usageDetailDefaultProvider: AgentProvider {
-        Self.usageDetailDefaultProvider(
+        let displayedState = sharedUsageBarState
+        return Self.usageDetailDefaultProvider(
             requestedProvider: usageDetailProvider,
             contextSession: usageContextSession,
+            displayedSharedUsageProvider: displayedState?.isProviderSpecific == true ? displayedState?.provider : nil,
             lastUsedProvider: AppSettings.lastUsedAgentProvider
         )
     }
@@ -314,7 +316,11 @@ struct ExpandedPanelView: View {
             isLoading: usageService.isLoading,
             error: usageService.error,
             statusMessage: usageService.statusMessage,
-            isStale: usageService.isUsageStale,
+            isStale: Self.mainUsageIsStale(
+                for: period,
+                isUsageStale: usageService.isUsageStale,
+                isUsingHeadersFallback: usageService.isUsingHeadersFallback
+            ),
             recoveryAction: usageService.recoveryAction,
             lastObservedAt: usageService.lastObservedAt
         ) : nil
@@ -622,6 +628,22 @@ struct ExpandedPanelView: View {
         period == .session && isUsingExtraUsage
     }
 
+    /// Claude's headers-fallback mode only refreshes `currentUsage` (session); `currentWeeklyUsage`
+    /// stays at whatever it was from the last successful OAuth response, and a successful headers
+    /// refresh clears `isUsageStale`. So a held-over weekly quota can read as fresh even though it
+    /// isn't. `UsageDetailView` already treats Weekly/Model rows as stale during headers fallback —
+    /// mirror that here for the main bar's Weekly period.
+    static func mainUsageIsStale(
+        for period: MainUsageBarPeriod,
+        isUsageStale: Bool,
+        isUsingHeadersFallback: Bool
+    ) -> Bool {
+        switch period {
+        case .session: isUsageStale
+        case .weekly: isUsageStale || isUsingHeadersFallback
+        }
+    }
+
     static func sharedUsageBarIsEnabled(
         provider: AgentProvider,
         appUsageEnabled: Bool = AppSettings.isUsageEnabled
@@ -629,12 +651,18 @@ struct ExpandedPanelView: View {
         provider == .codex || appUsageEnabled
     }
 
+    /// - Parameter displayedSharedUsageProvider: the provider actually rendered by the compact
+    ///   shared usage bar right now (post fallback-arbitration), when that's unambiguous. It's
+    ///   consulted after an explicit `requestedProvider` but before the raw `contextSession`,
+    ///   since `contextSession` can diverge from what's on-screen once `sharedUsageBarState`
+    ///   falls back to the other provider for a period the context provider has no data for.
     static func usageDetailDefaultProvider(
         requestedProvider: AgentProvider?,
         contextSession: SessionData?,
+        displayedSharedUsageProvider: AgentProvider? = nil,
         lastUsedProvider: AgentProvider
     ) -> AgentProvider {
-        requestedProvider ?? contextSession?.provider ?? lastUsedProvider
+        requestedProvider ?? displayedSharedUsageProvider ?? contextSession?.provider ?? lastUsedProvider
     }
 
     static func sharedUsageBarState(
@@ -670,14 +698,17 @@ struct ExpandedPanelView: View {
         return claude
     }
 
-    /// Picks `preferred`, unless it has no quota data for the currently selected period while
-    /// `fallback` does — in which case showing `fallback` beats leaving the bar empty when a
-    /// usable quota exists for the other active provider.
+    /// Picks `preferred`, unless it's idle (not loading, no error) with no quota data for the
+    /// currently selected period while `fallback` does have data — in which case showing
+    /// `fallback` beats leaving the bar empty when a usable quota exists for the other active
+    /// provider. Never overrides `preferred` while it's loading or has an error to show: that
+    /// state is itself meaningful (e.g. a retry action) and shouldn't be silently swapped away.
     private static func preferredOrFallback(
         _ preferred: SharedUsageBarState,
         _ fallback: SharedUsageBarState
     ) -> SharedUsageBarState {
-        preferred.usage == nil && fallback.usage != nil ? fallback : preferred
+        let preferredIsIdleWithNoData = preferred.usage == nil && !preferred.isLoading && preferred.error == nil
+        return preferredIsIdleWithNoData && fallback.usage != nil ? fallback : preferred
     }
 
     private var activitySection: some View {

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -113,6 +113,7 @@ nonisolated struct SharedUsageBarState {
     let lastObservedAt: Date?
     let labelOverride: String?
     let isProviderSpecific: Bool
+    let period: MainUsageBarPeriod
 
     init(
         provider: AgentProvider,
@@ -125,7 +126,8 @@ nonisolated struct SharedUsageBarState {
         recoveryAction: ClaudeUsageRecoveryAction,
         lastObservedAt: Date?,
         labelOverride: String? = nil,
-        isProviderSpecific: Bool = true
+        isProviderSpecific: Bool = true,
+        period: MainUsageBarPeriod = .session
     ) {
         self.provider = provider
         self.usage = usage
@@ -138,6 +140,7 @@ nonisolated struct SharedUsageBarState {
         self.lastObservedAt = lastObservedAt
         self.labelOverride = labelOverride
         self.isProviderSpecific = isProviderSpecific
+        self.period = period
     }
 
     var label: String {
@@ -231,11 +234,9 @@ struct ExpandedPanelView: View {
     }
 
     private var usageDetailDefaultProvider: AgentProvider {
-        let displayedState = sharedUsageBarState
-        return Self.usageDetailDefaultProvider(
+        Self.usageDetailDefaultProvider(
             requestedProvider: usageDetailProvider,
             contextSession: usageContextSession,
-            displayedSharedUsageProvider: displayedState?.isProviderSpecific == true ? displayedState?.provider : nil,
             lastUsedProvider: AppSettings.lastUsedAgentProvider
         )
     }
@@ -281,14 +282,14 @@ struct ExpandedPanelView: View {
     }
 
     private var mainUsageBarPeriod: MainUsageBarPeriod {
-        MainUsageBarPeriod(rawValue: mainUsageBarPeriodRaw) ?? .session
+        AppSettings.mainUsageBarPeriod(fromRaw: mainUsageBarPeriodRaw)
     }
 
     private var sharedUsageResetLabelPrefix: String? {
         Self.sharedUsageResetLabelPrefix(
             state: sharedUsageBarState,
             activeSessions: sessionStore.sortedSessions,
-            period: mainUsageBarPeriod
+            requestedPeriod: mainUsageBarPeriod
         )
     }
 
@@ -309,27 +310,38 @@ struct ExpandedPanelView: View {
         let includesCodex = Self.includesCodexUsage(activeSessions: activeSessions)
         let period = mainUsageBarPeriod
 
+        let claudePeriod = Self.effectiveMainUsagePeriod(
+            for: period,
+            sessionUsage: usageService.currentUsage,
+            weeklyUsage: usageService.currentWeeklyUsage
+        )
         let claude = includesClaude ? SharedUsageBarState(
             provider: .claude,
-            usage: Self.mainUsage(for: period, sessionUsage: usageService.currentUsage, weeklyUsage: usageService.currentWeeklyUsage),
-            isUsingExtraUsage: Self.mainUsageIsUsingExtraUsage(for: period, isUsingExtraUsage: usageService.isUsingExtraUsage),
+            usage: Self.mainUsage(for: claudePeriod, sessionUsage: usageService.currentUsage, weeklyUsage: usageService.currentWeeklyUsage),
+            isUsingExtraUsage: Self.mainUsageIsUsingExtraUsage(for: claudePeriod, isUsingExtraUsage: usageService.isUsingExtraUsage),
             isLoading: usageService.isLoading,
             error: usageService.error,
             statusMessage: usageService.statusMessage,
             isStale: Self.mainUsageIsStale(
-                for: period,
+                for: claudePeriod,
                 isUsageStale: usageService.isUsageStale,
-                isUsingHeadersFallback: usageService.isUsingHeadersFallback
+                isWeeklyUsageHeldOver: usageService.isWeeklyUsageHeldOver
             ),
             recoveryAction: usageService.recoveryAction,
-            lastObservedAt: usageService.lastObservedAt
+            lastObservedAt: usageService.lastObservedAt,
+            period: claudePeriod
         ) : nil
 
+        let codexPeriod = Self.effectiveMainUsagePeriod(
+            for: period,
+            sessionUsage: codexUsageService.currentUsage,
+            weeklyUsage: codexUsageService.currentWeeklyUsage
+        )
         let codex = includesCodex ? SharedUsageBarState(
             provider: .codex,
             usage: Self.mainUsage(
-                for: period,
-                sessionUsage: codexUsageService.displayUsage,
+                for: codexPeriod,
+                sessionUsage: codexUsageService.currentUsage,
                 weeklyUsage: codexUsageService.currentWeeklyUsage
             ),
             isUsingExtraUsage: false,
@@ -338,7 +350,8 @@ struct ExpandedPanelView: View {
             statusMessage: codexUsageService.statusMessage,
             isStale: codexUsageService.isUsageStale,
             recoveryAction: .none,
-            lastObservedAt: codexUsageService.lastObservedAt
+            lastObservedAt: codexUsageService.lastObservedAt,
+            period: codexPeriod
         ) : nil
 
         return Self.sharedUsageBarState(
@@ -592,7 +605,7 @@ struct ExpandedPanelView: View {
     static func sharedUsageResetLabelPrefix(
         state: SharedUsageBarState?,
         activeSessions: [SessionData],
-        period: MainUsageBarPeriod = .session
+        requestedPeriod: MainUsageBarPeriod
     ) -> String? {
         guard let state else { return nil }
 
@@ -600,16 +613,26 @@ struct ExpandedPanelView: View {
         if hasMixedClaudeAndCodexSessions(activeSessions) {
             parts.append(state.provider.displayName)
         }
-        if period != .session {
-            parts.append(period.displayName)
+        if state.period == .weekly || state.period != requestedPeriod {
+            let periodName = state.period.displayName
+            parts.append(parts.isEmpty ? periodName : periodName.lowercased(with: .autoupdatingCurrent))
         }
         return parts.isEmpty ? nil : parts.joined(separator: " ")
     }
 
-    /// Picks which quota to surface in the compact main-page usage bar for the given period.
-    /// Callers pass each provider's existing "session" value as-is (e.g. Codex's `displayUsage`,
-    /// which already falls back to weekly on its own), so `.session` behavior is unchanged from
-    /// before this setting existed.
+    // The selected period falls back to the provider's other quota when its own is missing, so the
+    // bar shows live data instead of staying empty. The label follows via SharedUsageBarState.period.
+    static func effectiveMainUsagePeriod(
+        for period: MainUsageBarPeriod,
+        sessionUsage: QuotaPeriod?,
+        weeklyUsage: QuotaPeriod?
+    ) -> MainUsageBarPeriod {
+        switch period {
+        case .session: sessionUsage == nil && weeklyUsage != nil ? .weekly : .session
+        case .weekly: weeklyUsage == nil && sessionUsage != nil ? .session : .weekly
+        }
+    }
+
     static func mainUsage(
         for period: MainUsageBarPeriod,
         sessionUsage: QuotaPeriod?,
@@ -621,26 +644,19 @@ struct ExpandedPanelView: View {
         }
     }
 
-    /// The "Extra Usage" badge reflects overflow past the five-hour session quota, so it's only
-    /// meaningful when the session period is the one being displayed — showing it next to the
-    /// weekly percentage would misleadingly imply the weekly quota is what's overflowing.
+    // Extra usage means session quota overflow, so the badge is misleading next to a weekly percentage.
     static func mainUsageIsUsingExtraUsage(for period: MainUsageBarPeriod, isUsingExtraUsage: Bool) -> Bool {
         period == .session && isUsingExtraUsage
     }
 
-    /// Claude's headers-fallback mode only refreshes `currentUsage` (session); `currentWeeklyUsage`
-    /// stays at whatever it was from the last successful OAuth response, and a successful headers
-    /// refresh clears `isUsageStale`. So a held-over weekly quota can read as fresh even though it
-    /// isn't. `UsageDetailView` already treats Weekly/Model rows as stale during headers fallback —
-    /// mirror that here for the main bar's Weekly period.
     static func mainUsageIsStale(
         for period: MainUsageBarPeriod,
         isUsageStale: Bool,
-        isUsingHeadersFallback: Bool
+        isWeeklyUsageHeldOver: Bool
     ) -> Bool {
         switch period {
         case .session: isUsageStale
-        case .weekly: isUsageStale || isUsingHeadersFallback
+        case .weekly: isWeeklyUsageHeldOver
         }
     }
 
@@ -651,33 +667,26 @@ struct ExpandedPanelView: View {
         provider == .codex || appUsageEnabled
     }
 
-    /// - Parameter displayedSharedUsageProvider: the provider actually rendered by the compact
-    ///   shared usage bar right now (post fallback-arbitration), when that's unambiguous. It's
-    ///   consulted after an explicit `requestedProvider` but before the raw `contextSession`,
-    ///   since `contextSession` can diverge from what's on-screen once `sharedUsageBarState`
-    ///   falls back to the other provider for a period the context provider has no data for.
     static func usageDetailDefaultProvider(
         requestedProvider: AgentProvider?,
         contextSession: SessionData?,
-        displayedSharedUsageProvider: AgentProvider? = nil,
         lastUsedProvider: AgentProvider
     ) -> AgentProvider {
-        requestedProvider ?? displayedSharedUsageProvider ?? contextSession?.provider ?? lastUsedProvider
+        requestedProvider ?? contextSession?.provider ?? lastUsedProvider
     }
 
     static func sharedUsageBarState(
         contextSession: SessionData?,
         claude: SharedUsageBarState?,
-        codex: SharedUsageBarState?
+        codex: SharedUsageBarState?,
+        claudeUsageEnabled: Bool = AppSettings.isUsageEnabled
     ) -> SharedUsageBarState? {
         guard let claude, let codex else {
             return claude ?? codex
         }
 
         if let contextSession {
-            let preferred = contextSession.provider == .claude ? claude : codex
-            let fallback = contextSession.provider == .claude ? codex : claude
-            return preferredOrFallback(preferred, fallback)
+            return contextSession.provider == .claude ? claude : codex
         }
 
         if let claudeObservedAt = claude.lastObservedAt,
@@ -685,30 +694,26 @@ struct ExpandedPanelView: View {
            claudeObservedAt != codexObservedAt {
             let newer = codexObservedAt > claudeObservedAt ? codex : claude
             let older = codexObservedAt > claudeObservedAt ? claude : codex
-            return preferredOrFallback(newer, older)
+            return preferredOrFallback(newer, older, claudeUsageEnabled: claudeUsageEnabled)
         }
 
-        if claude.usage == nil, codex.usage != nil {
-            return codex
-        }
-        if codex.usage == nil, claude.usage != nil {
-            return claude
-        }
-
-        return claude
+        return preferredOrFallback(claude, codex, claudeUsageEnabled: claudeUsageEnabled)
     }
 
-    /// Picks `preferred`, unless it's idle (not loading, no error) with no quota data for the
-    /// currently selected period while `fallback` does have data — in which case showing
-    /// `fallback` beats leaving the bar empty when a usable quota exists for the other active
-    /// provider. Never overrides `preferred` while it's loading or has an error to show: that
-    /// state is itself meaningful (e.g. a retry action) and shouldn't be silently swapped away.
+    // Only a bar with nothing at all to show swaps to the provider that has data. Loading, error,
+    // status, and recovery states stay visible, and a disabled Claude keeps its connect placeholder.
     private static func preferredOrFallback(
         _ preferred: SharedUsageBarState,
-        _ fallback: SharedUsageBarState
+        _ fallback: SharedUsageBarState,
+        claudeUsageEnabled: Bool
     ) -> SharedUsageBarState {
-        let preferredIsIdleWithNoData = preferred.usage == nil && !preferred.isLoading && preferred.error == nil
-        return preferredIsIdleWithNoData && fallback.usage != nil ? fallback : preferred
+        let preferredIsEnabled = sharedUsageBarIsEnabled(provider: preferred.provider, appUsageEnabled: claudeUsageEnabled)
+        let preferredIsSilentlyEmpty = preferred.usage == nil
+            && !preferred.isLoading
+            && preferred.error == nil
+            && preferred.statusMessage == nil
+            && preferred.recoveryAction == .none
+        return preferredIsEnabled && preferredIsSilentlyEmpty && fallback.usage != nil ? fallback : preferred
     }
 
     private var activitySection: some View {

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -175,6 +175,7 @@ struct ExpandedPanelView: View {
     @Binding var isActivityCollapsed: Bool
     @Binding var hoveredSessionId: String?
     @AppStorage(AppSettings.hideGrassIslandKey) private var hideGrassIsland = false
+    @AppStorage(AppSettings.mainUsageBarPeriodKey) private var mainUsageBarPeriodRaw = MainUsageBarPeriod.session.rawValue
     @Environment(\.panelScale) private var panelScale
 
     static let compactHeaderClearance: CGFloat = 0
@@ -277,10 +278,15 @@ struct ExpandedPanelView: View {
         sessionStore.activeSessionCount >= 2 && !showingSessionActivity
     }
 
+    private var mainUsageBarPeriod: MainUsageBarPeriod {
+        MainUsageBarPeriod(rawValue: mainUsageBarPeriodRaw) ?? .session
+    }
+
     private var sharedUsageResetLabelPrefix: String? {
         Self.sharedUsageResetLabelPrefix(
             state: sharedUsageBarState,
-            activeSessions: sessionStore.sortedSessions
+            activeSessions: sessionStore.sortedSessions,
+            period: mainUsageBarPeriod
         )
     }
 
@@ -299,10 +305,11 @@ struct ExpandedPanelView: View {
 
         let includesClaude = Self.includesClaudeUsage(activeSessions: activeSessions)
         let includesCodex = Self.includesCodexUsage(activeSessions: activeSessions)
+        let period = mainUsageBarPeriod
 
         let claude = includesClaude ? SharedUsageBarState(
             provider: .claude,
-            usage: usageService.currentUsage,
+            usage: Self.mainUsage(for: period, sessionUsage: usageService.currentUsage, weeklyUsage: usageService.currentWeeklyUsage),
             isUsingExtraUsage: usageService.isUsingExtraUsage,
             isLoading: usageService.isLoading,
             error: usageService.error,
@@ -314,7 +321,11 @@ struct ExpandedPanelView: View {
 
         let codex = includesCodex ? SharedUsageBarState(
             provider: .codex,
-            usage: codexUsageService.displayUsage,
+            usage: Self.mainUsage(
+                for: period,
+                sessionUsage: codexUsageService.displayUsage,
+                weeklyUsage: codexUsageService.currentWeeklyUsage
+            ),
             isUsingExtraUsage: false,
             isLoading: false,
             error: nil,
@@ -574,12 +585,34 @@ struct ExpandedPanelView: View {
 
     static func sharedUsageResetLabelPrefix(
         state: SharedUsageBarState?,
-        activeSessions: [SessionData]
+        activeSessions: [SessionData],
+        period: MainUsageBarPeriod = .session
     ) -> String? {
-        guard let state, hasMixedClaudeAndCodexSessions(activeSessions) else {
-            return nil
+        guard let state else { return nil }
+
+        var parts: [String] = []
+        if hasMixedClaudeAndCodexSessions(activeSessions) {
+            parts.append(state.provider.displayName)
         }
-        return state.provider.displayName
+        if period != .session {
+            parts.append(period.displayName)
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " ")
+    }
+
+    /// Picks which quota to surface in the compact main-page usage bar for the given period.
+    /// Callers pass each provider's existing "session" value as-is (e.g. Codex's `displayUsage`,
+    /// which already falls back to weekly on its own), so `.session` behavior is unchanged from
+    /// before this setting existed.
+    static func mainUsage(
+        for period: MainUsageBarPeriod,
+        sessionUsage: QuotaPeriod?,
+        weeklyUsage: QuotaPeriod?
+    ) -> QuotaPeriod? {
+        switch period {
+        case .session: sessionUsage
+        case .weekly: weeklyUsage
+        }
     }
 
     static func sharedUsageBarIsEnabled(

--- a/notchi/notchi/Views/SettingsAppearanceView.swift
+++ b/notchi/notchi/Views/SettingsAppearanceView.swift
@@ -10,6 +10,8 @@ struct SettingsAppearanceView: View {
 
             PanelSizeSettingsView()
 
+            MainUsageBarSettingsView()
+
             Divider().background(Color.white.opacity(0.08))
 
             Button(action: { hideSpriteWhenIdle.toggle() }) {
@@ -95,6 +97,65 @@ private struct PanelSizeSettingsView: View {
                         .panelFont(size: 9)
                         .foregroundColor(TerminalColors.dimmedText)
                 }
+            }
+            .padding(.horizontal, SettingsLayout.pickerOptionHorizontalPadding)
+            .padding(.vertical, SettingsLayout.pickerOptionVerticalPadding)
+            .background(isSelected ? TerminalColors.hoverBackground : Color.clear)
+            .cornerRadius(4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct MainUsageBarSettingsView: View {
+    @AppStorage(AppSettings.mainUsageBarPeriodKey) private var periodRaw = MainUsageBarPeriod.session.rawValue
+    @State private var isExpanded = false
+
+    private var period: MainUsageBarPeriod { MainUsageBarPeriod(rawValue: periodRaw) ?? .session }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: { isExpanded.toggle() }) {
+                SettingsRowView(icon: "chart.bar.xaxis", title: "Main Usage Bar") {
+                    HStack(spacing: 4) {
+                        Text(period.displayName)
+                            .panelFont(size: 11)
+                            .foregroundColor(TerminalColors.secondaryText)
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .panelFont(size: 9)
+                            .foregroundColor(TerminalColors.dimmedText)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                SettingsPicker(rowCount: MainUsageBarPeriod.allCases.count) {
+                    ForEach(MainUsageBarPeriod.allCases) { option in
+                        optionRow(option)
+                    }
+                }
+            }
+        }
+        .animation(.spring(response: 0.3), value: isExpanded)
+    }
+
+    private func optionRow(_ option: MainUsageBarPeriod) -> some View {
+        let isSelected = period == option
+        return Button(action: {
+            AppSettings.mainUsageBarPeriod = option
+            isExpanded = false
+        }) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(isSelected ? TerminalColors.green : Color.clear)
+                    .frame(width: 6, height: 6)
+                Text(option.displayName)
+                    .panelFont(size: 11, weight: .medium)
+                    .foregroundColor(isSelected ? TerminalColors.primaryText : TerminalColors.secondaryText)
+                    .lineLimit(1)
+                Spacer()
             }
             .padding(.horizontal, SettingsLayout.pickerOptionHorizontalPadding)
             .padding(.vertical, SettingsLayout.pickerOptionVerticalPadding)

--- a/notchi/notchi/Views/SettingsAppearanceView.swift
+++ b/notchi/notchi/Views/SettingsAppearanceView.swift
@@ -112,7 +112,7 @@ private struct MainUsageBarSettingsView: View {
     @AppStorage(AppSettings.mainUsageBarPeriodKey) private var periodRaw = MainUsageBarPeriod.session.rawValue
     @State private var isExpanded = false
 
-    private var period: MainUsageBarPeriod { MainUsageBarPeriod(rawValue: periodRaw) ?? .session }
+    private var period: MainUsageBarPeriod { AppSettings.mainUsageBarPeriod(fromRaw: periodRaw) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {

--- a/notchi/notchi/Views/UsageDetailView.swift
+++ b/notchi/notchi/Views/UsageDetailView.swift
@@ -79,7 +79,7 @@ struct UsageDetailView: View {
         switch resolvedProvider {
         case .claude:
             let stale = claudeUsage.isUsageStale
-            let heldOver = stale || claudeUsage.isUsingHeadersFallback
+            let heldOver = claudeUsage.isWeeklyUsageHeldOver
             return [
                 UsageMetrics.periodDisplay(title: String(localized: "Session"), usage: claudeUsage.currentUsage, isStale: stale),
                 UsageMetrics.periodDisplay(title: String(localized: "Weekly"), usage: claudeUsage.currentWeeklyUsage, isStale: heldOver),


### PR DESCRIPTION
Closes #107

The compact usage bar shown at the bottom of the panel's main page (and reused for the collapsed usage ring's tap target) was hardcoded to the Session (5-hour) quota. The full usage detail view already tracks and displays Weekly usage side-by-side with Session, so the data was there — the main page just had no way to surface it.

Adds `Settings > Appearance > Main Usage Bar` with **Session** (default, unchanged) and **Weekly**, using the same expandable-picker pattern as the existing Panel Size and Notch Left/Right rows.

### Implementation

- `MainUsageBarPeriod` enum + `AppSettings.mainUsageBarPeriod` (`UserDefaults`-backed, same shape as `notchLeftContent`/`expandedPanelScale`).
- `ExpandedPanelView.mainUsage(for:sessionUsage:weeklyUsage:)` is a small pure static function that picks which `QuotaPeriod` to show. Callers still pass each provider's existing "session" value as-is (Codex's `displayUsage`, which already falls back to weekly on its own), so **Session behavior is byte-identical to before this setting existed** — nothing changes unless you open Settings and switch it.
- `sharedUsageResetLabelPrefix` now also prefixes "Weekly" when that period is selected (e.g. "Weekly resets in 4d 17h"), so it's unambiguous which quota you're looking at. It still only adds the provider name ("Claude"/"Codex") when sessions from both are active, same as before.

### Testing

Added unit tests for `mainUsage` (session/weekly selection, nil-when-missing) and the extended `sharedUsageResetLabelPrefix` (weekly-only prefix, and combined with the mixed-provider prefix). Full suite passes locally (`./scripts/test.sh all`, 211/211).

Localization added for the new `Main Usage Bar` settings row label across ja, ko, vi, zh-Hans, zh-Hant (marked `needs_review` since I'm not a native speaker in any of them — happy to have these corrected). `Session` and `Weekly` reuse the existing translated strings from the usage detail view, so no new work needed there.