### PR TITLE
Show a badge for the auto permission mode

### DIFF
--- a/notchi/Tests/LocalizationCoverageTests.swift
+++ b/notchi/Tests/LocalizationCoverageTests.swift
@@ -8,7 +8,7 @@ final class LocalizationCoverageTests: XCTestCase {
         "Waiting for activity", "Today", "Top model", "Stale data", "Network error, retrying in %llds",
         "Expand on Hover",
         // Hand-edited into the catalog outside Xcode, so verify they survive the .lproj round-trip:
-        "Report an Issue", "Sponsor",
+        "Report an Issue", "Sponsor", "Auto",
     ]
     private let targetLocales = ["ja", "zh-Hans", "zh-Hant", "ko", "vi"]
 

--- a/notchi/Tests/ModeBadgeViewTests.swift
+++ b/notchi/Tests/ModeBadgeViewTests.swift
@@ -13,6 +13,11 @@ final class ModeBadgeViewTests: XCTestCase {
         XCTAssertEqual(badge.color, TerminalColors.acceptEdits)
     }
 
+    func testAutoBadgeColorComesFromRawModeNotDisplayText() {
+        let badge = ModeBadgeView(mode: "自動", rawMode: "auto")
+        XCTAssertEqual(badge.color, TerminalColors.autoMode)
+    }
+
     func testUnknownRawModeFallsBackToSecondaryTextColor() {
         let badge = ModeBadgeView(mode: "Bypass", rawMode: "bypassPermissions")
         XCTAssertEqual(badge.color, TerminalColors.secondaryText)

--- a/notchi/Tests/SessionDataTests.swift
+++ b/notchi/Tests/SessionDataTests.swift
@@ -4,6 +4,20 @@ import XCTest
 
 @MainActor
 final class SessionDataTests: XCTestCase {
+    func testAutoPermissionModeShowsAutoBadge() {
+        let session = SessionData(sessionId: "auto-session", provider: .claude, cwd: "/tmp/project")
+
+        session.updatePermissionMode("auto")
+
+        XCTAssertEqual(session.currentModeDisplay, "Auto")
+    }
+
+    func testDefaultPermissionModeShowsNoBadge() {
+        let session = SessionData(sessionId: "default-session", provider: .claude, cwd: "/tmp/project")
+
+        XCTAssertNil(session.currentModeDisplay)
+    }
+
     func testResolveXPositionUsesHashDerivedCandidateWhenItDoesNotCollide() {
         let resolved = SessionData.resolveXPositionForTesting(
             hash: 0,

--- a/notchi/notchi/Models/SessionData.swift
+++ b/notchi/notchi/Models/SessionData.swift
@@ -70,6 +70,7 @@ final class SessionData: Identifiable {
         switch permissionMode {
         case "plan": return String(localized: "Plan Mode")
         case "acceptEdits": return String(localized: "Accept Edits")
+        case "auto": return String(localized: "Auto")
         case "dontAsk": return String(localized: "Don't Ask")
         case "bypassPermissions": return String(localized: "Bypass")
         default: return nil

--- a/notchi/notchi/UI/TerminalColors.swift
+++ b/notchi/notchi/UI/TerminalColors.swift
@@ -22,6 +22,7 @@ struct TerminalColors {
     static let iMessageBlue = Color(red: 0, green: 0.478, blue: 1)
     static let planMode = Color(red: 72.0 / 255.0, green: 150.0 / 255.0, blue: 140.0 / 255.0)
     static let acceptEdits = Color(red: 169.0 / 255.0, green: 137.0 / 255.0, blue: 248.0 / 255.0)
+    static let autoMode = Color(red: 245.0 / 255.0, green: 195.0 / 255.0, blue: 68.0 / 255.0)
 
     static let primaryText = Color.white.opacity(0.9)
     static let secondaryText = Color.white.opacity(0.5)

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -823,6 +823,7 @@ struct ModeBadgeView: View {
         switch rawMode {
         case "plan": TerminalColors.planMode
         case "acceptEdits": TerminalColors.acceptEdits
+        case "auto": TerminalColors.autoMode
         default: TerminalColors.secondaryText
         }
     }


### PR DESCRIPTION
## Summary
Claude Code's newer auto permission mode (reported by hooks as `permission_mode: "auto"`) previously showed no mode badge, making it indistinguishable from default mode. Sessions in auto mode now show a yellow `#f5c344` **Auto** badge in the expanded panel, alongside the existing Plan Mode / Accept Edits / Don't Ask / Bypass badges.

## Changes
- `SessionData.currentModeDisplay` maps `"auto"` to a localized "Auto" badge
- New `TerminalColors.autoMode` (`#f5c344`) wired into `ModeBadgeView`
- Reuses the existing "Auto" catalog entry, which already has ja / zh-Hans / zh-Hant / ko / vi translations; added it to the localization coverage sample keys

## Testing
- New tests: auto mode shows the badge, default mode shows none, badge color keys off the raw mode string
- `./scripts/test.sh focused` and `./scripts/test.sh all` both pass