### PR TITLE
fix(notch): size the panel to the menu bar on screens without a notch

### DIFF
--- a/notchi/Tests/NSScreenNotchTests.swift
+++ b/notchi/Tests/NSScreenNotchTests.swift
@@ -1,0 +1,35 @@
+import AppKit
+import XCTest
+@testable import notchi
+
+final class NSScreenNotchTests: XCTestCase {
+    func testNonNotchSizeMatchesMenuBarHeight() {
+        let size = NSScreen.nonNotchSize(menuBarHeight: 25)
+        XCTAssertEqual(size, CGSize(width: 224, height: 25))
+    }
+
+    func testNonNotchSizeFallsBackWhenMenuBarIsHidden() {
+        let size = NSScreen.nonNotchSize(menuBarHeight: 0)
+        XCTAssertEqual(size, CGSize(width: 224, height: 24))
+    }
+
+    func testHeaderSpriteFitScaleShrinksBelowReferenceHeightOnNonNotchScreens() {
+        XCTAssertEqual(
+            NotchContentView.headerSpriteFitScale(notchHeight: 34, screenHasNotch: false),
+            34.0 / 38.0,
+            accuracy: 0.0001
+        )
+    }
+
+    func testHeaderSpriteFitScaleFloorsAtMinimumForShortMenuBars() {
+        XCTAssertEqual(NotchContentView.headerSpriteFitScale(notchHeight: 24, screenHasNotch: false), 0.8)
+    }
+
+    func testHeaderSpriteFitScaleNeverExceedsOne() {
+        XCTAssertEqual(NotchContentView.headerSpriteFitScale(notchHeight: 50, screenHasNotch: false), 1)
+    }
+
+    func testHeaderSpriteFitScaleIsUnchangedOnNotchedScreens() {
+        XCTAssertEqual(NotchContentView.headerSpriteFitScale(notchHeight: 35, screenHasNotch: true), 1)
+    }
+}

--- a/notchi/notchi/NSScreen+Notch.swift
+++ b/notchi/notchi/NSScreen+Notch.swift
@@ -19,17 +19,27 @@ extension NSScreen {
         safeAreaInsets.top > 0
     }
 
+    static let nonNotchWidth: CGFloat = 224
+    static let fallbackMenuBarHeight: CGFloat = 24
+
+    static func nonNotchSize(menuBarHeight: CGFloat) -> CGSize {
+        CGSize(
+            width: nonNotchWidth,
+            height: menuBarHeight > 0 ? menuBarHeight : fallbackMenuBarHeight
+        )
+    }
+
     /// Calculates the notch dimensions for this screen
     var notchSize: CGSize {
+        let menuBarHeight = frame.maxY - visibleFrame.maxY
         guard hasNotch else {
-            return CGSize(width: 224, height: 38)
+            return Self.nonNotchSize(menuBarHeight: menuBarHeight)
         }
 
         let fullWidth = frame.width
         let leftPadding = auxiliaryTopLeftArea?.width ?? 0
         let rightPadding = auxiliaryTopRightArea?.width ?? 0
         let notchWidth = fullWidth - leftPadding - rightPadding + 4
-        let menuBarHeight = frame.maxY - visibleFrame.maxY
         let notchHeight = max(safeAreaInsets.top, menuBarHeight)
 
         return CGSize(width: notchWidth, height: notchHeight)

--- a/notchi/notchi/NotchContentView.swift
+++ b/notchi/notchi/NotchContentView.swift
@@ -349,7 +349,18 @@ struct NotchContentView: View {
     }
 
     private var collapsedHeaderSpriteScale: CGFloat {
-        !isExpanded && panelManager.isCollapsedHovered ? 1.08 : 1
+        let hoverScale: CGFloat = !isExpanded && panelManager.isCollapsedHovered ? 1.08 : 1
+        return hoverScale * Self.headerSpriteFitScale(
+            notchHeight: notchSize.height,
+            screenHasNotch: panelManager.screenHasNotch
+        )
+    }
+
+    static func headerSpriteFitScale(notchHeight: CGFloat, screenHasNotch: Bool) -> CGFloat {
+        guard !screenHasNotch else { return 1 }
+        let referenceNotchHeight: CGFloat = 38
+        let minimumScale: CGFloat = 0.8
+        return min(1, max(minimumScale, notchHeight / referenceNotchHeight))
     }
 
     private var collapsedHeaderSpriteOffsetX: CGFloat {

--- a/notchi/notchi/Services/NotchPanelManager.swift
+++ b/notchi/notchi/Services/NotchPanelManager.swift
@@ -56,6 +56,7 @@ final class NotchPanelManager {
     private(set) var isCollapsedHovered = false
     private(set) var collapsedMode: CollapsedMode = .normalCollapsed
     private(set) var notchSize: CGSize = .zero
+    private(set) var screenHasNotch = false
     private(set) var notchRect: CGRect = .zero
     private(set) var compactNotchRect: CGRect = .zero
     private(set) var panelRect: CGRect = .zero
@@ -128,6 +129,7 @@ final class NotchPanelManager {
         let screenFrame = screen.frame
 
         notchSize = newNotchSize
+        screenHasNotch = screen.hasNotch
         systemNotchPath = screen.notchPath
 
         let notchCenterX = screenFrame.origin.x + screenFrame.width / 2


### PR DESCRIPTION
## Summary
- On screens without a notch, size the panel to the measured menu bar height (fallback 24pt when hidden) instead of a hardcoded 38pt, so it no longer juts into window content on external monitors.
- Scale the mascot and usage ring (floor 0.8) to fit the shorter bar; notched displays keep exactly their previous geometry and sprite size.
- Add `NSScreenNotchTests` covering the non-notch size and fit scale.

Closes #98

## Testing
- `./scripts/test.sh focused` passes
- `NSScreenNotchTests` and `NotchPanelManagerTests` pass
- Verified visually on the built-in notched display; external display verification still pending