### PR TITLE
chore(release): prepare 1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Notchi is free and open source. If it's useful to you, you can [sponsor developm
 
 GPL-3.0-only. See [LICENSE](LICENSE).
 
-[dmg]: https://github.com/sk-ruban/notchi/releases/download/v1.2.3/Notchi-1.2.3.dmg
+[dmg]: https://github.com/sk-ruban/notchi/releases/download/v1.2.4/Notchi-1.2.4.dmg

--- a/docs/release-notes/1.2.4.md
+++ b/docs/release-notes/1.2.4.md
@@ -1,0 +1,20 @@
+# Notchi 1.2.4
+
+This release adds a setting for which quota the main usage bar shows, a badge for auto permission mode, and a better fit on external displays.
+
+## Usage
+
+- Adds a Main Usage Bar setting in Appearance so the compact bar can show Session or Weekly quota
+- Keeps the main bar on the current session's provider, and labels the period when it falls back to the provider's other window
+- Shows loading, error, and reconnect states on the bar instead of swapping to the other provider
+- Opens the usage detail view on the provider the bar is actually showing
+- Drops Codex quota windows whose reset time has already passed, so a lapsed percentage never shows as fresh
+- Marks held-over Claude weekly and model quota as stale when a refresh fails
+
+## Sessions
+
+- Shows an Auto badge for sessions running in Claude Code's auto permission mode
+
+## Panel
+
+- Sizes the panel to the menu bar on screens without a notch, so it no longer overhangs window content on external displays

--- a/notchi/notchi.xcodeproj/project.pbxproj
+++ b/notchi/notchi.xcodeproj/project.pbxproj
@@ -348,7 +348,7 @@
 				CODE_SIGN_ENTITLEMENTS = notchi/notchi.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = SXT98GH5HN;
 				ENABLE_APP_SANDBOX = NO;
@@ -363,7 +363,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ruban.notchi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -384,7 +384,7 @@
 				CODE_SIGN_ENTITLEMENTS = notchi/notchi.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 15;
+				CURRENT_PROJECT_VERSION = 16;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = SXT98GH5HN;
 				ENABLE_APP_SANDBOX = NO;
@@ -399,7 +399,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ruban.notchi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary
- Bump `MARKETING_VERSION` to 1.2.4 and `CURRENT_PROJECT_VERSION` to 16
- Add `docs/release-notes/1.2.4.md`
- Point the README DMG link at the 1.2.4 asset

## Verification
- `./scripts/test.sh focused` passes
- Debug build succeeds
- Localization catalog diffed against v1.2.3: all new user-facing keys have ja, zh-Hans, zh-Hant, ko, vi translations

## Before tagging
- [ ] Install the shipped 1.2.3 DMG and verify it upgrades to this build (discovery, release notes, download, relaunch)