### PR TITLE
fix(ui): match permission mode badge colors to Claude Code

### DIFF
--- a/notchi/Tests/ModeBadgeViewTests.swift
+++ b/notchi/Tests/ModeBadgeViewTests.swift
@@ -18,8 +18,18 @@ final class ModeBadgeViewTests: XCTestCase {
         XCTAssertEqual(badge.color, TerminalColors.autoMode)
     }
 
-    func testUnknownRawModeFallsBackToSecondaryTextColor() {
+    func testBypassBadgeUsesBypassPermissionsColor() {
         let badge = ModeBadgeView(mode: "Bypass", rawMode: "bypassPermissions")
+        XCTAssertEqual(badge.color, TerminalColors.bypassPermissions)
+    }
+
+    func testDontAskBadgeSharesBypassPermissionsColor() {
+        let badge = ModeBadgeView(mode: "Don't Ask", rawMode: "dontAsk")
+        XCTAssertEqual(badge.color, TerminalColors.bypassPermissions)
+    }
+
+    func testUnknownRawModeFallsBackToSecondaryTextColor() {
+        let badge = ModeBadgeView(mode: "Mystery", rawMode: "somethingNew")
         XCTAssertEqual(badge.color, TerminalColors.secondaryText)
     }
 }

--- a/notchi/notchi/UI/TerminalColors.swift
+++ b/notchi/notchi/UI/TerminalColors.swift
@@ -21,8 +21,9 @@ struct TerminalColors {
     ]
     static let iMessageBlue = Color(red: 0, green: 0.478, blue: 1)
     static let planMode = Color(red: 72.0 / 255.0, green: 150.0 / 255.0, blue: 140.0 / 255.0)
-    static let acceptEdits = Color(red: 169.0 / 255.0, green: 137.0 / 255.0, blue: 248.0 / 255.0)
-    static let autoMode = Color(red: 245.0 / 255.0, green: 195.0 / 255.0, blue: 68.0 / 255.0)
+    static let acceptEdits = Color(red: 175.0 / 255.0, green: 135.0 / 255.0, blue: 255.0 / 255.0)
+    static let autoMode = Color(red: 255.0 / 255.0, green: 193.0 / 255.0, blue: 7.0 / 255.0)
+    static let bypassPermissions = Color(red: 255.0 / 255.0, green: 107.0 / 255.0, blue: 128.0 / 255.0)
 
     static let primaryText = Color.white.opacity(0.9)
     static let secondaryText = Color.white.opacity(0.5)

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -909,6 +909,7 @@ struct ModeBadgeView: View {
         case "plan": TerminalColors.planMode
         case "acceptEdits": TerminalColors.acceptEdits
         case "auto": TerminalColors.autoMode
+        case "bypassPermissions", "dontAsk": TerminalColors.bypassPermissions
         default: TerminalColors.secondaryText
         }
     }


### PR DESCRIPTION
## Summary
- Align the permission mode badge colors in the expanded panel with the values Claude Code uses in its dark theme (pulled from the CLI's theme table):
  - plan: `#48968c` (unchanged)
  - acceptEdits: `#af87ff` (was `#a989f8`)
  - auto: `#ffc107` (was `#f5c344`)
  - bypassPermissions and dontAsk: `#ff6b80` (new; both previously fell back to the grey secondary text color, matching Claude Code which uses its `error` color for both)
- Update `ModeBadgeViewTests` to cover bypass and don't ask, and use a genuinely unknown mode for the grey fallback case.

## Validation
- `xcodebuild ... build` succeeds
- `./scripts/test.sh focused` passes
- `ModeBadgeViewTests` run directly: 6/6 pass