### PR TITLE
fix(codex): migrate hooks feature flag to [features].hooks

### DIFF
--- a/notchi/Tests/CodexHookInstallerTests.swift
+++ b/notchi/Tests/CodexHookInstallerTests.swift
@@ -81,7 +81,93 @@ final class CodexHookInstallerTests: XCTestCase {
         """)
 
         XCTAssertTrue(updated.contains("[features]"))
-        XCTAssertTrue(updated.contains("codex_hooks = true"))
+        XCTAssertTrue(updated.contains("hooks = true"))
+        XCTAssertFalse(updated.contains("codex_hooks"))
+    }
+
+    func testUpsertFeatureFlagMigratesLegacyCodexHooksKeyInPlace() {
+        let updated = CodexHookInstaller.upsertFeatureFlag(in: """
+        model = "gpt-5.4"
+
+        [features]
+        codex_hooks = true
+        js_repl = false
+        """)
+
+        XCTAssertEqual(updated, """
+        model = "gpt-5.4"
+
+        [features]
+        hooks = true
+        js_repl = false
+        """)
+    }
+
+    func testUpsertFeatureFlagDropsLegacyKeyWhenNewKeyAlreadyPresent() {
+        let updated = CodexHookInstaller.upsertFeatureFlag(in: """
+        [features]
+        hooks = false
+        codex_hooks = true
+        """)
+
+        XCTAssertEqual(updated, """
+        [features]
+        hooks = true
+
+        """)
+    }
+
+    func testUpsertFeatureFlagLeavesTopLevelInlineHooksTableAlone() {
+        let updated = CodexHookInstaller.upsertFeatureFlag(in: """
+        hooks = { state = { "/Users/me/.codex/hooks.json:stop:0:0" = { disabled = true } } }
+
+        [features]
+        codex_hooks = true
+        """)
+
+        XCTAssertEqual(updated, """
+        hooks = { state = { "/Users/me/.codex/hooks.json:stop:0:0" = { disabled = true } } }
+
+        [features]
+        hooks = true
+        """)
+    }
+
+    func testUpsertFeatureFlagDoesNotTouchHooksKeysInOtherSections() {
+        let updated = CodexHookInstaller.upsertFeatureFlag(in: """
+        [features]
+        js_repl = false
+
+        [plugins.demo]
+        hooks = false
+        """)
+
+        XCTAssertEqual(updated, """
+        [features]
+        hooks = true
+        js_repl = false
+
+        [plugins.demo]
+        hooks = false
+        """)
+    }
+
+    func testUpsertFeatureFlagHandlesFeaturesHeaderAtEndOfFile() {
+        let updated = CodexHookInstaller.upsertFeatureFlag(in: "model = \"gpt-5.4\"\n[features]")
+
+        XCTAssertEqual(updated, "model = \"gpt-5.4\"\n[features]\nhooks = true\n")
+    }
+
+    func testIsFeatureEnabledOnlyConsidersFeaturesSection() {
+        XCTAssertFalse(CodexHookInstaller.isFeatureEnabled(in: "hooks = true\n\n[features]\njs_repl = false\n"))
+        XCTAssertTrue(CodexHookInstaller.isFeatureEnabled(in: "[features]\nhooks = true\n\n[plugins.demo]\nhooks = false\n"))
+        XCTAssertFalse(CodexHookInstaller.isFeatureEnabled(in: "[plugins.demo]\nhooks = true\n"))
+    }
+
+    func testIsFeatureEnabledIgnoresLegacyKey() {
+        XCTAssertFalse(CodexHookInstaller.isFeatureEnabled(in: "[features]\ncodex_hooks = true\n"))
+        XCTAssertTrue(CodexHookInstaller.isFeatureEnabled(in: "[features]\nhooks = true\n"))
+        XCTAssertFalse(CodexHookInstaller.isFeatureEnabled(in: "[features]\nhooks = false\n"))
     }
 
     func testUpsertHooksJSONIsIdempotentSoReinstallSkipsRewrite() throws {

--- a/notchi/Tests/CodexHookInstallerTests.swift
+++ b/notchi/Tests/CodexHookInstallerTests.swift
@@ -164,6 +164,34 @@ final class CodexHookInstallerTests: XCTestCase {
         XCTAssertFalse(CodexHookInstaller.isFeatureEnabled(in: "[plugins.demo]\nhooks = true\n"))
     }
 
+    func testUpsertFeatureFlagMigratesCRLFConfigWithoutDuplicatingFeaturesTable() {
+        let updated = CodexHookInstaller.upsertFeatureFlag(in: "model = \"gpt-5.4\"\r\n\r\n[features]\r\ncodex_hooks = true\r\njs_repl = false\r\n")
+
+        XCTAssertEqual(updated, "model = \"gpt-5.4\"\r\n\r\n[features]\r\nhooks = true\r\njs_repl = false\r\n")
+        XCTAssertEqual(updated.components(separatedBy: "[features]").count - 1, 1)
+        XCTAssertTrue(CodexHookInstaller.isFeatureEnabled(in: updated))
+    }
+
+    func testUpsertFeatureFlagRecognisesFeaturesHeaderWithTrailingComment() {
+        let updated = CodexHookInstaller.upsertFeatureFlag(in: """
+        [features] # managed by notchi
+        js_repl = false
+        """)
+
+        XCTAssertEqual(updated, """
+        [features] # managed by notchi
+        hooks = true
+        js_repl = false
+        """)
+        XCTAssertTrue(CodexHookInstaller.isFeatureEnabled(in: updated))
+    }
+
+    func testIsFeatureEnabledAcceptsTrailingCommentAndCRLF() {
+        XCTAssertTrue(CodexHookInstaller.isFeatureEnabled(in: "[features]\nhooks = true # keep\n"))
+        XCTAssertTrue(CodexHookInstaller.isFeatureEnabled(in: "[features]\r\nhooks = true\r\n"))
+        XCTAssertFalse(CodexHookInstaller.isFeatureEnabled(in: "[features]\nhooks = truely\n"))
+    }
+
     func testIsFeatureEnabledIgnoresLegacyKey() {
         XCTAssertFalse(CodexHookInstaller.isFeatureEnabled(in: "[features]\ncodex_hooks = true\n"))
         XCTAssertTrue(CodexHookInstaller.isFeatureEnabled(in: "[features]\nhooks = true\n"))

--- a/notchi/notchi/Services/CodexHookInstaller.swift
+++ b/notchi/notchi/Services/CodexHookInstaller.swift
@@ -165,9 +165,11 @@ struct CodexHookInstaller {
     }
 
     private nonisolated static let featureLine = "hooks = true"
-    private nonisolated static let hooksKeyPattern = #"(?m)^[ \t]*hooks[ \t]*=[^\n]*$"#
-    private nonisolated static let legacyKeyPattern = #"(?m)^[ \t]*codex_hooks[ \t]*=[^\n]*$"#
-    private nonisolated static let legacyKeyLinePattern = #"(?m)^[ \t]*codex_hooks[ \t]*=[^\n]*\n?"#
+    private nonisolated static let hooksKeyPattern = #"(?m)^[ \t]*hooks[ \t]*=[^\r\n]*"#
+    private nonisolated static let legacyKeyPattern = #"(?m)^[ \t]*codex_hooks[ \t]*=[^\r\n]*"#
+    private nonisolated static let legacyKeyLinePattern = #"(?m)^[ \t]*codex_hooks[ \t]*=[^\r\n]*\r?\n?"#
+    private nonisolated static let featuresHeaderPattern = #"(?m)^\[features\][ \t]*(#[^\r\n]*)?\r?$"#
+    private nonisolated static let enabledPattern = #"(?m)^[ \t]*hooks[ \t]*=[ \t]*true[ \t]*(#[^\r\n]*)?\r?$"#
 
     nonisolated static func upsertFeatureFlag(in existingContents: String?) -> String {
         var text = existingContents ?? ""
@@ -193,13 +195,14 @@ struct CodexHookInstaller {
     }
 
     private nonisolated static func featuresSectionBodyRange(in text: inout String) -> Range<String.Index>? {
-        guard let header = text.range(of: #"(?m)^\[features\][ \t]*$"#, options: .regularExpression) else {
+        guard let header = text.range(of: featuresHeaderPattern, options: .regularExpression) else {
             return nil
         }
-        if text[header.upperBound...].firstIndex(of: "\n") == nil {
+        guard let newlineIndex = text[header.upperBound...].utf8.firstIndex(of: UInt8(ascii: "\n")) else {
             text.insert("\n", at: header.upperBound)
+            return featuresSectionBodyRange(in: &text)
         }
-        let bodyStart = text.index(after: text[header.upperBound...].firstIndex(of: "\n")!)
+        let bodyStart = text.utf8.index(after: newlineIndex)
         let bodyEnd = text[bodyStart...].range(of: #"(?m)^[ \t]*\["#, options: .regularExpression)?.lowerBound
             ?? text.endIndex
         return bodyStart..<bodyEnd
@@ -225,10 +228,7 @@ struct CodexHookInstaller {
 
     nonisolated static func isFeatureEnabled(in configContents: String?) -> Bool {
         guard var text = configContents, let section = featuresSectionBodyRange(in: &text) else { return false }
-        return text[section].range(
-            of: #"(?m)^[ \t]*hooks[ \t]*=[ \t]*true[ \t]*$"#,
-            options: .regularExpression
-        ) != nil
+        return text[section].range(of: enabledPattern, options: .regularExpression) != nil
     }
 
     nonisolated static func isInstalled() -> Bool {

--- a/notchi/notchi/Services/CodexHookInstaller.swift
+++ b/notchi/notchi/Services/CodexHookInstaller.swift
@@ -164,33 +164,45 @@ struct CodexHookInstaller {
         }
     }
 
+    private nonisolated static let featureLine = "hooks = true"
+    private nonisolated static let hooksKeyPattern = #"(?m)^[ \t]*hooks[ \t]*=[^\n]*$"#
+    private nonisolated static let legacyKeyPattern = #"(?m)^[ \t]*codex_hooks[ \t]*=[^\n]*$"#
+    private nonisolated static let legacyKeyLinePattern = #"(?m)^[ \t]*codex_hooks[ \t]*=[^\n]*\n?"#
+
     nonisolated static func upsertFeatureFlag(in existingContents: String?) -> String {
-        let featureLine = "codex_hooks = true"
         var text = existingContents ?? ""
 
-        if let range = text.range(
-            of: #"(?m)^[ \t]*codex_hooks[ \t]*=[^\n]*$"#,
-            options: .regularExpression
-        ) {
-            text.replaceSubrange(range, with: featureLine)
-            return text
-        }
-
-        if let featuresRange = text.range(of: #"(?m)^\[features\][ \t]*$"#, options: .regularExpression) {
-            if let newlineIndex = text[featuresRange.upperBound...].firstIndex(of: "\n") {
-                let insertionPoint = text.index(after: newlineIndex)
-                text.insert(contentsOf: "\(featureLine)\n", at: insertionPoint)
-            } else {
-                text.insert(contentsOf: "\n\(featureLine)", at: featuresRange.upperBound)
+        guard let section = featuresSectionBodyRange(in: &text) else {
+            if !text.isEmpty && !text.hasSuffix("\n") {
+                text += "\n"
             }
-            return text
+            return text + "\n[features]\n\(featureLine)\n"
         }
 
-        if !text.isEmpty && !text.hasSuffix("\n") {
-            text += "\n"
+        var body = String(text[section])
+        if let range = body.range(of: hooksKeyPattern, options: .regularExpression) {
+            body.replaceSubrange(range, with: featureLine)
+            body = body.replacingOccurrences(of: legacyKeyLinePattern, with: "", options: .regularExpression)
+        } else if let range = body.range(of: legacyKeyPattern, options: .regularExpression) {
+            body.replaceSubrange(range, with: featureLine)
+        } else {
+            body = "\(featureLine)\n" + body
         }
+        text.replaceSubrange(section, with: body)
+        return text
+    }
 
-        return text + "\n[features]\n\(featureLine)\n"
+    private nonisolated static func featuresSectionBodyRange(in text: inout String) -> Range<String.Index>? {
+        guard let header = text.range(of: #"(?m)^\[features\][ \t]*$"#, options: .regularExpression) else {
+            return nil
+        }
+        if text[header.upperBound...].firstIndex(of: "\n") == nil {
+            text.insert("\n", at: header.upperBound)
+        }
+        let bodyStart = text.index(after: text[header.upperBound...].firstIndex(of: "\n")!)
+        let bodyEnd = text[bodyStart...].range(of: #"(?m)^[ \t]*\["#, options: .regularExpression)?.lowerBound
+            ?? text.endIndex
+        return bodyStart..<bodyEnd
     }
 
     nonisolated static func isHookInstalled(in hooksData: Data?) -> Bool {
@@ -212,9 +224,9 @@ struct CodexHookInstaller {
     }
 
     nonisolated static func isFeatureEnabled(in configContents: String?) -> Bool {
-        guard let configContents else { return false }
-        return configContents.range(
-            of: #"(?m)^[ \t]*codex_hooks[ \t]*=[ \t]*true[ \t]*$"#,
+        guard var text = configContents, let section = featuresSectionBodyRange(in: &text) else { return false }
+        return text[section].range(
+            of: #"(?m)^[ \t]*hooks[ \t]*=[ \t]*true[ \t]*$"#,
             options: .regularExpression
         ) != nil
     }


### PR DESCRIPTION
## Summary
Codex 0.130.0 (2026-05-08) aliased the `codex_hooks` feature flag to `hooks` and prints `[features].codex_hooks is deprecated. Use [features].hooks instead.` on every launch while the old key is present.

`CodexHookInstaller` now:
- writes `hooks = true` instead of `codex_hooks = true`
- rewrites an existing `codex_hooks` line in place, preserving neighbouring flags
- drops the legacy key when both are present
- treats only `[features].hooks = true` as enabled, so legacy-only configs are migrated by the existing launch-time `installIfNeeded()` with no user action

All lookup and mutation is scoped to the `[features]` section body (header to next `[` header), so a top-level `hooks` table, including the inline `hooks = { ... }` form, and `hooks` keys in other sections are never touched.

## Trade-off
Codex older than 0.130.0 does not know `hooks`; it logs `unknown feature key in config` and hooks stay inactive there. Chosen over spawning `codex --version` on each launch.

## Validation
- Build: zero warnings
- `CodexHookInstallerTests`: 18 (new: writes new key, in-place migration, drops legacy when both present, top-level inline hooks table untouched, other-section `hooks` keys untouched, header at EOF, `isFeatureEnabled` scoping)
- `./scripts/test.sh all`: 670 passed