### PR TITLE
feat(panel): show elapsed time in the working indicator

### DIFF
--- a/notchi/Tests/WorkingIndicatorPresentationTests.swift
+++ b/notchi/Tests/WorkingIndicatorPresentationTests.swift
@@ -23,4 +23,40 @@ final class WorkingIndicatorPresentationTests: XCTestCase {
             "Clanking.."
         )
     }
+
+    func testWorkingTextAppendsElapsedTimeBeforeDots() {
+        let text = WorkingIndicatorPresentation.text(for: .working, workingVerb: "Clanking", dots: "..", elapsed: "34s")
+        XCTAssertEqual(text, "Clanking for 34s..")
+    }
+
+    func testWaitingTextIgnoresElapsedTime() {
+        let text = WorkingIndicatorPresentation.text(for: .waiting, workingVerb: "Clanking", dots: ".", elapsed: "34s")
+        XCTAssertEqual(text, "Waiting.")
+    }
+
+    func testElapsedDisplayFormatsSecondsMinutesAndHours() {
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        func display(after seconds: TimeInterval) -> String? {
+            WorkingIndicatorPresentation.elapsedDisplay(
+                since: start,
+                now: start.addingTimeInterval(seconds),
+                locale: Locale(identifier: "en_US")
+            )
+        }
+        XCTAssertNil(display(after: 0.4))
+        XCTAssertEqual(display(after: 34), "34s")
+        XCTAssertEqual(display(after: 59), "59s")
+        XCTAssertEqual(display(after: 94), "1m 34s")
+        XCTAssertEqual(display(after: 3720), "1h 2m")
+    }
+
+    func testElapsedDisplayLocalizesUnitsForJapanese() {
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        let display = WorkingIndicatorPresentation.elapsedDisplay(
+            since: start,
+            now: start.addingTimeInterval(94),
+            locale: Locale(identifier: "ja_JP")
+        )
+        XCTAssertEqual(display, "1分34秒")
+    }
 }

--- a/notchi/notchi/Localizable.xcstrings
+++ b/notchi/notchi/Localizable.xcstrings
@@ -20,6 +20,40 @@
         }
       }
     },
+    "%@ for %@" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · %2$@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · %2$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · %2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · %2$@"
+          }
+        }
+      }
+    },
     "%@ API returned HTTP %lld" : {
       "localizations" : {
         "en" : {

--- a/notchi/notchi/UI/ActivityRowView.swift
+++ b/notchi/notchi/UI/ActivityRowView.swift
@@ -763,6 +763,7 @@ private struct QuestionHintShake: GeometryEffect {
 struct WorkingIndicatorView: View {
     let state: NotchiState
     let workingVerb: String
+    var workingSince: Date?
     let color: Color
     @State private var dotCount = 1
     @State private var symbolPhase = 0
@@ -779,7 +780,12 @@ struct WorkingIndicatorView: View {
     }
 
     private var displayText: String {
-        WorkingIndicatorPresentation.text(for: state.task, workingVerb: workingVerb, dots: dots)
+        WorkingIndicatorPresentation.text(
+            for: state.task,
+            workingVerb: workingVerb,
+            dots: dots,
+            elapsed: workingSince.flatMap { WorkingIndicatorPresentation.elapsedDisplay(since: $0, now: Date()) }
+        )
     }
 
     var body: some View {
@@ -907,14 +913,24 @@ enum WorkingIndicatorPresentation {
         return animatedSymbols[phase % animatedSymbols.count]
     }
 
-    static func text(for task: NotchiTask, workingVerb: String, dots: String) -> String {
+    static func text(for task: NotchiTask, workingVerb: String, dots: String, elapsed: String? = nil) -> String {
         switch task {
         case .compacting:
             return "Compacting\(dots)"
         case .waiting:
             return "Waiting\(dots)"
         default:
-            return "\(workingVerb)\(dots)"
+            guard let elapsed else { return "\(workingVerb)\(dots)" }
+            return String(localized: "\(workingVerb) for \(elapsed)") + dots
         }
+    }
+
+    static func elapsedDisplay(since start: Date, now: Date, locale: Locale = .autoupdatingCurrent) -> String? {
+        let seconds = Int(now.timeIntervalSince(start))
+        guard seconds >= 1 else { return nil }
+        return Duration.seconds(seconds).formatted(
+            .units(allowed: [.hours, .minutes, .seconds], width: .narrow, maximumUnitCount: 2)
+            .locale(locale)
+        )
     }
 }

--- a/notchi/notchi/Views/ExpandedPanelView.swift
+++ b/notchi/notchi/Views/ExpandedPanelView.swift
@@ -545,6 +545,7 @@ struct ExpandedPanelView: View {
                     WorkingIndicatorView(
                         state: state,
                         workingVerb: currentSpinnerVerb,
+                        workingSince: effectiveSession?.promptSubmitTime,
                         color: effectiveSession?.provider.accentColor ?? TerminalColors.claudeOrange
                     )
                 }


### PR DESCRIPTION
## Summary
- The working indicator now shows how long the current turn has been running: `✻ Clanking for 34s...`, with the animated dots after the counter. Past a minute it reads `1m 34s`, past an hour `1h 2m` (two units max).
- Anchored to `promptSubmitTime`, so it measures the whole turn, the same semantics as T3 Code's "Working for Xs" and Claude Code's own spinner. Waiting and compacting states are unchanged and show no counter.
- The counter updates on the existing 0.4s dots timer, so no new timers and it only ticks while a session is working.

## Localization
- English keeps the `for` phrasing. The other languages use a `%1$@ · %2$@` separator via the catalog, because the spinner verbs themselves are English in every locale.
- Duration units go through `Duration.UnitsFormatStyle`, so ja renders `1分34秒`, ko `1분 34초`, etc., with no hand-rolled unit strings.

## Validation
- Build: zero warnings
- `WorkingIndicatorPresentationTests`: elapsed ordering with dots, waiting ignores elapsed, en boundary formatting, Japanese unit localization
- `./scripts/test.sh all`: 690 passed