### PR TITLE
chore(release): prepare 1.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Notchi is free and open source. If it's useful to you, you can [sponsor developm
 
 GPL-3.0-only. See [LICENSE](LICENSE).
 
-[dmg]: https://github.com/sk-ruban/notchi/releases/download/v1.2.4/Notchi-1.2.4.dmg
+[dmg]: https://github.com/sk-ruban/notchi/releases/download/v1.2.5/Notchi-1.2.5.dmg

--- a/docs/release-notes/1.2.5.md
+++ b/docs/release-notes/1.2.5.md
@@ -1,0 +1,24 @@
+# Notchi 1.2.5
+
+This release adds git branch and pull request info to the session header, an elapsed timer on the working indicator, and real permission mode badges for Codex sessions.
+
+## Sessions
+
+- Shows the current git branch beside the session title, and clicking it copies the branch name
+- Shows the branch's open pull request with a click-through to GitHub, appearing within seconds after an agent pushes or opens a PR
+- Shows Codex sessions' real permission mode as Plan, Auto, Read Only, Default, or Full Access
+- Matches the permission mode badge colors to Claude Code's terminal theme
+
+## Panel
+
+- Shows how long the current turn has been running on the working indicator, for example "Clanking for 34s"
+- Renders user prompts with inline markdown and expands the bubble on hover to show the full text
+- Keeps automated harness notifications out of the prompt bubble, so it always shows what you actually typed
+
+## Settings
+
+- Renames the appearance toggles to Show Sprite When Idle, Show Grass Island, and Show Git Branch & PR, so an enabled switch means the item is visible. If you previously turned on a Hide toggle, that preference resets once and the item shows again until you switch the new toggle off.
+
+## Codex
+
+- Migrates the hooks feature flag in config.toml from codex_hooks to hooks, removing the deprecation warning on every Codex launch (requires Codex 0.130 or newer)

--- a/notchi/notchi.xcodeproj/project.pbxproj
+++ b/notchi/notchi.xcodeproj/project.pbxproj
@@ -348,7 +348,7 @@
 				CODE_SIGN_ENTITLEMENTS = notchi/notchi.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = SXT98GH5HN;
 				ENABLE_APP_SANDBOX = NO;
@@ -363,7 +363,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ruban.notchi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -384,7 +384,7 @@
 				CODE_SIGN_ENTITLEMENTS = notchi/notchi.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = SXT98GH5HN;
 				ENABLE_APP_SANDBOX = NO;
@@ -399,7 +399,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.4;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ruban.notchi;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary
Release prep for 1.2.5: version bump (1.2.5 / build 17), `docs/release-notes/1.2.5.md`, and the README DMG link.

## Checklist (release protocol)
- [x] `MARKETING_VERSION` 1.2.5, `CURRENT_PROJECT_VERSION` 17 (appcast newest is 16, ordering correct; built app verified reporting 1.2.5/17)
- [x] `docs/release-notes/1.2.5.md`
- [x] Localization audit: catalog diffed against `v1.2.4`, 9 new/changed keys all carry ja/ko/vi/zh-Hans/zh-Hant
- [x] README `[dmg]:` link updated to `v1.2.5`
- [x] `SUFeedURL` and `SUPublicEDKey` unchanged in Info.plist
- [x] Signing inputs present: all six Actions secrets incl. `SPARKLE_PRIVATE_KEY`, plus local `.sparkle-keys/eddsa_private_key`
- [ ] Manual upgrade rehearsal from the shipped 1.2.4 DMG (before tagging `v1.2.5`)

## Release highlights
Git branch + open PR in the session header (copy on click, click-through to GitHub), elapsed working time, Codex permission mode badges, markdown prompt bubble with hover expand, Show-toggle rename (one-time preference reset), Codex hooks flag migration.