### PR TITLE
fix(jump): keep T3 Code sessions pointed at T3 Code after their process exits

### DIFF
--- a/notchi/Tests/NotchiStateMachineTests.swift
+++ b/notchi/Tests/NotchiStateMachineTests.swift
@@ -365,6 +365,33 @@ final class NotchiStateMachineTests: XCTestCase {
         XCTAssertNotNil(SessionStore.shared.session(for: sessionKey))
     }
 
+    func testCodexDesktopSessionHostedByKnownAppEndsAfterProcessMisses() {
+        let stateMachine = NotchiStateMachine.shared
+        stateMachine.isCodexProcessAlive = { _ in false }
+        SessionStore.shared.setHostBundleIdentifierResolverForTesting { _ in "com.t3tools.t3code" }
+        defer { SessionStore.shared.resetHostBundleIdentifierResolverForTesting() }
+        let sessionId = "codex-hosted-exit-\(UUID().uuidString)"
+        let sessionKey = ProviderSessionKey(provider: .codex, rawSessionId: sessionId)
+
+        stateMachine.handleEvent(makeEvent(
+            sessionId: sessionId,
+            provider: .codex,
+            event: .userPromptSubmitted,
+            status: "processing",
+            userPrompt: "hello",
+            codexProcessId: 12345,
+            codexOrigin: .desktop
+        ))
+
+        XCTAssertEqual(SessionStore.shared.session(for: sessionKey)?.hostBundleIdentifier, "com.t3tools.t3code")
+
+        stateMachine.reconcileCodexProcessLivenessForTesting()
+        XCTAssertNotNil(SessionStore.shared.session(for: sessionKey))
+
+        stateMachine.reconcileCodexProcessLivenessForTesting()
+        XCTAssertNil(SessionStore.shared.session(for: sessionKey))
+    }
+
     func testArchivedCodexThreadRemovesSessionOnMetadataReconcile() {
         let stateMachine = NotchiStateMachine.shared
         stateMachine.setCodexThreadMetadataAutoRefreshEnabledForTesting(false)

--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -487,6 +487,63 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertNotNil(session.promptSubmitTime)
     }
 
+    func testProcessResolvesHostBundleIdentifierOnceForNewProcessId() {
+        let store = SessionStore.shared
+        var resolvedProcessIds: [pid_t] = []
+        store.setHostBundleIdentifierResolverForTesting { processId in
+            resolvedProcessIds.append(processId)
+            return "com.t3tools.t3code"
+        }
+        defer { store.resetHostBundleIdentifierResolverForTesting() }
+        let sessionId = "host-resolution-\(UUID().uuidString)"
+
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            provider: .codex,
+            event: .sessionStarted,
+            status: "waiting_for_input",
+            codexProcessId: 42
+        ))
+        _ = store.process(makeEvent(
+            sessionId: sessionId,
+            provider: .codex,
+            event: .stop,
+            status: "waiting_for_input",
+            codexProcessId: 42
+        ))
+
+        XCTAssertEqual(session.hostBundleIdentifier, "com.t3tools.t3code")
+        XCTAssertEqual(resolvedProcessIds, [42])
+    }
+
+    func testProcessClearsHostBundleIdentifierWhenNewProcessHasNoSupportedHost() {
+        let store = SessionStore.shared
+        store.setHostBundleIdentifierResolverForTesting { processId in
+            processId == 42 ? "com.t3tools.t3code" : nil
+        }
+        defer { store.resetHostBundleIdentifierResolverForTesting() }
+        let sessionId = "host-migration-\(UUID().uuidString)"
+
+        let session = store.process(makeEvent(
+            sessionId: sessionId,
+            provider: .codex,
+            event: .sessionStarted,
+            status: "waiting_for_input",
+            codexProcessId: 42
+        ))
+        XCTAssertEqual(session.hostBundleIdentifier, "com.t3tools.t3code")
+
+        _ = store.process(makeEvent(
+            sessionId: sessionId,
+            provider: .codex,
+            event: .stop,
+            status: "waiting_for_input",
+            codexProcessId: 43
+        ))
+
+        XCTAssertNil(session.hostBundleIdentifier)
+    }
+
     func testUserPromptStoresImageAttachments() {
         let store = SessionStore.shared
         let attachment = UserPromptImageAttachment(
@@ -1916,7 +1973,9 @@ final class SessionStoreTests: XCTestCase {
         toolInput: [String: AnyCodable]? = nil,
         permissionSuggestions: [AnyCodable]? = nil,
         interactionRequestId: String? = nil,
-        permissionMode: String? = nil
+        permissionMode: String? = nil,
+        claudeProcessId: Int? = nil,
+        codexProcessId: Int? = nil
     ) -> HookEvent {
         HookEvent(
             provider: provider,
@@ -1934,6 +1993,8 @@ final class SessionStoreTests: XCTestCase {
             permissionMode: permissionMode,
             permissionSuggestions: permissionSuggestions,
             interactive: true,
+            claudeProcessId: claudeProcessId,
+            codexProcessId: codexProcessId,
             interactionRequestId: interactionRequestId
         )
     }

--- a/notchi/Tests/SessionStoreTests.swift
+++ b/notchi/Tests/SessionStoreTests.swift
@@ -516,6 +516,37 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(resolvedProcessIds, [42])
     }
 
+    func testProcessRejectsProcessIdsThatDoNotFitInPid() {
+        let store = SessionStore.shared
+        var resolvedProcessIds: [pid_t] = []
+        store.setHostBundleIdentifierResolverForTesting { processId in
+            resolvedProcessIds.append(processId)
+            return "com.t3tools.t3code"
+        }
+        defer { store.resetHostBundleIdentifierResolverForTesting() }
+        let outOfRangeProcessId = Int(Int32.max) + 1
+
+        let codexSession = store.process(makeEvent(
+            sessionId: "oversized-codex-pid-\(UUID().uuidString)",
+            provider: .codex,
+            event: .sessionStarted,
+            status: "waiting_for_input",
+            codexProcessId: outOfRangeProcessId
+        ))
+        let claudeSession = store.process(makeEvent(
+            sessionId: "oversized-claude-pid-\(UUID().uuidString)",
+            event: .sessionStarted,
+            status: "waiting_for_input",
+            claudeProcessId: outOfRangeProcessId
+        ))
+
+        XCTAssertNil(codexSession.codexProcessId)
+        XCTAssertNil(claudeSession.claudeProcessId)
+        XCTAssertNil(codexSession.hostBundleIdentifier)
+        XCTAssertNil(claudeSession.hostBundleIdentifier)
+        XCTAssertTrue(resolvedProcessIds.isEmpty)
+    }
+
     func testProcessClearsHostBundleIdentifierWhenNewProcessHasNoSupportedHost() {
         let store = SessionStore.shared
         store.setHostBundleIdentifierResolverForTesting { processId in

--- a/notchi/Tests/TerminalJumpServiceTests.swift
+++ b/notchi/Tests/TerminalJumpServiceTests.swift
@@ -278,7 +278,7 @@ final class TerminalJumpServiceTests: XCTestCase {
         XCTAssertEqual(activatedProcessIds, [10])
     }
 
-    func testCodexDesktopSessionFallsBackToThreadURLWhenHostActivationFails() {
+    func testCodexDesktopSessionWithLiveHostDoesNotOpenURLWhenActivationFails() {
         let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
         session.updateCodexRuntime(processId: 30, origin: .desktop)
         var openedURLs: [URL] = []
@@ -298,9 +298,91 @@ final class TerminalJumpServiceTests: XCTestCase {
 
         let didJump = service.jump(to: session)
 
-        XCTAssertTrue(didJump)
+        XCTAssertFalse(didJump)
         XCTAssertEqual(activatedProcessIds, [10])
-        XCTAssertEqual(openedURLs.map(\.absoluteString), ["codex://threads/thread-123"])
+        XCTAssertTrue(openedURLs.isEmpty)
+    }
+
+    func testCodexSessionWithDeadProcessActivatesStoredHostApp() {
+        let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
+        session.updateCodexRuntime(processId: 30, origin: .desktop)
+        session.updateHostBundleIdentifier("com.t3tools.t3code")
+        var openedURLs: [URL] = []
+        var activatedBundleIds: [String] = []
+        let service = makeService(
+            openURL: { url in
+                openedURLs.append(url)
+                return true
+            },
+            processSnapshot: { _ in nil },
+            activateApplication: { bundleId in
+                activatedBundleIds.append(bundleId)
+                return true
+            }
+        )
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertTrue(didJump)
+        XCTAssertEqual(activatedBundleIds, ["com.t3tools.t3code"])
+        XCTAssertTrue(openedURLs.isEmpty)
+    }
+
+    func testCodexSessionWithDeadProcessAndQuitHostDoesNotOpenURL() {
+        let session = SessionData(sessionId: "thread-123", provider: .codex, cwd: "/tmp/project")
+        session.updateCodexRuntime(processId: 30, origin: .desktop)
+        session.updateHostBundleIdentifier("com.t3tools.t3code")
+        var openedURLs: [URL] = []
+        let service = makeService(
+            openURL: { url in
+                openedURLs.append(url)
+                return true
+            },
+            processSnapshot: { _ in nil },
+            activateApplication: { _ in false }
+        )
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertFalse(didJump)
+        XCTAssertTrue(openedURLs.isEmpty)
+    }
+
+    func testClaudeSessionWithDeadProcessActivatesStoredHostApp() {
+        let session = SessionData(sessionId: "claude-session", provider: .claude, cwd: "/tmp/project")
+        session.updateClaudeRuntime(processId: 30)
+        session.updateHostBundleIdentifier("com.t3tools.t3code")
+        var activatedBundleIds: [String] = []
+        let service = makeService(
+            processSnapshot: { _ in nil },
+            activateApplication: { bundleId in
+                activatedBundleIds.append(bundleId)
+                return true
+            }
+        )
+
+        let didJump = service.jump(to: session)
+
+        XCTAssertTrue(didJump)
+        XCTAssertEqual(activatedBundleIds, ["com.t3tools.t3code"])
+    }
+
+    func testHostBundleIdentifierResolvesSupportedHostFromAncestry() {
+        let service = makeService(
+            processSnapshot: { self.makeSnapshot(parentProcessId: Self.terminalAncestry[$0]) },
+            bundleIdentifierForProcess: { Self.t3CodeBundles[$0] }
+        )
+
+        XCTAssertEqual(service.hostBundleIdentifier(hosting: 30), "com.t3tools.t3code")
+    }
+
+    func testHostBundleIdentifierIsNilForUnsupportedAncestry() {
+        let service = makeService(
+            processSnapshot: { self.makeSnapshot(parentProcessId: Self.terminalAncestry[$0]) },
+            bundleIdentifierForProcess: { [pid_t(10): "com.openai.codex"][$0] }
+        )
+
+        XCTAssertNil(service.hostBundleIdentifier(hosting: 30))
     }
 
     func testCodexDesktopSessionHostedByCodexAppOpensThreadURL() {
@@ -357,13 +439,15 @@ final class TerminalJumpServiceTests: XCTestCase {
         openURL: @escaping (URL) -> Bool = { _ in true },
         processSnapshot: @escaping @MainActor (pid_t) -> TerminalJumpService.ProcessSnapshot? = { _ in nil },
         bundleIdentifierForProcess: @escaping @MainActor (pid_t) -> String? = { _ in nil },
-        activateProcess: @escaping @MainActor (pid_t) -> Bool = { _ in true }
+        activateProcess: @escaping @MainActor (pid_t) -> Bool = { _ in true },
+        activateApplication: @escaping @MainActor (String) -> Bool = { _ in false }
     ) -> TerminalJumpService {
         TerminalJumpService(
             openURL: openURL,
             processSnapshot: processSnapshot,
             bundleIdentifierForProcess: bundleIdentifierForProcess,
-            activateProcess: activateProcess
+            activateProcess: activateProcess,
+            activateApplication: activateApplication
         )
     }
 

--- a/notchi/notchi/Models/SessionData.swift
+++ b/notchi/notchi/Models/SessionData.swift
@@ -55,6 +55,7 @@ final class SessionData: Identifiable {
     private(set) var claudeProcessId: Int?
     private(set) var codexProcessId: Int?
     private(set) var codexOrigin: CodexOrigin?
+    private(set) var hostBundleIdentifier: String?
     private(set) var codexTitle: String?
     private(set) var codexTranscriptPath: String?
     private(set) var codexArchived: Bool = false
@@ -105,6 +106,10 @@ final class SessionData: Identifiable {
 
     var isCodexThreadBacked: Bool {
         provider == .codex && codexTranscriptPath != nil
+    }
+
+    var hostProcessId: Int? {
+        provider == .codex ? codexProcessId : claudeProcessId
     }
 
     // Sprite positioning constants (normalized 0..1 range for X, points for Y)
@@ -307,6 +312,10 @@ final class SessionData: Identifiable {
         if let origin {
             codexOrigin = origin
         }
+    }
+
+    func updateHostBundleIdentifier(_ bundleIdentifier: String?) {
+        hostBundleIdentifier = bundleIdentifier.flatMap { $0.isEmpty ? nil : $0 }
     }
 
     func updateCodexTitle(_ title: String?) {

--- a/notchi/notchi/Models/SessionData.swift
+++ b/notchi/notchi/Models/SessionData.swift
@@ -96,8 +96,8 @@ final class SessionData: Identifiable {
         return nil
     }
 
-    var isCodexCLIProcessBacked: Bool {
-        provider == .codex && codexOrigin == .cli && codexProcessId != nil
+    var isCodexProcessMonitored: Bool {
+        provider == .codex && codexProcessId != nil && (codexOrigin == .cli || hostBundleIdentifier != nil)
     }
 
     var isClaudeProcessBacked: Bool {

--- a/notchi/notchi/Models/SessionData.swift
+++ b/notchi/notchi/Models/SessionData.swift
@@ -297,7 +297,7 @@ final class SessionData: Identifiable {
     func updateClaudeRuntime(processId: Int?) {
         guard provider == .claude,
               let processId,
-              processId > 0 else { return }
+              Self.isValidProcessId(processId) else { return }
 
         claudeProcessId = processId
     }
@@ -305,13 +305,17 @@ final class SessionData: Identifiable {
     func updateCodexRuntime(processId: Int?, origin: CodexOrigin?) {
         guard provider == .codex else { return }
 
-        if let processId, processId > 0 {
+        if let processId, Self.isValidProcessId(processId) {
             codexProcessId = processId
         }
 
         if let origin {
             codexOrigin = origin
         }
+    }
+
+    private static func isValidProcessId(_ processId: Int) -> Bool {
+        processId > 0 && processId <= Int(pid_t.max)
     }
 
     func updateHostBundleIdentifier(_ bundleIdentifier: String?) {

--- a/notchi/notchi/Services/NotchiStateMachine.swift
+++ b/notchi/notchi/Services/NotchiStateMachine.swift
@@ -296,7 +296,7 @@ final class NotchiStateMachine {
     }
 
     private func reconcileCodexProcessLiveness() {
-        let trackedSessions = sessionStore.sessions.values.filter { $0.isCodexCLIProcessBacked }
+        let trackedSessions = sessionStore.sessions.values.filter { $0.isCodexProcessMonitored }
         let trackedKeys = Set(trackedSessions.map(\.sessionKey))
         codexProcessMissCounts = codexProcessMissCounts.filter { trackedKeys.contains($0.key) }
 
@@ -411,7 +411,7 @@ final class NotchiStateMachine {
     }
 
     private func refreshCodexProcessMonitoring() {
-        let shouldMonitor = sessionStore.sessions.values.contains { $0.isCodexCLIProcessBacked }
+        let shouldMonitor = sessionStore.sessions.values.contains { $0.isCodexProcessMonitored }
 
         if shouldMonitor {
             guard codexProcessMonitorTask == nil else { return }

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -173,8 +173,10 @@ final class SessionStore {
         let previousHostProcessId = session.hostProcessId
         session.updateClaudeRuntime(processId: event.claudeProcessId)
         session.updateCodexRuntime(processId: event.codexProcessId, origin: event.codexOrigin)
-        if let hostProcessId = session.hostProcessId, hostProcessId != previousHostProcessId {
-            session.updateHostBundleIdentifier(resolveHostBundleIdentifier(pid_t(hostProcessId)))
+        if let hostProcessId = session.hostProcessId,
+           hostProcessId != previousHostProcessId,
+           let processId = pid_t(exactly: hostProcessId) {
+            session.updateHostBundleIdentifier(resolveHostBundleIdentifier(processId))
         }
         if event.provider == .codex, let transcriptPath = event.transcriptPath {
             session.updateCodexThreadMetadata(

--- a/notchi/notchi/Services/SessionStore.swift
+++ b/notchi/notchi/Services/SessionStore.swift
@@ -26,6 +26,9 @@ final class SessionStore {
     private var resolveGitPullRequest: @Sendable (String, String) -> GitPullRequestLookup = { branch, cwd in
         GitPullRequestResolver.shared.lookup(forBranch: branch, repositoryAt: cwd)
     }
+    private var resolveHostBundleIdentifier: @MainActor (pid_t) -> String? = { processId in
+        TerminalJumpService.shared.hostBundleIdentifier(hosting: processId)
+    }
     private var invalidateGitPullRequestCache: @Sendable (String) -> Void = { cwd in
         GitPullRequestResolver.shared.invalidate(repositoryAt: cwd)
     }
@@ -167,8 +170,12 @@ final class SessionStore {
         refreshGitBranch(for: session, sessionKey: event.sessionKey, cwd: event.cwd)
         ensureGitRefreshLoop()
 
+        let previousHostProcessId = session.hostProcessId
         session.updateClaudeRuntime(processId: event.claudeProcessId)
         session.updateCodexRuntime(processId: event.codexProcessId, origin: event.codexOrigin)
+        if let hostProcessId = session.hostProcessId, hostProcessId != previousHostProcessId {
+            session.updateHostBundleIdentifier(resolveHostBundleIdentifier(pid_t(hostProcessId)))
+        }
         if event.provider == .codex, let transcriptPath = event.transcriptPath {
             session.updateCodexThreadMetadata(
                 transcriptPath: transcriptPath,
@@ -684,6 +691,16 @@ final class SessionStore {
 
     func setGitPullRequestCacheInvalidatorForTesting(_ invalidator: @escaping @Sendable (String) -> Void) {
         invalidateGitPullRequestCache = invalidator
+    }
+
+    func setHostBundleIdentifierResolverForTesting(_ resolver: @escaping @MainActor (pid_t) -> String?) {
+        resolveHostBundleIdentifier = resolver
+    }
+
+    func resetHostBundleIdentifierResolverForTesting() {
+        resolveHostBundleIdentifier = { processId in
+            TerminalJumpService.shared.hostBundleIdentifier(hosting: processId)
+        }
     }
 
     func setGitRefreshIntervalForTesting(_ interval: Duration) {

--- a/notchi/notchi/Services/TerminalJumpService.swift
+++ b/notchi/notchi/Services/TerminalJumpService.swift
@@ -13,25 +13,31 @@ struct TerminalJumpService {
     private let processSnapshot: @MainActor (pid_t) -> ProcessSnapshot?
     private let bundleIdentifierForProcess: @MainActor (pid_t) -> String?
     private let activateProcess: @MainActor (pid_t) -> Bool
+    private let activateApplication: @MainActor (String) -> Bool
 
     init(
         openURL: @escaping (URL) -> Bool = { NSWorkspace.shared.open($0) },
         processSnapshot: @escaping @MainActor (pid_t) -> ProcessSnapshot? = Self.defaultProcessSnapshot,
         bundleIdentifierForProcess: @escaping @MainActor (pid_t) -> String? = Self.defaultBundleIdentifier,
-        activateProcess: @escaping @MainActor (pid_t) -> Bool = Self.defaultActivateProcess
+        activateProcess: @escaping @MainActor (pid_t) -> Bool = Self.defaultActivateProcess,
+        activateApplication: @escaping @MainActor (String) -> Bool = Self.defaultActivateApplication
     ) {
         self.openURL = openURL
         self.processSnapshot = processSnapshot
         self.bundleIdentifierForProcess = bundleIdentifierForProcess
         self.activateProcess = activateProcess
+        self.activateApplication = activateApplication
     }
 
     @discardableResult
     func jump(to session: SessionData) -> Bool {
         if let processId = Self.hostBackedProcessId(for: session),
-           let hostProcessId = terminalProcessID(hosting: processId),
-           activateProcess(hostProcessId) {
-            return true
+           let hostProcessId = terminalProcessID(hosting: processId) {
+            return activateProcess(hostProcessId)
+        }
+
+        if let hostBundleIdentifier = session.hostBundleIdentifier {
+            return activateApplication(hostBundleIdentifier)
         }
 
         if let url = Self.codexDesktopThreadURL(for: session) {
@@ -39,6 +45,10 @@ struct TerminalJumpService {
         }
 
         return false
+    }
+
+    func hostBundleIdentifier(hosting processId: pid_t) -> String? {
+        terminalProcessID(hosting: processId).flatMap(bundleIdentifierForProcess)
     }
 
     static func codexDesktopThreadURL(for session: SessionData) -> URL? {
@@ -140,6 +150,14 @@ struct TerminalJumpService {
 
     private static func defaultActivateProcess(_ processId: pid_t) -> Bool {
         guard let app = NSRunningApplication(processIdentifier: processId) else {
+            return false
+        }
+
+        return app.activate()
+    }
+
+    private static func defaultActivateApplication(_ bundleIdentifier: String) -> Bool {
+        guard let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first else {
             return false
         }
 


### PR DESCRIPTION
## Summary

T3 Code tears down a thread's provider process once the thread goes idle. Notchi kept the dead process ID, so clicking a Codex mascot fell through to the `codex://` URL and launched the Codex desktop app, and Codex mascots never went away because nothing ended them.

## Changes

- **Remember the hosting app.** When a session's process ID arrives, resolve the hosting app while the process is alive and store its bundle identifier. On click: live ancestry walk first, then activate the stored host if it's running, and only open the Codex thread URL when no host was ever recorded. A live host whose activation fails no longer falls through to the Codex URL. The stored host is cleared when the process changes and the new one resolves to no supported host, so a thread that moves to the Codex app opens its thread URL again.
- **End hosted Codex sessions when their process exits.** The liveness monitor now covers any Codex session with a resolved host, in addition to TTY-backed ones. Codex desktop app sessions resolve no host and stay excluded as before.

## Testing

- `TerminalJumpServiceTests`: dead process with stored host activates it for Codex and Claude, quit host opens no URL, live host with failed activation opens no URL, host resolution from ancestry.
- `SessionStoreTests`: host resolved once per new process ID, cleared on migration to an unsupported host.
- `NotchiStateMachineTests`: hosted desktop-origin session ends after process misses; existing desktop exclusion test still passes.
- `./scripts/test.sh focused` passes.
- Stored hosts are only learned from events after relaunch, so mascots already present before the relaunch keep the old behavior until they receive another hook event.